### PR TITLE
Don't throw EmptyBatchRequest

### DIFF
--- a/netkan/netkan/scheduler.py
+++ b/netkan/netkan/scheduler.py
@@ -33,11 +33,12 @@ class NetkanScheduler:
             'MessageDeduplicationId': md5(content.encode()).hexdigest()
         }
 
+    def __list_split(self, list, length):
+        return (list[n:(n+length)] for n in range(0, len(list), length))
+
     def sqs_batch_entries(self, batch_size=10):
-        netkans = list(self.netkans())
-        while len(netkans) > 0:
-            yield [self.generate_netkan_message(nk) for nk in netkans[:batch_size]]
-            netkans = netkans[batch_size:]
+        for batch in self.__list_split(self.netkans(), batch_size):
+            yield [self.generate_netkan_message(nk) for nk in batch]
 
     def sqs_batch_attrs(self, batch):
         return {

--- a/netkan/netkan/scheduler.py
+++ b/netkan/netkan/scheduler.py
@@ -34,14 +34,10 @@ class NetkanScheduler:
         }
 
     def sqs_batch_entries(self, batch_size=10):
-        batch = []
-
-        for netkan in self.netkans():
-            batch.append(self.generate_netkan_message(netkan))
-            if len(batch) == batch_size:
-                yield(batch)
-                batch = []
-        yield(batch)
+        netkans = self.netkans()
+        while len(netkans) > 0:
+            yield [self.generate_netkan_message(nk) for nk in netkans[:batch_size]]
+            netkans = netkans[batch_size:]
 
     def sqs_batch_attrs(self, batch):
         return {

--- a/netkan/netkan/scheduler.py
+++ b/netkan/netkan/scheduler.py
@@ -34,7 +34,7 @@ class NetkanScheduler:
         }
 
     def sqs_batch_entries(self, batch_size=10):
-        netkans = self.netkans()
+        netkans = list(self.netkans())
         while len(netkans) > 0:
             yield [self.generate_netkan_message(nk) for nk in netkans[:batch_size]]
             netkans = netkans[batch_size:]


### PR DESCRIPTION
## Problem

The scheduler throws an exception at the end of a pass if the total number of netkans is a multiple of 10 (as it is as of KSP-CKAN/NetKAN#7383):

```
[2019-09-16 00:39:20,150] [INFO    ] Scheduler started at log level 20
[2019-09-16 00:39:20,297] [INFO    ] Cloning https://github.com/KSP-CKAN/NetKAN.git
Traceback (most recent call last):
  File ".local/bin/netkan", line 10, in <module>
    sys.exit(netkan())
  File "/home/netkan/.local/lib/python3.7/site-packages/click/core.py", line 764, in __call__
    return self.main(*args, **kwargs)
  File "/home/netkan/.local/lib/python3.7/site-packages/click/core.py", line 717, in main
    rv = self.invoke(ctx)
  File "/home/netkan/.local/lib/python3.7/site-packages/click/core.py", line 1137, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/home/netkan/.local/lib/python3.7/site-packages/click/core.py", line 956, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "/home/netkan/.local/lib/python3.7/site-packages/click/core.py", line 555, in invoke
    return callback(*args, **kwargs)
  File "/home/netkan/.local/lib/python3.7/site-packages/netkan/cli.py", line 114, in scheduler
    scheduler.schedule_all_netkans()
  File "/home/netkan/.local/lib/python3.7/site-packages/netkan/scheduler.py", line 54, in schedule_all_netkans
    self.client.send_message_batch(**self.sqs_batch_attrs(batch))
  File "/home/netkan/.local/lib/python3.7/site-packages/botocore/client.py", line 357, in _api_call
    return self._make_api_call(operation_name, kwargs)
  File "/home/netkan/.local/lib/python3.7/site-packages/botocore/client.py", line 661, in _make_api_call
    raise error_class(parsed_response, operation_name)
botocore.errorfactory.EmptyBatchRequest: An error occurred (AWS.SimpleQueueService.EmptyBatchRequest) when calling the SendMessageBatch operation: There should be at least one SendMessageBatchRequestEntry in the request.
```

## Cause

The final `yield(batch)` statement of `sqs_batch_entries` returns whatever is in the `batch` variable. If the list's length is a multiple of 10, then `batch` will be the empty list at that point, because the loop body clears it and nothing is put back in:

https://github.com/KSP-CKAN/NetKAN-Infra/blob/85ccd9268778839590db0e08b902673942e84cad/netkan/netkan/scheduler.py#L36-L44

## Changes

Now the logic of this loop is rewritten:

1. Return the first 10 entries in the list
2. Remove the first 10 netkans from the front of the list
3. Repeat till empty

This will avoid corner cases with empty lists.

Fixes #24.