### PR TITLE
Force JSON parse of SD request

### DIFF
--- a/netkan/netkan/webhooks/inflate.py
+++ b/netkan/netkan/webhooks/inflate.py
@@ -11,7 +11,8 @@ inflate = Blueprint('inflate', __name__)
 # Payload: { "identifiers": [ "Id1", "Id2", ... ] }
 @inflate.route('/inflate', methods=['POST'])
 def inflate_hook():
-    ids = request.json.get('identifiers')
+    # SpaceDock doesn't set the `Content-Type: application/json` header
+    ids = request.get_json(force=True).get('identifiers')
     if not ids:
         current_app.logger.info('No identifiers received')
         return 'An array of identifiers is required', 400


### PR DESCRIPTION
## Problem

Exception on SpaceDock webhook trigger:

```
ERROR:netkan.webhooks:Exception on /inflate [POST]
Traceback (most recent call last):
  File "/home/netkan/.local/lib/python3.7/site-packages/flask/app.py", line 2446, in wsgi_app
    response = self.full_dispatch_request()
  File "/home/netkan/.local/lib/python3.7/site-packages/flask/app.py", line 1951, in full_dispatch_request
    rv = self.handle_user_exception(e)
  File "/home/netkan/.local/lib/python3.7/site-packages/flask/app.py", line 1820, in handle_user_exception
    reraise(exc_type, exc_value, tb)
  File "/home/netkan/.local/lib/python3.7/site-packages/flask/_compat.py", line 39, in reraise
    raise value
  File "/home/netkan/.local/lib/python3.7/site-packages/flask/app.py", line 1949, in full_dispatch_request
    rv = self.dispatch_request()
  File "/home/netkan/.local/lib/python3.7/site-packages/flask/app.py", line 1935, in dispatch_request
    return self.view_functions[rule.endpoint](**req.view_args)
  File "/home/netkan/.local/lib/python3.7/site-packages/netkan/webhooks/inflate.py", line 14, in inflate_hook
    ids = request.json.get('identifiers')
AttributeError: 'NoneType' object has no attribute 'get'
172.17.0.6 - - [23/Oct/2019:11:21:44 +0000] "POST /inflate HTTP/1.0" 500 290 "-" "python-requests/2.22.0"
ERROR:netkan.webhooks:Exception on /inflate [POST]
Traceback (most recent call last):
  File "/home/netkan/.local/lib/python3.7/site-packages/flask/app.py", line 2446, in wsgi_app
    response = self.full_dispatch_request()
  File "/home/netkan/.local/lib/python3.7/site-packages/flask/app.py", line 1951, in full_dispatch_request
    rv = self.handle_user_exception(e)
  File "/home/netkan/.local/lib/python3.7/site-packages/flask/app.py", line 1820, in handle_user_exception
    reraise(exc_type, exc_value, tb)
  File "/home/netkan/.local/lib/python3.7/site-packages/flask/_compat.py", line 39, in reraise
    raise value
  File "/home/netkan/.local/lib/python3.7/site-packages/flask/app.py", line 1949, in full_dispatch_request
    rv = self.dispatch_request()
  File "/home/netkan/.local/lib/python3.7/site-packages/flask/app.py", line 1935, in dispatch_request
    return self.view_functions[rule.endpoint](**req.view_args)
  File "/home/netkan/.local/lib/python3.7/site-packages/netkan/webhooks/inflate.py", line 14, in inflate_hook
    ids = request.json.get('identifiers')
AttributeError: 'NoneType' object has no attribute 'get'
```

## Cause

https://flask.palletsprojects.com/en/1.1.x/api/#flask.Request.json

> property json
> The parsed JSON data if mimetype indicates JSON (application/json, see is_json()).
> 
> Calls get_json() with default arguments.

> get_json(force=False, silent=False, cache=True)
> Parse data as JSON.
> 
> If the mimetype does not indicate JSON (application/json, see is_json()), this returns None.
> 
> If parsing fails, on_json_loading_failed() is called and its return value is used as the return value.
> 
> Parameters
> force – Ignore the mimetype and always try to parse JSON.
> 
> silent – Silence parsing errors and return None instead.
> 
> cache – Store the parsed JSON to return for subsequent calls.

I noticed that this would be `None` unless I passed the `Content-Type: application/json` header during dev, but I did not suspect that SpaceDock wouldn't pass it.

## Changes

Now we use `get_json(force=True)`, which will do the parse with or without the header.

Fixes #63.