### PR TITLE
Configure Netkan Git Config

### DIFF
--- a/netkan/.gitconfig
+++ b/netkan/.gitconfig
@@ -1,0 +1,3 @@
+[user]
+	email = netkan-bot@ksp-ckan.space
+	name = NetKAN inflator Robot

--- a/netkan/Dockerfile
+++ b/netkan/Dockerfile
@@ -24,5 +24,6 @@ RUN useradd -Ms /bin/bash netkan
 RUN chown -R netkan:netkan /home/netkan
 WORKDIR /home/netkan
 USER netkan
+ADD .gitconfig .
 ENTRYPOINT [".local/bin/netkan"]
 CMD ["--help"]


### PR DESCRIPTION
The git config was missing, which meant our commits weren't being tied back to the correct user.