### PR TITLE
Count missing repo as zero instead of throwing

### DIFF
--- a/netkan/netkan/download_counter.py
+++ b/netkan/netkan/download_counter.py
@@ -47,9 +47,10 @@ class NetkanDownloads(Netkan):
         ).json()
 
         total = 0
-        for rel in releases:
-            for asset in rel['assets']:
-                total += asset['download_count']
+        if isinstance(releases, list):
+            for rel in releases:
+                for asset in rel['assets']:
+                    total += asset['download_count']
 
         repo = requests.get(
             url, headers=self.github_headers


### PR DESCRIPTION
## Problem

Download counts haven't updated in 7 days.

https://github.com/KSP-CKAN/CKAN-meta/commits/master/download_counts.json

## Cause

```
Traceback (most recent call last):
  File ".local/bin/netkan", line 8, in <module>
    sys.exit(netkan())
  File "/home/netkan/.local/lib/python3.7/site-packages/click/core.py", line 764, in __call__
    return self.main(*args, **kwargs)
  File "/home/netkan/.local/lib/python3.7/site-packages/click/core.py", line 717, in main
    rv = self.invoke(ctx)
  File "/home/netkan/.local/lib/python3.7/site-packages/click/core.py", line 1137, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/home/netkan/.local/lib/python3.7/site-packages/click/core.py", line 956, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "/home/netkan/.local/lib/python3.7/site-packages/click/core.py", line 555, in invoke
    return callback(*args, **kwargs)
  File "/home/netkan/.local/lib/python3.7/site-packages/netkan/cli.py", line 255, in download_counter
    token
  File "/home/netkan/.local/lib/python3.7/site-packages/netkan/download_counter.py", line 120, in update_counts
    self.get_counts()
  File "/home/netkan/.local/lib/python3.7/site-packages/netkan/download_counter.py", line 101, in get_counts
    count = netkan.get_count()
  File "/home/netkan/.local/lib/python3.7/site-packages/netkan/download_counter.py", line 75, in get_count
    count = getattr(self, f'count_from_{self.kref_src}')()
  File "/home/netkan/.local/lib/python3.7/site-packages/netkan/download_counter.py", line 51, in count_from_github
    for asset in rel['assets']:
TypeError: string indices must be integers
```

`Galileo88/SSRSS-StockIncl`, `SSRSS-Clouds-LR`, `SSRSS-Cont`, and `SSRSS-Clouds-HR` were deleted from GitHub. If a GitHub `$kref` points to a non-existent repo, the `/releases` call returns this:

```json
{
  "message": "Not Found",
  "documentation_url": "https://developer.github.com/v3/repos/releases/#list-releases-for-a-repository"
}
```

... and Python happily allows us to loop over that object's keys using code intended to loop over the elements of an array:

https://github.com/KSP-CKAN/NetKAN-Infra/blob/8eb0b9043c36315b739c91b0b231716bbe8e048d/netkan/netkan/download_counter.py#L49-L52

And `rel['assets']` tries to access the `assets` property of `"message"`, which throws the exception.

## Changes

Now we check the type of `releases` before trying to loop over it.

Fixes #50 (again).