### PR TITLE
Fix missing kref check

### DIFF
--- a/netkan/netkan/scheduler.py
+++ b/netkan/netkan/scheduler.py
@@ -18,9 +18,9 @@ class Netkan:
         self.json     = json.loads(self.contents)
 
     def on_spacedock(self):
-        kref = self.json['$kref']
-        if not kref:
+        if not '$kref' in self.json:
             return False
+        kref = self.json['$kref']
         (kind, mod_id) = Netkan.kref_pattern.match(kref).groups()
         return kind == 'spacedock'
 


### PR DESCRIPTION
Fixes #43 more simply than #44 so the scheduler can get back in business quickly. We can still refactor, but now it's not a hurry.

I didn't realize the dict would throw on a missing key.