### PR TITLE
Clear old errors on successful inflation

### DIFF
--- a/netkan/netkan/indexer.py
+++ b/netkan/netkan/indexer.py
@@ -106,6 +106,7 @@ class CkanMessage:
         inflation_time = parse(self.CheckTime)
         attrs = {
             'success': self.Success,
+            'last_error': self.ErrorMessage,
             # We may wish to change the name in the inflator
             # as the index will set 'last_checked'
             'last_inflated': inflation_time,
@@ -117,8 +118,6 @@ class CkanMessage:
             attrs['ModIdentifier'] = self.ModIdentifier
         if self.indexed:
             attrs['last_indexed'] = datetime.now(timezone.utc)
-        if self.ErrorMessage:
-            attrs['last_error'] = self.ErrorMessage
         return attrs
 
     def _process_ckan(self):

--- a/netkan/tests/indexer.py
+++ b/netkan/tests/indexer.py
@@ -109,8 +109,7 @@ class TestCkan(unittest.TestCase):
         self.assertTrue(attrs['success'])
         self.assertIsInstance(attrs['last_checked'], datetime)
         self.assertIsInstance(attrs['last_inflated'], datetime)
-        with self.assertRaises(KeyError):
-            attrs['last_error']
+        self.assertEqual(attrs['last_error'], None)
         with self.assertRaises(KeyError):
             attrs['last_indexed']
 


### PR DESCRIPTION
## Problem

A day or two ago, SpaceDock had some downtime, and many modules hosted there were marked with errors. Now SpaceDock is fixed, but the errors are all still there:

http://status.ksp-ckan.space/

This means we can't tell whether a problem is still happening or already fixed.

## Cause

The new bot only sets the `last_error` attribute of the status object, and never clears it. Since the status objects persist long-term, this means the errors never go away.

## Changes

Now `last_error` is cleared upon success.