### PR TITLE
Don't try to extract kref pieces if there's no kref

### DIFF
--- a/netkan/netkan/metadata.py
+++ b/netkan/netkan/metadata.py
@@ -16,8 +16,11 @@ class Netkan:
             self.contents = contents
         self._raw = json.loads(self.contents)
         # Extract kref_src + kref_id from the kref
-        self.kref_src, self.kref_id = self.KREF_PATTERN.match(
-            self.kref).groups()
+        if self.has_kref:
+            self.kref_src, self.kref_id = self.KREF_PATTERN.match(self.kref).groups()
+        else:
+            self.kref_src = None
+            self.kref_id = None
 
     def __getattr__(self, name):
         # Return kref host, ie `self.on_spacedock`. Current krefs include

--- a/netkan/netkan/scheduler.py
+++ b/netkan/netkan/scheduler.py
@@ -22,7 +22,7 @@ class NetkanScheduler:
 
     def netkans(self):
         # This can easily be recursive with '**/*.netkan', however
-        # implemeneting like for like initially.
+        # implementing like for like initially.
         return (Netkan(f) for f in self.path.glob('*.netkan'))
 
     def sqs_batch_entries(self, batch_size=10):

--- a/netkan/tests/metadata.py
+++ b/netkan/tests/metadata.py
@@ -86,6 +86,27 @@ class TestNetKANNetkan(TestNetKAN):
         self.assertFalse(self.netkan.hook_only())
 
 
+class TestNetKANNoKref(TestNetKAN):
+
+    def setUp(self):
+        self.netkan = Netkan(contents="""{
+            "spec_version": "v1.4",
+            "identifier":   "LightsOut-Fwiffo",
+            "license":      "MIT",
+            "version":      "v0.1.5.1",
+            "download":     "https://cdn.rawgit.com/rkagerer/KSP-Fwiffo-Repository/master/Mods/LightsOut-Fwiffo-v0.1.5.1.zip"
+        }""")
+
+    def test_kref(self):
+        self.assertFalse(self.netkan.has_kref)
+
+    def test_kref_src(self):
+        self.assertEqual(self.netkan.kref_src, None)
+
+    def test_kref_id(self):
+        self.assertEqual(self.netkan.kref_id, None)
+
+
 class TestNetKANVref(TestNetKAN):
 
     def setUp(self):
@@ -101,7 +122,7 @@ class TestNetKANVref(TestNetKAN):
 class TestCkanSimple(unittest.TestCase):
 
     def setUp(self):
-        self.ckan = Ckan(contents = """{
+        self.ckan = Ckan(contents="""{
             "spec_version": "v1.4",
             "identifier":   "AwesomeMod",
             "version":      "1.0.0",
@@ -135,7 +156,7 @@ class TestCkanSimple(unittest.TestCase):
 class TestCkanComplex(unittest.TestCase):
 
     def setUp(self):
-        self.ckan = Ckan(contents = """{
+        self.ckan = Ckan(contents="""{
             "spec_version": "v1.4",
             "identifier":   "AwesomeMod",
             "version":      "1.0.0",


### PR DESCRIPTION
## Problem

See #66; the bot is doing incomplete passes at the moment.

## Cause

This line from #48 throws when loading a netkan without a `$kref`:

https://github.com/KSP-CKAN/NetKAN-Infra/blob/7b72e54ee985b7cc3dead5b2381b1a6eada021f5/netkan/netkan/metadata.py#L18-L20

Once the Scheduler encounters such a netkan (after about 30 mods), it throws this exception and stops:

```
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "NetKAN-Infra/netkan/netkan/scheduler.py", line 26, in <genexpr>
    return (Netkan(f) for f in self.path.glob('*.netkan'))
  File "NetKAN-Infra/netkan/netkan/metadata.py", line 20, in __init__
    self.kref).groups()
  File "NetKAN-Infra/netkan/netkan/metadata.py", line 37, in __getattr__
    raise AttributeError
```

## Changes

Now we check `self.has_kref` first. If it's false, we set `kref_src` and `kref_id` to `None`.

Tests are added to cover the missing-`$kref` case.

Fixes #66.