### PR TITLE
Push Staging Branches only on 'Indexed'

### DIFF
--- a/bin/push_deploy_containers.sh
+++ b/bin/push_deploy_containers.sh
@@ -4,12 +4,6 @@
 docker tag "kspckan/netkan" "kspckan/netkan:latest"
 docker push "kspckan/netkan:latest"
 
-# Legacy Webhooks
-docker pull "kspckan/webhooks" || true
-docker build webhooks/. -t kspckan/webhooks
-docker tag "kspckan/webhooks" "kspckan/webhooks:latest"
-docker push "kspckan/webhooks:latest"
-
 # Webhooks Proxy
 docker pull "kspckan/webhooks-proxy" || true
 docker build nginx/. -t kspckan/webhooks-proxy

--- a/bin/push_deploy_legacy.sh
+++ b/bin/push_deploy_legacy.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+# Legacy Webhooks
+docker pull "kspckan/webhooks" || true
+docker build webhooks/. -t kspckan/webhooks
+docker tag "kspckan/webhooks" "kspckan/webhooks:latest"
+docker push "kspckan/webhooks:latest"
+


### PR DESCRIPTION
Currently the indexer indescrimently creates branches regardless of whether there are changes to submit. It's mostly just an annoyance right now, but it will make the branches available unmanageable at some point.

There is already an indexed flag set, so lets just use it! Also with the lack of testing going on in the webhooks container and it very much considered legacy, we probably only want to build that when we have a change to push (and not worth building automation for, lets just replace it!)