### PR TITLE
Customize web hook git user name

### DIFF
--- a/webhooks/.gitconfig
+++ b/webhooks/.gitconfig
@@ -1,3 +1,3 @@
 [user]
 	email = netkan-bot@ksp-ckan.space
-	name = NetKAN inflator Robot
+	name = NetKAN Webhook


### PR DESCRIPTION
I thought #38 would require some restructuring or scripting changes or something, but it turns out the webhook handler already has its own separate `.gitconfig` file.

Now commits from the webhook will be associated with a user name of "NetKAN Webhook".

Fixes #38.