### PR TITLE
Fix Download Counts + Improve Build

### DIFF
--- a/bin/push_deploy_containers.sh
+++ b/bin/push_deploy_containers.sh
@@ -5,11 +5,13 @@ docker tag "kspckan/netkan" "kspckan/netkan:latest"
 docker push "kspckan/netkan:latest"
 
 # Legacy Webhooks
+docker pull "kspckan/webhooks" || true
 docker build webhooks/. -t kspckan/webhooks
 docker tag "kspckan/webhooks" "kspckan/webhooks:latest"
 docker push "kspckan/webhooks:latest"
 
 # Webhooks Proxy
+docker pull "kspckan/webhooks-proxy" || true
 docker build nginx/. -t kspckan/webhooks-proxy
 docker tag "kspckan/webhooks-proxy" "kspckan/webhooks-proxy:latest"
 docker push "kspckan/webhooks-proxy:latest"

--- a/netkan/netkan/download_counter.py
+++ b/netkan/netkan/download_counter.py
@@ -4,6 +4,7 @@ import re
 import requests
 from pathlib import Path
 from json.decoder import JSONDecodeError
+from .utils import repo_file_add_or_changed
 
 
 class DownloadCounter:
@@ -88,14 +89,6 @@ class DownloadCounter:
             json.dumps(self.counts, sort_keys=True, indent=4)
         )
 
-    def counts_changed(self):
-        if self.output_file in self.ckan_meta.untracked_files:
-            return True
-        if self.output_file in [
-                x.a_path for x in self.ckan_meta.index.diff(None)]:
-            return True
-        return False
-
     def commit_counts(self):
         index = self.ckan_meta.index
         index.add([self.output_file.as_posix()])
@@ -111,7 +104,7 @@ class DownloadCounter:
             'master', strategy='ours'
         )
         self.write_json()
-        if self.counts_changed():
+        if repo_file_add_or_changed(self.ckan_meta, self.output_file):
             self.commit_counts()
         else:
             logging.info('Download counts match existing data.')

--- a/netkan/netkan/download_counter.py
+++ b/netkan/netkan/download_counter.py
@@ -78,9 +78,17 @@ class DownloadCounter:
     def get_counts(self):
         for netkan in self.netkan_path.glob('NetKAN/*.netkan'):
             netkan = Path(netkan)
-            count = self.count_from_netkan(
-                json.loads(netkan.read_text())
-            )
+
+            # TODO: This downloader works, but needs refactoring. The error cases
+            #       are awkward and there is a fair bit of duplication going on.
+            count = 0
+            try:
+                count = self.count_from_netkan(
+                    json.loads(netkan.read_text())
+                )
+            except JSONDecodeError:
+                logging.error("Failed decoding count for  {}".format(netkan.stem))
+
             if count > 0:
                 self.counts[netkan.stem] = count
 

--- a/netkan/netkan/utils.py
+++ b/netkan/netkan/utils.py
@@ -33,3 +33,13 @@ def init_ssh(key, path):
             'ssh-keyscan', '-t', 'rsa', 'github.com'
         ], stdout=subprocess.PIPE)
         Path(key_path, 'known_hosts').write_text(scan.stdout.decode('utf-8'))
+
+
+def repo_file_add_or_changed(repo, filename):
+    relative_file = Path(filename).relative_to(repo.working_dir).as_posix()
+    if relative_file in repo.untracked_files:
+        return True
+    if relative_file in [
+            x.a_path for x in repo.index.diff(None)]:
+        return True
+    return False

--- a/netkan/tests/__init__.py
+++ b/netkan/tests/__init__.py
@@ -1,2 +1,3 @@
 from .indexer import *
 from .scheduler import *
+from .utils import *

--- a/netkan/tests/utils.py
+++ b/netkan/tests/utils.py
@@ -1,0 +1,52 @@
+from netkan.utils import repo_file_add_or_changed
+
+import unittest
+import tempfile
+from pathlib import Path
+from git import Repo
+
+
+class TestNetKANUtilsRepoFileAddOrChange(unittest.TestCase):
+
+    def setUp(self):
+        self.tmpdir = tempfile.TemporaryDirectory()
+        self.working = Path(self.tmpdir.name)
+        self.repo = Repo.init(self.working)
+        Path(self.working, 'existing.txt').touch()
+        self.nested = Path(self.working, 'nested')
+        self.nested.mkdir()
+        Path(self.nested, 'existing_nested.txt').touch()
+        self.repo.index.add(self.repo.untracked_files)
+        self.repo.index.commit('test')
+
+    def tearDown(self):
+        self.tmpdir.cleanup()
+
+    def test_no_file(self):
+        no_file = Path(self.working, 'newfile.txt')
+        self.assertFalse(repo_file_add_or_changed(self.repo, no_file))
+
+    def test_new_file(self):
+        new_file = Path(self.working, 'newfile.txt')
+        new_file.touch()
+        self.assertTrue(repo_file_add_or_changed(self.repo, new_file))
+
+    def test_no_changes(self):
+        existing = Path(self.working, 'existing.txt')
+        existing.touch()
+        self.assertFalse(repo_file_add_or_changed(self.repo, existing))
+
+    def test_changes(self):
+        existing = Path(self.working, 'existing.txt')
+        existing.write_text('I made a change')
+        self.assertTrue(repo_file_add_or_changed(self.repo, existing))
+
+    def test_new_nested(self):
+        existing = Path(self.nested, 'existing.txt')
+        existing.touch()
+        self.assertTrue(repo_file_add_or_changed(self.repo, existing))
+
+    def test_changes_nested(self):
+        existing = Path(self.nested, 'existing_nested.txt')
+        existing.write_text('text')
+        self.assertTrue(repo_file_add_or_changed(self.repo, existing))


### PR DESCRIPTION
The `counts_changed` function never actually worked primarily because I was comparing a path object with a list of strings.

```python
In [14]: 'test.txt' in ['test.txt', 'test2.txt']                                                                                                                                                                                                                                                                             
Out[14]: True

In [15]: test = Path('test.txt')                                                                                                                                                                                                                                                                                             

In [16]: test.name in ['test.txt', 'test2.txt']                                                                                                                                                                                                                                                                              
Out[16]: True

In [17]: test in ['test.txt', 'test2.txt']                                                                                                                                                                                                                                                                                   
Out[17]: False
```

Secondly it didn't work as the output file was an absolute path and both the diff and the untracked files deal in relative paths.

I addressed a build issue (#28) and added a to-do regarding a work around. As it did bail out during a test due to trying to decode json that didn't exist.

I did go to fully test this, but it looks like spacedock has gone down for the moment.