### PR TITLE
Mirroring webhook

### DIFF
--- a/bin/push_deploy_containers.sh
+++ b/bin/push_deploy_containers.sh
@@ -29,3 +29,9 @@ docker run \
 	-e AWS_DEFAULT_REGION="$AWS_DEFAULT_REGION" \
 	"kspckan/netkan" redeploy-service --cluster \
 	NetKANCluster --service-name Adder
+docker run \
+	-e AWS_ACCESS_KEY_ID="$AWS_ACCESS_KEY_ID" \
+	-e AWS_SECRET_ACCESS_KEY="$AWS_SECRET_ACCESS_KEY" \
+	-e AWS_DEFAULT_REGION="$AWS_DEFAULT_REGION" \
+	"kspckan/netkan" redeploy-service --cluster \
+	NetKANCluster --service-name Mirrorer

--- a/dev-stack.py
+++ b/dev-stack.py
@@ -1,14 +1,14 @@
 # Converted from SQS_With_CloudWatch_Alarms.template located at:
 # http://aws.amazon.com/cloudformation/aws-cloudformation-templates/
 
+import os
+import sys
 from troposphere import GetAtt, Output, Ref, Sub, Template
 from troposphere.iam import Group, PolicyType
 from troposphere.sqs import Queue
 from troposphere.dynamodb import Table, KeySchema, AttributeDefinition, \
     ProvisionedThroughput
 from troposphere.s3 import Bucket
-import os
-import sys
 
 zone_id = os.environ.get('CKAN_DEV_ZONEID', False)
 
@@ -32,6 +32,10 @@ addqueue = t.add_resource(Queue("Adding",
                                 QueueName="AddingDev.fifo",
                                 ReceiveMessageWaitTimeSeconds=20,
                                 FifoQueue=True))
+mirrorqueue = t.add_resource(Queue("Mirroring",
+                                   QueueName="MirroringDev.fifo",
+                                   ReceiveMessageWaitTimeSeconds=20,
+                                   FifoQueue=True))
 
 queue_dev_group = t.add_resource(Group("QueueDevGroup"))
 t.add_resource(PolicyType(
@@ -65,7 +69,7 @@ t.add_resource(PolicyType(
     }
 ))
 
-for queue in [inbound, outbound, addqueue]:
+for queue in [inbound, outbound, addqueue, mirrorqueue]:
     t.add_output([
         Output(
             "{}QueueURL".format(queue.title),

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -79,6 +79,7 @@ services:
       SSH_KEY: ${CKAN_NETKAN_SSHKEY}
       NETKAN_REMOTE: ${NETKAN_METADATA_PATH}
       INFLATION_SQS_QUEUE: InboundDev.fifo
+      MIRROR_SQS_QUEUE: MirroringDev.fifo
       AWS_DEFAULT_REGION: ${CKAN_AWS_DEFAULT_REGION}
       AWS_SECRET_ACCESS_KEY: ${CKAN_AWS_SECRET_ACCESS_KEY}
       AWS_ACCESS_KEY_ID: ${CKAN_AWS_ACCESS_KEY_ID}
@@ -96,6 +97,23 @@ services:
       NETKAN_USER: ${CKAN_NETKAN_USER}
       NETKAN_REPO:  ${CKAN_NETKAN_REPO}
     command: spacedock-adder
+  mirrorer:
+    build:
+      context: netkan/.
+      target: dev
+    environment:
+      SQS_QUEUE: MirroringDev.fifo
+      SQS_TIMEOUT: 30
+      AWS_DEFAULT_REGION: ${CKAN_AWS_DEFAULT_REGION}
+      AWS_SECRET_ACCESS_KEY: ${CKAN_AWS_SECRET_ACCESS_KEY}
+      AWS_ACCESS_KEY_ID: ${CKAN_AWS_ACCESS_KEY_ID}
+      CKANMETA_REMOTE: ${CKAN_METADATA_PATH}
+      IA_access: test
+      IA_secret: test
+      IA_collection: test
+    volumes:
+      - ${HOME}/ckan_cache:/home/netkan/ckan_cache
+    command: mirrorer
   status:
     build:
       context: netkan/.

--- a/netkan/netkan/cli.py
+++ b/netkan/netkan/cli.py
@@ -62,7 +62,7 @@ def netkan(debug):
     help='SSH key for accessing repositories',
 )
 def indexer(queue, ckanmeta_remote, token, repo, user, key, timeout):
-    init_ssh(key,  Path(Path.home(), '.ssh'))
+    init_ssh(key, Path(Path.home(), '.ssh'))
     ckan_meta = init_repo(ckanmeta_remote, '/tmp/CKAN-meta')
 
     github_pr = GitHubPR(token, repo, user)
@@ -208,7 +208,7 @@ def redeploy_service(cluster, service_name):
         )
         raise click.UsageError(
             "Service '{}' not found. Available services:\n    - {}".format(
-                service, available)
+                service_name, available)
         )
     client.update_service(
         cluster=cluster,
@@ -382,11 +382,16 @@ def mirrorer(queue, timeout, ckan_meta, ia_access, ia_secret, ia_collection):
     help='Collection to put mirrored mods in on Internet Archive',
     required=True,
 )
-def mirror_purge_epochs(ckan_meta, ia_access, ia_secret, ia_collection):
+@click.option(
+    '--dry-run',
+    help='',
+    default=False,
+)
+def mirror_purge_epochs(ckan_meta, ia_access, ia_secret, ia_collection, dry_run):
     Mirrorer(
         init_repo(ckan_meta, '/tmp/CKAN-meta'),
         ia_access, ia_secret, ia_collection
-    ).purge_epochs()
+    ).purge_epochs(dry_run)
 
 
 @click.command()
@@ -420,7 +425,7 @@ def mirror_purge_epochs(ckan_meta, ia_access, ia_secret, ia_collection):
     help='SSH key for accessing repositories',
 )
 def spacedock_adder(queue, timeout, netkan_remote, token, repo, user, key):
-    init_ssh(key,  Path(Path.home(), '.ssh'))
+    init_ssh(key, Path(Path.home(), '.ssh'))
     sd_adder = SpaceDockAdder(
         queue,
         timeout,

--- a/netkan/netkan/common.py
+++ b/netkan/netkan/common.py
@@ -17,5 +17,5 @@ def sqs_batch_entries(messages, batch_size=10):
 
 
 def pull_all(repos):
-    for r in repos:
-        r.remotes.origin.pull('master', strategy_option='theirs')
+    for repo in repos:
+        repo.remotes.origin.pull('master', strategy_option='theirs')

--- a/netkan/netkan/metadata.py
+++ b/netkan/netkan/metadata.py
@@ -68,9 +68,9 @@ class Netkan:
     def sqs_message_attribs(self, ckan_group=None):
         attribs = {}
         if ckan_group and not getattr(self, 'x_netkan_allow_out_of_order', False):
-            highVer = ckan_group.highest_version()
-            if highVer:
-                attribs['HighestVersion'] = self.string_attrib(highVer.string)
+            high_ver = ckan_group.highest_version()
+            if high_ver:
+                attribs['HighestVersion'] = self.string_attrib(high_ver.string)
         return attribs
 
     def sqs_message(self, ckan_group=None):

--- a/netkan/netkan/mirrorer.py
+++ b/netkan/netkan/mirrorer.py
@@ -1,0 +1,336 @@
+import re
+import tempfile
+import urllib.request
+import hashlib
+import logging
+from pathlib import Path
+import requests
+import boto3
+import internetarchive
+
+from .metadata import Ckan
+
+
+class Mirrorer:
+
+    CACHE_PATH = Path('/home/netkan/ckan_cache/')
+    EPOCH_ID_REGEXP = re.compile('-[0-9]+-')
+    EPOCH_TITLE_REGEXP = re.compile(' - [0-9]+:')
+
+    def __init__(self, ckan_meta_repo, ia_access, ia_secret, ia_collection):
+        sqs = boto3.resource('sqs')
+        self.sqs_client = boto3.client('sqs')
+        self.ckan_meta_repo = ckan_meta_repo
+        self.ia_collection = ia_collection
+        self.ia_access = ia_access
+        self.ia_session = internetarchive.get_session(config={
+            's3': {
+                'access': ia_access,
+                'secret': ia_secret,
+            }
+        })
+
+    def process_queue(self, queue_name, timeout):
+        queue = sqs.get_queue_by_name(QueueName=queue_name)
+        while True:
+            messages = queue.receive_messages(
+                MaxNumberOfMessages=10,
+                MessageAttributeNames=['All'],
+                VisibilityTimeout=timeout,
+            )
+            if messages:
+                # Check if archive.org is overloaded
+                if self.ia_overloaded():
+                    logging.info('The Internet Archive is overloaded, try again later')
+                    continue
+                # Get up to date copy of the metadata for the files we're mirroring
+                logging.info('Updating repo')
+                self.ckan_meta_repo.heads.master.checkout()
+                self.ckan_meta_repo.remotes.origin.pull('master', strategy_option='theirs')
+                # Start processing the messages
+                to_delete = []
+                for msg in messages:
+                    path = Path(self.ckan_meta_repo.working_dir, msg.body)
+                    if self.try_mirror(CkanMirror(path)):
+                        # Successfully handled -> OK to delete
+                        to_delete.append(self.deletion_msg(msg))
+                queue.delete_messages(Entries=to_delete)
+                # Clean up GitPython's lingering file handles between batches
+                self.ckan_meta_repo.close()
+
+    def try_mirror(self, ckan):
+        if not ckan.can_mirror:
+            # If we can't mirror, then we're done with this message
+            logging.info('Ckan %s cannot be mirrored', ckan.mirror_item)
+            return True
+        if ckan.mirrored(self.ia_session):
+            # If it's already mirrored, then we're done with this message
+            logging.info('Ckan %s is already mirrored', ckan.mirror_item)
+            return True
+        cached_file = self.cache_find_file(ckan)
+        if cached_file:
+            # If the download is in the cache, use it
+            with cached_file.open(mode='rb') as file:
+                logging.info('Found matching cache entry at %s', cached_file)
+                return self.try_upload(ckan, file)
+        else:
+            # Download the file as needed
+            with tempfile.NamedTemporaryFile() as tmp:
+                logging.info('Downloading %s', ckan.download)
+                urllib.request.urlretrieve(ckan.download, tmp.name)
+                logging.info('Downloaded %s to %s', ckan.mirror_item, tmp.name)
+                return self.try_upload(ckan, tmp.file)
+        return True
+
+    def cache_find_file(self, ckan):
+        found = list(self.CACHE_PATH.glob(f'**/{ckan.cache_prefix}*'))
+        if found:
+            return found[0]
+        return None
+
+    def try_upload(self, ckan, file):
+        if ckan.download_hash.get('sha256') != self.large_file_sha256(file):
+            # Bad download, try again later
+            logging.info('Hash mismatch')
+            return False
+        logging.info('Uploading %s', ckan.mirror_item)
+        lic_urls = ckan.license_urls()
+        item = internetarchive.Item(self.ia_session, ckan.mirror_item)
+        return item.upload_file(file.name, ckan.mirror_item, {
+            'title':       ckan.mirror_title,
+            'description': ckan.mirror_description,
+            'creator':     ckan.authors(),
+            'collection':  self.ia_collection,
+            'subject':     'ksp; kerbal space program; mod',
+            'mediatype':   'software',
+            **({'licenseurl': lic_urls} if lic_urls else {}),
+        }, {
+            'Content-Type':           ckan.download_content_type,
+            'Content-Length':         ckan.download_size,
+            'x-amz-auto-make-bucket': 1,
+        })
+
+    def large_file_sha256(self, file, block_size=8192):
+        sha = hashlib.sha256()
+        for block in iter(lambda: file.read(block_size), b''):
+            sha.update(block)
+        return sha.hexdigest().upper()
+
+    def deletion_msg(self, msg):
+        return {
+            'Id':            msg.message_id,
+            'ReceiptHandle': msg.receipt_handle,
+        }
+
+    def ia_overloaded(self):
+        return requests.get(
+            'https://s3.us.archive.org/?check_limit=1&accesskey={}'.format(
+                self.ia_access
+            )
+        ).status_code == 503
+
+    def purge_epochs(self):
+        for result in self._epoch_search():
+            ident = result.get('identifier')
+            if ident:
+                item = session.get_item(ident)
+                item.modify_metadata({
+                    'identifier': self.EPOCH_ID_REGEXP.sub('-', ident),
+                    'title': self.EPOCH_TITLE_REGEXP.sub(' - ', item.metadata.get('title')),
+                })
+
+    def _epoch_search(self):
+        return filter(
+            self._result_has_epoch,
+            self.ia_session.search_items(
+                f'collection:({self.ia_collection})',
+                fields=['identifier', 'title']
+            )
+        )
+
+    def _result_has_epoch(self, result):
+        return self.EPOCH_TITLE_REGEXP.search(result.get('title'))
+
+
+class CkanMirror(Ckan):
+
+    REDISTRIBUTABLE_LICENSES = {
+        "public-domain",
+        "Apache", "Apache-1.0", "Apache-2.0",
+        "Artistic", "Artistic-1.0", "Artistic-2.0",
+        "BSD-2-clause", "BSD-3-clause", "BSD-4-clause",
+        "ISC",
+        "CC-BY", "CC-BY-1.0", "CC-BY-2.0", "CC-BY-2.5", "CC-BY-3.0", "CC-BY-4.0",
+        "CC-BY-SA", "CC-BY-SA-1.0", "CC-BY-SA-2.0", "CC-BY-SA-2.5", "CC-BY-SA-3.0", "CC-BY-SA-4.0",
+        "CC-BY-NC", "CC-BY-NC-1.0", "CC-BY-NC-2.0", "CC-BY-NC-2.5", "CC-BY-NC-3.0", "CC-BY-NC-4.0",
+        "CC-BY-NC-SA", "CC-BY-NC-SA-1.0", "CC-BY-NC-SA-2.0", "CC-BY-NC-SA-2.5", "CC-BY-NC-SA-3.0", "CC-BY-NC-SA-4.0",
+        "CC-BY-NC-ND", "CC-BY-NC-ND-1.0", "CC-BY-NC-ND-2.0", "CC-BY-NC-ND-2.5", "CC-BY-NC-ND-3.0", "CC-BY-NC-ND-4.0",
+        "CC-BY-ND", "CC-BY-ND-1.0", "CC-BY-ND-2.0", "CC-BY-ND-2.5", "CC-BY-ND-3.0", "CC-BY-ND-4.0",
+        "CC0",
+        "CDDL", "CPL",
+        "EFL-1.0", "EFL-2.0",
+        "Expat", "MIT",
+        "GPL-1.0", "GPL-2.0", "GPL-3.0",
+        "LGPL-2.0", "LGPL-2.1", "LGPL-3.0",
+        "GFDL-1.0", "GFDL-1.1", "GFDL-1.2", "GFDL-1.3",
+        "GFDL-NIV-1.0", "GFDL-NIV-1.1", "GFDL-NIV-1.2", "GFDL-NIV-1.3",
+        "LPPL-1.0", "LPPL-1.1", "LPPL-1.2", "LPPL-1.3c",
+        "MPL-1.1",
+        "Perl",
+        "Python-2.0",
+        "QPL-1.0",
+        "W3C",
+        "Zlib",
+        "Zope",
+        "WTFPL",
+        "Unlicense",
+        "open-source", "unrestricted"
+    }
+
+    LICENSE_URLS = {
+        "Apache"            : 'http://www.apache.org/licenses/LICENSE-1.0',
+        "Apache-1.0"        : 'http://www.apache.org/licenses/LICENSE-1.0',
+        "Apache-2.0"        : 'http://www.apache.org/licenses/LICENSE-2.0',
+        "Artistic"          : 'http://www.gnu.org/licenses/license-list.en.html#ArtisticLicense',
+        "Artistic-1.0"      : 'http://www.gnu.org/licenses/license-list.en.html#ArtisticLicense',
+        "Artistic-2.0"      : 'http://www.perlfoundation.org/artistic_license_2_0',
+        "BSD-2-clause"      : 'https://opensource.org/licenses/BSD-2-Clause',
+        "BSD-3-clause"      : 'https://opensource.org/licenses/BSD-3-Clause',
+        "ISC"               : 'https://opensource.org/licenses/ISC',
+        "CC-BY"             : 'https://creativecommons.org/licenses/by/1.0/',
+        "CC-BY-1.0"         : 'https://creativecommons.org/licenses/by/1.0/',
+        "CC-BY-2.0"         : 'https://creativecommons.org/licenses/by/2.0/',
+        "CC-BY-2.5"         : 'https://creativecommons.org/licenses/by/2.5/',
+        "CC-BY-3.0"         : 'https://creativecommons.org/licenses/by/3.0/',
+        "CC-BY-4.0"         : 'https://creativecommons.org/licenses/by/4.0/',
+        "CC-BY-SA"          : 'https://creativecommons.org/licenses/by-sa/1.0/',
+        "CC-BY-SA-1.0"      : 'https://creativecommons.org/licenses/by-sa/1.0/',
+        "CC-BY-SA-2.0"      : 'https://creativecommons.org/licenses/by-sa/2.0/',
+        "CC-BY-SA-2.5"      : 'https://creativecommons.org/licenses/by-sa/2.5/',
+        "CC-BY-SA-3.0"      : 'https://creativecommons.org/licenses/by-sa/3.0/',
+        "CC-BY-SA-4.0"      : 'https://creativecommons.org/licenses/by-sa/4.0/',
+        "CC-BY-NC"          : 'https://creativecommons.org/licenses/by-nc/1.0/',
+        "CC-BY-NC-1.0"      : 'https://creativecommons.org/licenses/by-nc/1.0/',
+        "CC-BY-NC-2.0"      : 'https://creativecommons.org/licenses/by-nc/2.0/',
+        "CC-BY-NC-2.5"      : 'https://creativecommons.org/licenses/by-nc/2.5/',
+        "CC-BY-NC-3.0"      : 'https://creativecommons.org/licenses/by-nc/3.0/',
+        "CC-BY-NC-4.0"      : 'https://creativecommons.org/licenses/by-nc/4.0/',
+        "CC-BY-NC-SA"       : 'http://creativecommons.org/licenses/by-nc-sa/1.0/',
+        "CC-BY-NC-SA-1.0"   : 'http://creativecommons.org/licenses/by-nc-sa/1.0',
+        "CC-BY-NC-SA-2.0"   : 'http://creativecommons.org/licenses/by-nc-sa/2.0',
+        "CC-BY-NC-SA-2.5"   : 'http://creativecommons.org/licenses/by-nc-sa/2.5',
+        "CC-BY-NC-SA-3.0"   : 'http://creativecommons.org/licenses/by-nc-sa/3.0',
+        "CC-BY-NC-SA-4.0"   : 'http://creativecommons.org/licenses/by-nc-sa/4.0',
+        "CC-BY-NC-ND"       : 'https://creativecommons.org/licenses/by-nd-nc/1.0/',
+        "CC-BY-NC-ND-1.0"   : 'https://creativecommons.org/licenses/by-nd-nc/1.0/',
+        "CC-BY-NC-ND-2.0"   : 'https://creativecommons.org/licenses/by-nd-nc/2.0/',
+        "CC-BY-NC-ND-2.5"   : 'https://creativecommons.org/licenses/by-nd-nc/2.5/',
+        "CC-BY-NC-ND-3.0"   : 'https://creativecommons.org/licenses/by-nd-nc/3.0/',
+        "CC-BY-NC-ND-4.0"   : 'https://creativecommons.org/licenses/by-nd-nc/4.0/',
+        "CC-BY-ND"          : 'https://creativecommons.org/licenses/by-nd/1.0/',
+        "CC-BY-ND-1.0"      : 'https://creativecommons.org/licenses/by-nd/1.0/',
+        "CC-BY-ND-2.0"      : 'https://creativecommons.org/licenses/by-nd/2.0/',
+        "CC-BY-ND-2.5"      : 'https://creativecommons.org/licenses/by-nd/2.5/',
+        "CC-BY-ND-3.0"      : 'https://creativecommons.org/licenses/by-nd/3.0/',
+        "CC-BY-ND-4.0"      : 'https://creativecommons.org/licenses/by-nd/4.0/',
+        "CC0"               : 'https://creativecommons.org/publicdomain/zero/1.0/',
+        "CDDL"              : 'https://opensource.org/licenses/CDDL-1.0',
+        "CPL"               : 'https://opensource.org/licenses/cpl1.0.php',
+        "EFL-1.0"           : 'https://opensource.org/licenses/ver1_eiffel',
+        "EFL-2.0"           : 'https://opensource.org/licenses/EFL-2.0',
+        "Expat"             : 'https://opensource.org/licenses/MIT',
+        "MIT"               : 'https://opensource.org/licenses/MIT',
+        "GPL-1.0"           : 'http://www.gnu.org/licenses/old-licenses/gpl-1.0.en.html',
+        "GPL-2.0"           : 'http://www.gnu.org/licenses/old-licenses/gpl-2.0.en.html',
+        "GPL-3.0"           : 'http://www.gnu.org/licenses/gpl-3.0.en.html',
+        "LGPL-2.0"          : 'https://www.gnu.org/licenses/old-licenses/lgpl-2.0.html',
+        "LGPL-2.1"          : 'https://www.gnu.org/licenses/old-licenses/lgpl-2.1.html',
+        "LGPL-3.0"          : 'http://www.gnu.org/licenses/lgpl-3.0.en.html',
+        "GFDL-1.1"          : 'http://www.gnu.org/licenses/old-licenses/fdl-1.1.en.html',
+        "GFDL-1.2"          : 'http://www.gnu.org/licenses/old-licenses/fdl-1.2.html',
+        "GFDL-1.3"          : 'http://www.gnu.org/licenses/fdl-1.3.en.html',
+        "LPPL-1.0"          : 'https://latex-project.org/lppl/lppl-1-0.html',
+        "LPPL-1.1"          : 'https://latex-project.org/lppl/lppl-1-1.html',
+        "LPPL-1.2"          : 'https://latex-project.org/lppl/lppl-1-2.html',
+        "LPPL-1.3c"         : 'https://latex-project.org/lppl/lppl-1-3c.html',
+        "MPL-1.1"           : 'https://www.mozilla.org/en-US/MPL/1.1/',
+        "Perl"              : 'http://dev.perl.org/licenses/',
+        "Python-2.0"        : 'https://www.python.org/download/releases/2.0/license/',
+        "QPL-1.0"           : 'https://opensource.org/licenses/QPL-1.0',
+        "W3C"               : 'https://www.w3.org/Consortium/Legal/2015/copyright-software-and-document',
+        "Zlib"              : 'http://www.zlib.net/zlib_license.html',
+        "Zope"              : 'http://old.zope.org/Resources/License.1',
+        "Unlicense"         : 'https://unlicense.org/UNLICENSE',
+    }
+
+    EPOCH_VERSION_REGEXP = re.compile('^[0-9]+:')
+
+    @property
+    def can_mirror(self):
+        return (
+            self.kind == 'package'
+            and self.download_content_type in Ckan.MIME_TO_EXTENSION
+            and self.redistributable
+        )
+
+    def mirrored(self, iarchive):
+        results = iarchive.search_items(self.mirror_item)
+        return True if results else False
+
+    def license_urls(self):
+        return [self.LICENSE_URLS[lic]
+                for lic in self.licenses() if lic in self.LICENSE_URLS]
+
+    @property
+    def redistributable(self):
+        for lic in self.licenses():
+            if lic in self.REDISTRIBUTABLE_LICENSES:
+                return True
+        return False
+
+    @property
+    def mirror_item(self, with_epoch=False):
+        return '{}-{}'.format(
+            self.identifier,
+            self._format_version(with_epoch)
+        )
+
+    @property
+    def mirror_filename(self, with_epoch=False):
+        if not 'download_hash' in self._raw:
+            return None
+        return '{}-{}-{}.{}'.format(
+            self.download_hash['sha1'][0:8],
+            self.identifier,
+            self._format_version(with_epoch),
+            Ckan.MIME_TO_EXTENSION[self.download_content_type],
+        )
+
+    @property
+    def mirror_title(self, with_epoch=False):
+        return '{} - {}'.format(
+            self.name,
+            self._format_version(with_epoch),
+        )
+
+    def _format_version(self, with_epoch):
+        if with_epoch:
+            return self.version.string.replace(':', '-')
+        else:
+            return self.EPOCH_VERSION_REGEXP.sub('', self.version.string)
+
+    @property
+    def mirror_description(self):
+        descr = self.abstract + '<br>'
+        resources = self._raw.get('resources')
+        if resources:
+            homepage = resources.get('homepage')
+            if homepage:
+                descr += f'<br>Homepage: <a href="{homepage}">{homepage}</a>'
+            repository = resources.get('repository')
+            if repository:
+                descr += f'<br>Repository: <a href="{repository}">{repository}</a>'
+        lic = self.licenses()
+        if lic:
+            descr += '<br>License(s): {}'.format(' '.join(lic))
+        return descr

--- a/netkan/netkan/mirrorer.py
+++ b/netkan/netkan/mirrorer.py
@@ -13,7 +13,7 @@ from .metadata import Ckan
 
 class Mirrorer:
 
-    CACHE_PATH = Path('/home/netkan/ckan_cache/')
+    CACHE_PATH = Path.home().joinpath('ckan_cache')
     EPOCH_ID_REGEXP = re.compile('-[0-9]+-')
     EPOCH_TITLE_REGEXP = re.compile(' - [0-9]+:')
 

--- a/netkan/netkan/webhooks/__init__.py
+++ b/netkan/netkan/webhooks/__init__.py
@@ -11,6 +11,7 @@ from .inflate import inflate
 from .spacedock_inflate import spacedock_inflate
 from .spacedock_add import spacedock_add
 from .github_inflate import github_inflate
+from .github_mirror import github_mirror
 
 
 def create_app():
@@ -32,6 +33,7 @@ def create_app():
     app.config['inflation_queue'] = sqs.get_queue_by_name(
         QueueName=os.environ.get('INFLATION_SQS_QUEUE'))
     app.config['add_queue'] = sqs.get_queue_by_name(QueueName=os.environ.get('ADD_SQS_QUEUE'))
+    app.config['mirror_queue'] = sqs.get_queue_by_name(QueueName=os.environ.get('MIRROR_SQS_QUEUE'))
 
     # Add the hook handlers
     app.register_blueprint(errors)
@@ -39,5 +41,6 @@ def create_app():
     app.register_blueprint(spacedock_inflate, url_prefix='/sd')
     app.register_blueprint(spacedock_add, url_prefix='/sd')
     app.register_blueprint(github_inflate, url_prefix='/gh')
+    app.register_blueprint(github_mirror, url_prefix='/gh')
 
     return app

--- a/netkan/netkan/webhooks/github_mirror.py
+++ b/netkan/netkan/webhooks/github_mirror.py
@@ -1,0 +1,64 @@
+import re
+from pathlib import Path
+from hashlib import md5
+from flask import Blueprint, current_app, request, jsonify
+
+from .github_utils import signature_required
+from ..common import sqs_batch_entries
+
+
+github_mirror = Blueprint('github_mirror', __name__)  # pylint: disable=invalid-name
+
+
+# For after-commit hook in CKAN-meta repo
+# Handles: https://netkan.ksp-ckan.space/gh/mirror
+@github_mirror.route('/mirror', methods=['POST'])
+@signature_required
+def mirror_hook():
+    raw = request.get_json(silent=True)
+    commits = raw.get('commits')
+    if not commits:
+        current_app.logger.info('No commits received')
+        return jsonify({'message': 'No commits received'}), 200
+    # Make sure it's not from the crawler
+    sender = raw.get('sender')
+    if sender:
+        login = sender.get('login')
+        if login:
+            if login == 'kspckan-crawler':
+                current_app.logger.info('Commits sent by crawler, skipping on demand mirror')
+                return '', 204
+    # Submit mirroring requests to queue in batches of <=10
+    messages = (batch_message(p) for p in paths_from_commits(commits))
+    for batch in sqs_batch_entries(messages):
+        current_app.logger.info(f'Queueing mirroring request batch: {batch}')
+        current_app.config['client'].send_message_batch(
+            QueueUrl=current_app.config['mirror_queue'].url,
+            Entries=batch
+        )
+    return '', 204
+
+
+forbidden_id_chars = re.compile('[^-_A-Za-z0-9]')  # pylint: disable=invalid-name
+
+
+def batch_message(path):
+    body = path.as_posix()
+    return {
+        'Id':                     forbidden_id_chars.sub('_', body),
+        'MessageBody':            body,
+        'MessageGroupId':         '1',
+        'MessageDeduplicationId': md5(body.encode()).hexdigest()
+    }
+
+
+def ends_with_ckan(filename):
+    return filename.endswith('.ckan')
+
+
+def paths_from_commits(commits):
+    files = set()
+    for commit in commits:
+        files |= set(filter(ends_with_ckan,
+                            commit.get('added', []) + commit.get('modified', [])))
+    return (Path(f) for f in files)

--- a/netkan/tests/__init__.py
+++ b/netkan/tests/__init__.py
@@ -4,3 +4,4 @@ from .utils import *
 from .metadata import *
 from .download_counter import *
 from .cli import *
+from .mirrorer import *

--- a/netkan/tests/mirrorer.py
+++ b/netkan/tests/mirrorer.py
@@ -9,7 +9,7 @@ from netkan.mirrorer import Mirrorer, CkanMirror
 class TestCkanMirrorRedistributable(unittest.TestCase):
 
     def setUp(self):
-        self.ckan_mirror = CkanMirror(contents = """{
+        self.ckan_mirror = CkanMirror(contents="""{
             "spec_version": "v1.4",
             "identifier":   "AwesomeMod",
             "name":         "Awesome Mod",
@@ -36,16 +36,17 @@ class TestCkanMirrorRedistributable(unittest.TestCase):
         ])
 
     def test_strings(self):
-        self.assertEqual(self.ckan_mirror.mirror_item,        "AwesomeMod-1.0.0")
-        self.assertEqual(self.ckan_mirror.mirror_filename,    "DF564E21-AwesomeMod-1.0.0.zip")
-        self.assertEqual(self.ckan_mirror.mirror_title,       "Awesome Mod - 1.0.0")
-        self.assertEqual(self.ckan_mirror.mirror_description, "A great mod<br><br>License(s): CC-BY-NC-SA-4.0 GPL-3.0 MIT")
+        self.assertEqual(self.ckan_mirror.mirror_item(), "AwesomeMod-1.0.0")
+        self.assertEqual(self.ckan_mirror.mirror_filename(), "DF564E21-AwesomeMod-1.0.0.zip")
+        self.assertEqual(self.ckan_mirror.mirror_title(), "Awesome Mod - 1.0.0")
+        self.assertEqual(self.ckan_mirror.mirror_description,
+                         "A great mod<br><br>License(s): CC-BY-NC-SA-4.0 GPL-3.0 MIT")
 
 
 class TestCkanMirrorRestricted(unittest.TestCase):
 
     def setUp(self):
-        self.ckan_mirror = CkanMirror(contents = """{
+        self.ckan_mirror = CkanMirror(contents="""{
             "spec_version": "v1.4",
             "identifier":   "AwesomeMod",
             "version":      "1.0.0",

--- a/netkan/tests/mirrorer.py
+++ b/netkan/tests/mirrorer.py
@@ -1,0 +1,60 @@
+import unittest
+
+from netkan.mirrorer import Mirrorer, CkanMirror
+
+
+# I don't know how to test Mirrorer, it needs a queue and archive.org access
+
+
+class TestCkanMirrorRedistributable(unittest.TestCase):
+
+    def setUp(self):
+        self.ckan_mirror = CkanMirror(contents = """{
+            "spec_version": "v1.4",
+            "identifier":   "AwesomeMod",
+            "name":         "Awesome Mod",
+            "abstract":     "A great mod",
+            "version":      "1.0.0",
+            "ksp_version":  "1.7.3",
+            "author":       [ "techman83", "DasSkelett", "politas" ],
+            "license":      [ "CC-BY-NC-SA-4.0", "GPL-3.0", "MIT" ],
+            "download_content_type": "application/zip",
+            "download_hash": {
+                "sha1": "DF564E21929EA07C624F822E5C43B7D0A3B0DBDF"
+            }
+        }""")
+
+    def test_can_mirror(self):
+        self.assertTrue(self.ckan_mirror.redistributable)
+        self.assertTrue(self.ckan_mirror.can_mirror)
+
+    def test_license_urls(self):
+        self.assertEqual(self.ckan_mirror.license_urls(), [
+            'http://creativecommons.org/licenses/by-nc-sa/4.0',
+            'http://www.gnu.org/licenses/gpl-3.0.en.html',
+            'https://opensource.org/licenses/MIT',
+        ])
+
+    def test_strings(self):
+        self.assertEqual(self.ckan_mirror.mirror_item,        "AwesomeMod-1.0.0")
+        self.assertEqual(self.ckan_mirror.mirror_filename,    "DF564E21-AwesomeMod-1.0.0.zip")
+        self.assertEqual(self.ckan_mirror.mirror_title,       "Awesome Mod - 1.0.0")
+        self.assertEqual(self.ckan_mirror.mirror_description, "A great mod<br><br>License(s): CC-BY-NC-SA-4.0 GPL-3.0 MIT")
+
+
+class TestCkanMirrorRestricted(unittest.TestCase):
+
+    def setUp(self):
+        self.ckan_mirror = CkanMirror(contents = """{
+            "spec_version": "v1.4",
+            "identifier":   "AwesomeMod",
+            "version":      "1.0.0",
+            "ksp_version":  "1.7.3",
+            "author":       [ "techman83", "DasSkelett", "politas" ],
+            "license":      "restricted",
+            "download_content_type": "application/zip"
+        }""")
+
+    def test_can_mirror(self):
+        self.assertFalse(self.ckan_mirror.redistributable)
+        self.assertFalse(self.ckan_mirror.can_mirror)

--- a/prod-stack.py
+++ b/prod-stack.py
@@ -150,6 +150,7 @@ netkan_role = t.add_resource(Role(
                             GetAtt(inbound, "Arn"),
                             GetAtt(outbound, "Arn"),
                             GetAtt(addqueue, "Arn"),
+                            GetAtt(mirrorqueue, "Arn"),
                         ]
                     },
                     {
@@ -406,7 +407,7 @@ netkan_scheduler_role = t.add_resource(Role(
 # redeployment of services.
 ksp_builder_group = t.add_resource(Group("KspCkanBuilderGroup"))
 builder_services = []
-for service in ['Indexer', 'Inflator', 'Webhooks', 'Adder']:
+for service in ['Indexer', 'Inflator', 'Webhooks', 'Adder', 'Mirrorer']:
     builder_services.append(
         Sub(
             'arn:aws:ecs:${AWS::Region}:${AWS::AccountId}:service/NetKANCluster/${service}',


### PR DESCRIPTION
## Motivation

See #48; we need to recreate the old webhooks in Python. The part that mirrors mods to archive.org is particularly complicated and so we're splitting it out into its own pull request.

## Changes

A new webhook is added to handle mirroring requests.
New environment variable parameters:
- Name of SQS queue to which to send mirroring requests; note that the AWS environment variables must also be set to access this queue

Routes handled:
- `/gh/mirror` - Send a mirroring request to the mirroring queue in response to a commit in the CKAN-meta repo

Code files:
- `github_mirror.py` - Defines a blueprint to handle the GitHub webhook that interacts with archive.org

A new `mirrorer` command is added to `cli.py` that listens to a queue of requests for mirroring and uploads the relevant files to archive.org. Params:

- Name of SQS queue to monitor for mirroring requests
- Visibility timeout for queue messages
- URL for CKAN-meta repo
- Access, secret, and collection strings for archive.org mirroring

This was split out from #48 and builds upon it. We will need to rebase this PR as that one changes.