### PR TITLE
Fix Batching when total Netkans Divisible by 10

### DIFF
--- a/netkan/netkan/scheduler.py
+++ b/netkan/netkan/scheduler.py
@@ -41,7 +41,8 @@ class NetkanScheduler:
             if len(batch) == batch_size:
                 yield(batch)
                 batch = []
-        yield(batch)
+        if len(batch):
+            yield(batch)
 
     def sqs_batch_attrs(self, batch):
         return {

--- a/netkan/tests/scheduler.py
+++ b/netkan/tests/scheduler.py
@@ -41,3 +41,12 @@ class TestNetKAN(unittest.TestCase):
         attrs = self.scheduler.sqs_batch_attrs(batch)
         self.assertEqual(attrs['QueueUrl'], 'test_url')
         self.assertEqual(len(attrs['Entries']), 10)
+
+    def test_sqs_batching_ten(self):
+        test_data = Path(PurePath(__file__).parent, 'testdata/NetTEN')
+        scheduler = NetkanScheduler(test_data, 'TestyMcTestFace')
+        batches = []
+        for batch in scheduler.sqs_batch_entries():
+            batches.append(batch)
+        self.assertEqual(len(batches[0]), 10)
+        self.assertEqual(len(batches), 1)

--- a/netkan/tests/testdata/NetTEN/NetKAN/DogeCoinFlag.netkan
+++ b/netkan/tests/testdata/NetTEN/NetKAN/DogeCoinFlag.netkan
@@ -1,0 +1,15 @@
+{
+    "spec_version"   : 1,
+    "identifier"     : "DogeCoinFlag",
+    "name"           : "Dogecoin Flag",
+    "abstract"       : "Such flag. Very currency. Wow.",
+    "description"    : "Adorn your craft with your favourite cryptocurrency. To the mün!",
+    "$kref"          : "#/ckan/github/pjf/DogeCoinFlag",
+    "ksp_version"    : "any",
+    "comment"        : "flagmod",
+    "license"        : "CC-BY",
+    "author"         : "daviddwk",
+    "resources"      : {
+        "homepage"   : "https://www.reddit.com/r/dogecoin/comments/1tdlgg/i_made_a_more_accurate_dogecoin_and_a_ksp_flag/"
+    }
+}

--- a/netkan/tests/testdata/NetTEN/NetKAN/DogeDogeDoge.netkan
+++ b/netkan/tests/testdata/NetTEN/NetKAN/DogeDogeDoge.netkan
@@ -1,0 +1,1 @@
+DogeCoinFlag.netkan

--- a/netkan/tests/testdata/NetTEN/NetKAN/DogeFlagCoin.netkan
+++ b/netkan/tests/testdata/NetTEN/NetKAN/DogeFlagCoin.netkan
@@ -1,0 +1,1 @@
+DogeCoinFlag.netkan

--- a/netkan/tests/testdata/NetTEN/NetKAN/FlagCoinDoge.netkan
+++ b/netkan/tests/testdata/NetTEN/NetKAN/FlagCoinDoge.netkan
@@ -1,0 +1,1 @@
+DogeCoinFlag.netkan

--- a/netkan/tests/testdata/NetTEN/NetKAN/FlagDogeCoin.netkan
+++ b/netkan/tests/testdata/NetTEN/NetKAN/FlagDogeCoin.netkan
@@ -1,0 +1,1 @@
+DogeCoinFlag.netkan

--- a/netkan/tests/testdata/NetTEN/NetKAN/NotCoinDoge.netkan
+++ b/netkan/tests/testdata/NetTEN/NetKAN/NotCoinDoge.netkan
@@ -1,0 +1,1 @@
+DogeCoinFlag.netkan

--- a/netkan/tests/testdata/NetTEN/NetKAN/NotDogeCoin.netkan
+++ b/netkan/tests/testdata/NetTEN/NetKAN/NotDogeCoin.netkan
@@ -1,0 +1,1 @@
+DogeCoinFlag.netkan

--- a/netkan/tests/testdata/NetTEN/NetKAN/NotDogeCoinFlag.netkan
+++ b/netkan/tests/testdata/NetTEN/NetKAN/NotDogeCoinFlag.netkan
@@ -1,0 +1,1 @@
+DogeCoinFlag.netkan

--- a/netkan/tests/testdata/NetTEN/NetKAN/NotDogeFlagCoin.netkan
+++ b/netkan/tests/testdata/NetTEN/NetKAN/NotDogeFlagCoin.netkan
@@ -1,0 +1,1 @@
+DogeCoinFlag.netkan

--- a/netkan/tests/testdata/NetTEN/NetKAN/YetAnotherDogeCoinFlag.netkan
+++ b/netkan/tests/testdata/NetTEN/NetKAN/YetAnotherDogeCoinFlag.netkan
@@ -1,0 +1,1 @@
+DogeCoinFlag.netkan


### PR DESCRIPTION
The iteration will top automatically when there is nothing left to yield. This will avoid trying to send an empty list of messages to SQS.