### PR TITLE
Populate 'last_checked' upon inflation

### DIFF
--- a/netkan/netkan/indexer.py
+++ b/netkan/netkan/indexer.py
@@ -103,11 +103,15 @@ class CkanMessage:
             self.ckan_meta.heads.master.checkout()
 
     def status_attrs(self, new=False):
+        inflation_time = parse(self.CheckTime)
         attrs = {
             'success': self.Success,
             # We may wish to change the name in the inflator
             # as the index will set 'last_checked'
-            'last_inflated': parse(self.CheckTime),
+            'last_inflated': inflation_time,
+            # If we have perfomed an inflation, we certainly
+            # have checked the mod!
+            'last_checked': inflation_time,
         }
         if new:
             attrs['ModIdentifier'] = self.ModIdentifier

--- a/netkan/tests/indexer.py
+++ b/netkan/tests/indexer.py
@@ -107,6 +107,7 @@ class TestCkan(unittest.TestCase):
         attrs = self.message.status_attrs(new=True)
         self.assertEqual(attrs['ModIdentifier'], 'DogeCoinFlag')
         self.assertTrue(attrs['success'])
+        self.assertIsInstance(attrs['last_checked'], datetime)
         self.assertIsInstance(attrs['last_inflated'], datetime)
         with self.assertRaises(KeyError):
             attrs['last_error']
@@ -136,6 +137,7 @@ class TestUpdateCkan(TestCkan):
         attrs = self.message.status_attrs(new=True)
         self.assertEqual(attrs['ModIdentifier'], 'DogeCoinFlag')
         self.assertTrue(attrs['success'])
+        self.assertIsInstance(attrs['last_checked'], datetime)
         self.assertIsInstance(attrs['last_inflated'], datetime)
         self.assertIsInstance(attrs['last_indexed'], datetime)
 
@@ -182,6 +184,7 @@ class TestStagedCkan(TestUpdateCkan):
         attrs = self.message.status_attrs(new=True)
         self.assertEqual(attrs['ModIdentifier'], 'DogeCoinFlag')
         self.assertTrue(attrs['success'])
+        self.assertIsInstance(attrs['last_checked'], datetime)
         self.assertIsInstance(attrs['last_inflated'], datetime)
         with self.assertRaises(KeyError):
             attrs['last_indexed']
@@ -226,6 +229,7 @@ class TestFailedCkan(TestCkan):
         attrs = self.message.status_attrs(new=True)
         self.assertEqual(attrs['ModIdentifier'], 'DogeCoinFlag')
         self.assertFalse(attrs['success'])
+        self.assertIsInstance(attrs['last_checked'], datetime)
         self.assertIsInstance(attrs['last_inflated'], datetime)
         self.assertEqual(
             attrs['last_error'],


### PR DESCRIPTION
In hindsight, this should be populated on inflation.

Fixes #23.