### PR TITLE
Webhooks Deployment Tweaks

### DIFF
--- a/prod-stack.py
+++ b/prod-stack.py
@@ -694,7 +694,7 @@ services = [
                 'entrypoint': '.local/bin/gunicorn',
                 'command': [
                     '-b', '0.0.0.0:5000', '--access-logfile', '-',
-                    '"netkan.webhooks:create_app()"'
+                    'netkan.webhooks:create_app()'
                 ],
                 'secrets': [
                     'XKAN_GHSECRET',
@@ -712,7 +712,7 @@ services = [
                 'volumes': [
                     ('letsencrypt', '/etc/letsencrypt')
                 ],
-                'depends': 'webhooks',
+                'depends': ['webhooks', 'legacyhooks']
             },
         ]
     },
@@ -738,7 +738,7 @@ for service in services:
         command = container.get('command')
         volumes = container.get('volumes', [])
         ports = container.get('ports', [])
-        depends = container.get('depends')
+        depends = container.get('depends', [])
         definition = ContainerDefinition(
             Image=container.get('image', 'kspckan/netkan'),
             Memory=container.get('memory', '96'),
@@ -794,14 +794,14 @@ for service in services:
                     Protocol='tcp',
                 )
             )
-        if depends:
+        for depend in depends:
             definition.DependsOn.append(
                 ContainerDependency(
                     Condition='START',
-                    ContainerName=depends,
+                    ContainerName=depend,
                 )
             )
-            definition.Links.append(depends)
+            definition.Links.append(depend)
         task.ContainerDefinitions.append(definition)
     t.add_resource(task)
 


### PR DESCRIPTION
These were the tweaks required to get the containers running and talking in production.

* Proxy
```
192.30.252.98 "POST /gh/inflate HTTP/1.1" 204 0 "GitHub-Hookshot/6760791"
192.30.252.98 "POST /gh/inflate HTTP/1.1" 204 0 "GitHub-Hookshot/6760791"
192.30.252.99 "POST /gh/mirror HTTP/1.1" 204 0 "GitHub-Hookshot/6760791"
```
* Legacy
```
[xKanHooks:11] info @2019-10-23 11:19:39> Mirroring: AllTweak/AllTweak-0.7.ckan in /usr/local/lib/perl5/site_perl/5.30.0/App/KSP_CKAN/WebHooks.pm l. 141
```
* New
```
[2019-10-23 11:15:21 +0000] [1] [INFO] Starting gunicorn 19.9.0
[2019-10-23 11:15:21 +0000] [1] [INFO] Listening at: http://0.0.0.0:5000 (1)
[2019-10-23 11:15:21 +0000] [1] [INFO] Using worker: sync
[2019-10-23 11:15:21 +0000] [9] [INFO] Booting worker with pid: 9
[23/Oct/2019:11:17:17 +0000] "POST /gh/inflate HTTP/1.0" 204 0 "-" "GitHub-Hookshot/6760791"
[23/Oct/2019:11:18:13 +0000] "POST /gh/inflate HTTP/1.0" 204 0 "-" "GitHub-Hookshot/6760791"
```