### PR TITLE
Pull NetKAN before use in webhooks

### DIFF
--- a/netkan/netkan/webhooks/github_inflate.py
+++ b/netkan/netkan/webhooks/github_inflate.py
@@ -5,7 +5,7 @@ from .common import netkans, sqs_batch_entries
 from .github_utils import signature_required
 
 
-github_inflate = Blueprint('github_inflate', __name__)
+github_inflate = Blueprint('github_inflate', __name__) # pylint: disable=invalid-name
 
 
 # For after-commit hook in NetKAN repo
@@ -49,6 +49,8 @@ def ids_from_commits(commits):
 
 
 def inflate(ids):
+    # Make sure our NetKAN repo is up to date
+    current_app.config['netkan_repo'].remotes.origin.pull('master', strategy_option='ours')
     messages = (nk.sqs_message()
                 for nk in netkans(current_app.config['netkan_repo'].working_dir, ids))
     for batch in sqs_batch_entries(messages):

--- a/netkan/netkan/webhooks/github_inflate.py
+++ b/netkan/netkan/webhooks/github_inflate.py
@@ -5,7 +5,7 @@ from .common import netkans, sqs_batch_entries
 from .github_utils import signature_required
 
 
-github_inflate = Blueprint('github_inflate', __name__) # pylint: disable=invalid-name
+github_inflate = Blueprint('github_inflate', __name__)  # pylint: disable=invalid-name
 
 
 # For after-commit hook in NetKAN repo
@@ -50,7 +50,7 @@ def ids_from_commits(commits):
 
 def inflate(ids):
     # Make sure our NetKAN repo is up to date
-    current_app.config['netkan_repo'].remotes.origin.pull('master', strategy_option='ours')
+    current_app.config['netkan_repo'].remotes.origin.pull('master', strategy_option='theirs')
     messages = (nk.sqs_message()
                 for nk in netkans(current_app.config['netkan_repo'].working_dir, ids))
     for batch in sqs_batch_entries(messages):

--- a/netkan/netkan/webhooks/inflate.py
+++ b/netkan/netkan/webhooks/inflate.py
@@ -3,7 +3,7 @@ from flask import Blueprint, current_app, request
 from .common import netkans, sqs_batch_entries
 
 
-inflate = Blueprint('inflate', __name__) # pylint: disable=invalid-name
+inflate = Blueprint('inflate', __name__)  # pylint: disable=invalid-name
 
 
 # For SpaceDock's trigger when new versions are uploaded
@@ -17,7 +17,7 @@ def inflate_hook():
         current_app.logger.info('No identifiers received')
         return 'An array of identifiers is required', 400
     # Make sure our NetKAN repo is up to date
-    current_app.config['netkan_repo'].remotes.origin.pull('master', strategy_option='ours')
+    current_app.config['netkan_repo'].remotes.origin.pull('master', strategy_option='theirs')
     messages = (nk.sqs_message()
                 for nk in netkans(current_app.config['netkan_repo'].working_dir, ids))
     for batch in sqs_batch_entries(messages):

--- a/netkan/netkan/webhooks/inflate.py
+++ b/netkan/netkan/webhooks/inflate.py
@@ -3,7 +3,7 @@ from flask import Blueprint, current_app, request
 from .common import netkans, sqs_batch_entries
 
 
-inflate = Blueprint('inflate', __name__)
+inflate = Blueprint('inflate', __name__) # pylint: disable=invalid-name
 
 
 # For SpaceDock's trigger when new versions are uploaded
@@ -16,6 +16,8 @@ def inflate_hook():
     if not ids:
         current_app.logger.info('No identifiers received')
         return 'An array of identifiers is required', 400
+    # Make sure our NetKAN repo is up to date
+    current_app.config['netkan_repo'].remotes.origin.pull('master', strategy_option='ours')
     messages = (nk.sqs_message()
                 for nk in netkans(current_app.config['netkan_repo'].working_dir, ids))
     for batch in sqs_batch_entries(messages):

--- a/netkan/netkan/webhooks/spacedock_inflate.py
+++ b/netkan/netkan/webhooks/spacedock_inflate.py
@@ -5,7 +5,7 @@ from ..metadata import Netkan
 from .common import sqs_batch_entries
 
 
-spacedock_inflate = Blueprint('spacedock_inflate', __name__)
+spacedock_inflate = Blueprint('spacedock_inflate', __name__)  # pylint: disable=invalid-name
 
 
 # For after-upload hook on SpaceDock
@@ -14,7 +14,7 @@ spacedock_inflate = Blueprint('spacedock_inflate', __name__)
 @spacedock_inflate.route('/inflate', methods=['POST'])
 def inflate_hook():
     # Make sure our NetKAN repo is up to date
-    current_app.config['netkan_repo'].remotes.origin.pull('master', strategy_option='ours')
+    current_app.config['netkan_repo'].remotes.origin.pull('master', strategy_option='theirs')
     # Get the relevant netkans
     nks = find_netkans(request.form.get('mod_id'))
     if nks:


### PR DESCRIPTION
## Problem

I think the current webhooks can pass outdated metadata to the Inflator. If we change a file in NetKAN, the webhooks don't update their local repo before reading the files, so the version of the file from the last container refresh would be used.

(The exception is the new (and so far unused) `/sd/inflate` hook, which pulls the master branch before using it. I must have been thinking more carefully about new code as compared to the other hooks which were ports of the legacy Perl code.)

## Changes

Now we pull the master branch before we use files from the NetKAN repo.

The `pylint` comments are to inform pylint that it is OK that the blueprint variables are in lowercase.
