### PR TITLE
Preserve request types in Redirects

### DIFF
--- a/nginx/nginx-dev.conf
+++ b/nginx/nginx-dev.conf
@@ -20,7 +20,7 @@ http {
         listen 80;
         server_name local.test.ksp-ckan.space;
         location / {
-            return 301 https://$host$request_uri;
+            return 308 https://$host$request_uri;
         }    
     }
     server {

--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -20,7 +20,7 @@ http {
         listen 80;
         server_name netkan.ksp-ckan.space;
         location / {
-            return 301 https://$host$request_uri;
+            return 308 https://$host$request_uri;
         }    
     }
     server {


### PR DESCRIPTION
## Problem
SpaceDock webhook requests were not being received and mods subsequently not being inflated.

## Reason
We were using a `301` redirect, which allows `POST` to become a `GET` and most clients treat it this way.

## Fix
Use a [308 redirect](https://tools.ietf.org/id/draft-reschke-http-status-308-07.html) instead, which disallows rewriting from `POST` to `GET`