### PR TITLE
Skip scheduling netkans that only need webhooks

### DIFF
--- a/netkan/netkan/cli.py
+++ b/netkan/netkan/cli.py
@@ -101,14 +101,18 @@ def indexer(queue, metadata, token, repo, user, key,
     '--dev', is_flag=True, default=False,
     help='Disable AWS Credit Checks',
 )
-def scheduler(queue, netkan, max_queued, debug, dev):
+@click.option(
+    '--schedule-all', is_flag=True, default=False,
+    help='Schedule all modules even if we think they should be covered by webhooks'
+)
+def scheduler(queue, netkan, max_queued, debug, dev, schedule_all):
     level = logging.DEBUG if debug else logging.INFO
     logging.basicConfig(
         format='[%(asctime)s] [%(levelname)-8s] %(message)s', level=level
     )
     logging.info('Scheduler started at log level %s', level)
 
-    scheduler = NetkanScheduler(Path('/tmp/NetKAN'), queue)
+    scheduler = NetkanScheduler(Path('/tmp/NetKAN'), queue, force_all=schedule_all)
     if scheduler.can_schedule(max_queued, dev):
         init_repo(netkan, '/tmp/NetKAN')
         scheduler.schedule_all_netkans()

--- a/netkan/tests/scheduler.py
+++ b/netkan/tests/scheduler.py
@@ -1,4 +1,4 @@
-from netkan.scheduler import NetkanScheduler
+from netkan.scheduler import Netkan, NetkanScheduler
 
 import unittest
 from pathlib import Path, PurePath
@@ -12,7 +12,8 @@ class TestNetKAN(unittest.TestCase):
 
     def test_netkan_message(self):
         dogecoinflag = Path(self.test_data, 'NetKAN/DogeCoinFlag.netkan')
-        message = self.scheduler.generate_netkan_message(dogecoinflag)
+        netkan = Netkan(dogecoinflag)
+        message = netkan.sqs_message()
         self.assertEqual(message['Id'], 'DogeCoinFlag')
         self.assertEqual(
             message['MessageBody'],


### PR DESCRIPTION
## Motivation

There are 789 modules that are hosted on SpaceDock and have no `$vref`. These modules will be inflated by the SpaceDock webhook when they are uploaded, and the lack of a `$vref` means that their metadata is constant thereafter.

(A .version file's `URL` property points to a remote .version file which can be updated at any time to change the module's game version compatibility. This means that we always need to check modules with a `$vref`.)

## Changes

Now the scheduler checks for and skips such modules, so only modules that really need it will be inflated. This will reduce the amount of work the new bot needs to do on each pass, in exchange for having to parse the contents of the netkans into JSON.

Fixes #10.