### PR TITLE
Use the `ours` strategy OPTION rather than the `ours` strategy

### DIFF
--- a/netkan/netkan/download_counter.py
+++ b/netkan/netkan/download_counter.py
@@ -109,7 +109,7 @@ class DownloadCounter:
     def update_counts(self):
         self.get_counts()
         self.ckan_meta.remotes.origin.pull(
-            'master', strategy='ours'
+            'master', strategy_option='ours'
         )
         self.write_json()
         if repo_file_add_or_changed(self.ckan_meta, self.output_file):

--- a/netkan/netkan/indexer.py
+++ b/netkan/netkan/indexer.py
@@ -97,7 +97,7 @@ class CkanMessage:
             yield
         finally:
             self.ckan_meta.remotes.origin.pull(
-                self.mod_version, strategy='ours'
+                self.mod_version, strategy_option='ours'
             )
             self.ckan_meta.remotes.origin.push(self.mod_version)
             self.ckan_meta.heads.master.checkout()
@@ -218,7 +218,7 @@ class MessageHandler:
         if str(self.repo.active_branch) != 'master':
             self.repo.heads.master.checkout()
         self.repo.remotes.origin.pull(
-            'master', strategy='ours'
+            'master', strategy_option='ours'
         )
         if push:
             self.repo.remotes.origin.push('master')


### PR DESCRIPTION
## Problem

The new Python bot sometimes discards changes in its merge commits. Currently this is preventing the download counts from working (see #36); web hooks are also broken (see #33), maybe for the same reason, maybe with some additional complexity mixed in (will find out when we see whether this fixes it).

## Cause

Git has some very confusing syntax relating to merge strategies. The user can override the merge strategy, and/or provide *options* for a merge strategy, and **the `ours` keyword is allowed in both places!!!**

We want this one (and [used it historically in the Perl bot](https://github.com/KSP-CKAN/NetKAN-bot/blob/4f218a2085f9a5e49f151c499a9192e97c5af728/lib/App/KSP_CKAN/Tools/Git.pm#L411)):

https://git-scm.com/docs/git-pull

> **ours**
> This option forces conflicting hunks to be auto-resolved cleanly by favoring our version. Changes from the other tree that do not conflict with our side are reflected to the merge result. For a binary file, the entire contents are taken from our side.
>
> **This should not be confused with the ours merge strategy, which does not even look at what the other tree contains at all. It discards everything the other tree did, declaring our history contains all that happened in it.**

However, the Python bot currently uses this one:

> **ours**
> This resolves any number of heads, but the resulting tree of the merge is always that of the current branch head, effectively ignoring all changes from all other branches. It is meant to be used to supersede old development history of side branches. **Note that this is different from the -Xours option to the recursive merge strategy.**

This causes every `pull` that happens in the system to discard any changes that were added by another container!

## Changes

Now the Python bot uses the `ours` strategy *option* instead of the strategy, as intended. This will make it stop discarding changes.

To accomplish this, we need to switch from the `strategy` parameter to the `strategy-option` parameter.

> `-s <strategy>`
> `--strategy=<strategy>`
> Use the given merge strategy; can be supplied more than once to specify them in the order they should be tried. If there is no -s option, a built-in list of strategies is used instead (git merge-recursive when merging a single head, git merge-octopus otherwise).
> 
> `-X <option>`
> `--strategy-option=<option>`
> Pass merge strategy specific option through to the merge strategy.

In gitpython this is accomplished with an underscore in place of the dash:

- https://github.com/gitpython-developers/GitPython/blob/3d7eaf1253245c6b88fd969efa383b775927cdd0/git/cmd.py#L986
- https://github.com/gitpython-developers/GitPython/blob/3d7eaf1253245c6b88fd969efa383b775927cdd0/git/cmd.py#L897
- https://github.com/gitpython-developers/GitPython/blob/3d7eaf1253245c6b88fd969efa383b775927cdd0/git/cmd.py#L127-L128

Fixes #36. May fix #33, not sure about that one.