### PR TITLE
Clone repo normally

### DIFF
--- a/netkan/netkan/utils.py
+++ b/netkan/netkan/utils.py
@@ -9,10 +9,7 @@ def init_repo(metadata, path):
     clone_path = Path(path)
     if not clone_path.exists():
         logging.info('Cloning {}'.format(metadata))
-        clone_path.mkdir(parents=True)
-        repo = Repo.init(clone_path)
-        repo.create_remote('origin', metadata)
-        repo.remotes.origin.pull('master:master')
+        repo = Repo.clone_from(metadata, clone_path)
     else:
         repo = Repo(clone_path)
     return repo


### PR DESCRIPTION
## Problem

As @techman83 noted (see https://github.com/KSP-CKAN/NetKAN-Infra/issues/33#issuecomment-533073864), the new bot's git repos aren't being created properly.

A regular git clone's `.git/config` file:

```
[core]
	repositoryformatversion = 0
	filemode = true
	bare = false
	logallrefupdates = true
[remote "origin"]
	url = /tmp/tmpnvd6f81d/upstream
	fetch = +refs/heads/*:refs/remotes/origin/*
[branch "master"]
	remote = origin
	merge = refs/heads/master
```

The `.git/config` file from the new bot's repo:

```
[core]
	repositoryformatversion = 0
	filemode = true
	bare = false
	logallrefupdates = true
[remote "origin"]
	url = /tmp/tmpnvd6f81d/upstream
	fetch = +refs/heads/*:refs/remotes/origin/*
```

## Cause

The new bot attempts to set up its git repos manually in multiple steps: `mkdir`, `init`, `create_remote`, and `pull`. This leaves out the step of setting the upstream for the master branch.

## Changes

Now we use `clone_from` to set up the working dir normally. This will take care of the whole process for us in one step.

In a dir set up with the old code:

```
$ git status
On branch master
nothing to commit, working tree clean
```

In a dir set up with the new code:

```
$ git status
On branch master
Your branch is up to date with 'origin/master'.

nothing to commit, working tree clean
```

Note the new bit about "up to date with 'origin/master'". This means the upstream is set for the branch.

May relate to #33, but I'm not sure about that. I had expected the problem to relate more to the Perl web hook code and/or how it's configured, since the problem in that issue happens immediately without waiting for the new bot to mess things up.