### PR TITLE
Add VS Code Configuration

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,16 @@
+{
+	"name": "NetKAN Indexing",
+	"dockerComposeFile": [
+		"../docker-compose.vscode.yml"
+	],
+	"service": "netkan",
+	"workspaceFolder": "/home/netkan/workspace",
+	"settings": { 
+		// This will ignore your local shell user setting for Linux since shells like zsh are typically 
+		// not in base container images. You can also update this to an specific shell to ensure VS Code 
+		// uses the right one for terminals and tasks. For example, /bin/bash (or /bin/ash for Alpine).
+		"terminal.integrated.shell.linux": null
+	},
+	"postCreateCommand": "pip install --user -e netkan/.",
+	"extensions": []
+}

--- a/.pylintrc
+++ b/.pylintrc
@@ -1,0 +1,11 @@
+[MASTER]
+ignore-patterns=
+    setup.py
+    prod-stack.py
+    dev-stack.py
+
+[MESSAGES CONTROL]
+
+disable=
+    missing-docstring,
+    no-member,

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,6 @@
+{
+    "recommendations": [
+        "ms-vscode-remote.vscode-remote-extensionpack",
+        "ms-python.python"
+    ]
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,28 @@
+{
+  "python.pythonPath": "/usr/bin/python3",
+  "python.formatting.provider": "autopep8",
+  "editor.formatOnSave": false,
+  "python.linting.pylintEnabled": true,
+  "python.linting.enabled": true,
+  "python.linting.pylintArgs": [
+    "--rcfile",
+    "/home/netkan/workspace/.pylintrc"
+  ],
+  "python.linting.pylintUseMinimalCheckers": false,
+  "files.exclude": {
+    "**/__pycache__": true
+  },
+  "python.testing.unittestArgs": [
+    "-v",
+    "-s",
+    "./netkan",
+    "-p",
+    "tests/__init__.py"
+  ],
+  "python.testing.pytestEnabled": false,
+  "python.testing.nosetestsEnabled": false,
+  "python.testing.unittestEnabled": true,
+  "files.trimTrailingWhitespace": true,
+  "files.insertFinalNewline": true,
+  "files.trimFinalNewlines": true
+}

--- a/README.md
+++ b/README.md
@@ -1,11 +1,11 @@
 # NetKAN-Infra
-NetKAN Infrastructure Repo
+The NetKAN Infrastructure Project is a re-write of the original monolithic NetKAN-bot, with the goal of easier maintenance, a faster code to deployment pipeline, infrastructure as code.
 
 
 Performing Updates
 ------------------
 
-**Updating the Stacke:**
+**Updating the Stack:**
 ```bash
 aws cloudformation update-stack --stack-name DevQueues --template-body "`python dev-stack.py`" --capabilities CAPABILITY_IAM --profile ckan --region us-west-2
 ```

--- a/docker-compose.vscode.yml
+++ b/docker-compose.vscode.yml
@@ -1,0 +1,28 @@
+version: '3.4'
+
+services:
+  netkan:
+    user: netkan
+    build:
+      context: netkan/.
+      target: dev
+    environment:
+      SSH_KEY: ${CKAN_NETKAN_SSHKEY}
+      CKANMETA_REMOTE: ${CKAN_METADATA_PATH}
+      CKANMETA_USER: ${CKAN_METADATA_USER}
+      CKANMETA_REPO: ${CKAN_METADATA_REPO}
+      NETKAN_REMOTE: ${NETKAN_METADATA_PATH}
+      AWS_DEFAULT_REGION: ${CKAN_AWS_DEFAULT_REGION}
+      AWS_SECRET_ACCESS_KEY: ${CKAN_AWS_SECRET_ACCESS_KEY}
+      AWS_ACCESS_KEY_ID: ${CKAN_AWS_ACCESS_KEY_ID}
+      GH_Token: ${CKAN_GH_Token}
+      SQS_TIMEOUT: 30
+      STATUS_DB: DevNetKANStatus
+      XKAN_GHSECRET: test
+      INFLATION_SQS_QUEUE: InboundDev.fifo
+      MIRROR_SQS_QUEUE: MirroringDev.fifo
+      STATUS_BUCKET: ckan-test-status
+      STATUS_INTERVAL: 0
+    volumes:
+      - .:/home/netkan/workspace
+    entrypoint: sleep infinity

--- a/netkan/Dockerfile
+++ b/netkan/Dockerfile
@@ -10,13 +10,13 @@ USER root
 RUN rm -Rf /netkan
 
 FROM python:3.7 as dev
-COPY --from=base /home/netkan /home/netkan
-RUN useradd -Ms /bin/bash netkan
-RUN chown -R netkan:netkan /home/netkan
-ADD run_dev.sh /usr/local/bin/
+RUN useradd -ms /bin/bash netkan
+ADD . /netkan
 WORKDIR /home/netkan
+ADD run_dev.sh /usr/local/bin/
+ENV PATH "$PATH:/home/netkan/.local/bin"
 USER netkan
-ENTRYPOINT ["/usr/local/bin/run_dev.sh"]
+RUN pip install --user /netkan/.[development]
 
 FROM python:3.7
 COPY --from=base /home/netkan /home/netkan

--- a/netkan/setup.py
+++ b/netkan/setup.py
@@ -23,4 +23,13 @@ setup(
             'netkan=netkan.cli:netkan',
         ],
     },
+    extras_require={
+        'development': [
+            'pytest',
+            'ptvsd',
+            'pylint',
+            'autopep8',
+            'troposphere'
+        ]
+    },
 )


### PR DESCRIPTION
## Motivation
Having a consistent environment for develop and testing is really helpful. VS Code has a lot of mind share and drive behind it, allowing us to bundle up a lot of our requirements and dependencies in an easy to use package.

## Changes
This PR adds a standard vs code environment, including plugin recommendations, development dependencies, and automatically opening up a container with the netkan project installed in editable mode.

For example, opening a terminal after the container has been built and launched
```bash
netkan@39991ca05cb3:~/workspace$ netkan --help
Usage: netkan [OPTIONS] COMMAND [ARGS]...

Options:
  --help  Show this message and exit.

Commands:
  clean-cache
  download-counter
  dump-status
  export-status-s3
  indexer
  redeploy-service
  restore-status
  scheduler
```

## Things of Note

- I've only tested this under Linux, the infrastructure is all Linux based and the project makes that assumption.
- VS Code uses a search for test discovery, instead of the internal unittest logic. The first time you run it, it will complain no tests are found. If you run the tests again, they work. I've yet to find a work around beyond renaming all the test files with 'test' in the names :roll_eyes: 
- We can write launch tasks for each of the different tasks, with their own environment variables. But I have left that as a future enhancement we can do.
