### PR TITLE
Discord notifications

### DIFF
--- a/docker-compose.vscode.yml
+++ b/docker-compose.vscode.yml
@@ -23,6 +23,8 @@ services:
       MIRROR_SQS_QUEUE: MirroringDev.fifo
       STATUS_BUCKET: ckan-test-status
       STATUS_INTERVAL: 0
+      DISCORD_WEBHOOK_ID: ${DISCORD_WEBHOOK_ID}
+      DISCORD_WEBHOOK_TOKEN: ${DISCORD_WEBHOOK_TOKEN}
     volumes:
       - .:/home/netkan/workspace
     entrypoint: sleep infinity

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -20,6 +20,8 @@ services:
       SQS_QUEUE: OutboundDev.fifo
       SQS_TIMEOUT: 30
       STATUS_DB: DevNetKANStatus
+      DISCORD_WEBHOOK_ID: ${DISCORD_WEBHOOK_ID}
+      DISCORD_WEBHOOK_TOKEN: ${DISCORD_WEBHOOK_TOKEN}
     volumes:
       - ./netkan:/home/netkan/netkan
     command: indexer
@@ -34,6 +36,8 @@ services:
       AWS_ACCESS_KEY_ID: ${CKAN_AWS_ACCESS_KEY_ID}
       SQS_QUEUE: InboundDev.fifo
       MAX_QUEUED: 1
+      DISCORD_WEBHOOK_ID: ${DISCORD_WEBHOOK_ID}
+      DISCORD_WEBHOOK_TOKEN: ${DISCORD_WEBHOOK_TOKEN}
     volumes:
       - ./netkan:/home/netkan/netkan
     command: scheduler --dev
@@ -75,6 +79,8 @@ services:
       AWS_DEFAULT_REGION: ${CKAN_AWS_DEFAULT_REGION}
       AWS_SECRET_ACCESS_KEY: ${CKAN_AWS_SECRET_ACCESS_KEY}
       AWS_ACCESS_KEY_ID: ${CKAN_AWS_ACCESS_KEY_ID}
+      DISCORD_WEBHOOK_ID: ${DISCORD_WEBHOOK_ID}
+      DISCORD_WEBHOOK_TOKEN: ${DISCORD_WEBHOOK_TOKEN}
     entrypoint: .local/bin/gunicorn
     command: -b 0.0.0.0:5000 --access-logfile - "netkan.webhooks:create_app()"
   status:
@@ -88,6 +94,8 @@ services:
       AWS_SECRET_ACCESS_KEY: ${CKAN_AWS_SECRET_ACCESS_KEY}
       AWS_ACCESS_KEY_ID: ${CKAN_AWS_ACCESS_KEY_ID}
       STATUS_INTERVAL: 0
+      DISCORD_WEBHOOK_ID: ${DISCORD_WEBHOOK_ID}
+      DISCORD_WEBHOOK_TOKEN: ${DISCORD_WEBHOOK_TOKEN}
     volumes:
       - ./netkan:/home/netkan/netkan
     command: export-status-s3
@@ -126,6 +134,8 @@ services:
       NETKAN_REMOTE: ${NETKAN_METADATA_PATH}
       CKANMETA_REMOTE: ${CKAN_METADATA_PATH}
       GH_Token: ${CKAN_GH_Token}
+      DISCORD_WEBHOOK_ID: ${DISCORD_WEBHOOK_ID}
+      DISCORD_WEBHOOK_TOKEN: ${DISCORD_WEBHOOK_TOKEN}
     volumes:
       - ./netkan:/home/netkan/netkan
     command: download-counter
@@ -138,6 +148,8 @@ services:
       NETKAN_REMOTE: ${NETKAN_METADATA_PATH}
       CKANMETA_REMOTE: ${CKAN_METADATA_PATH}
       GH_Token: ${CKAN_GH_Token}
+      DISCORD_WEBHOOK_ID: ${DISCORD_WEBHOOK_ID}
+      DISCORD_WEBHOOK_TOKEN: ${DISCORD_WEBHOOK_TOKEN}
     volumes:
       - ./netkan:/home/netkan/netkan
     entrypoint: sleep infinity

--- a/netkan/netkan/cli.py
+++ b/netkan/netkan/cli.py
@@ -6,6 +6,7 @@ from pathlib import Path
 import boto3
 import click
 from .utils import init_repo, init_ssh
+from .notifications import setup_log_handler
 from .github import GitHubPR
 from .indexer import MessageHandler
 from .scheduler import NetkanScheduler
@@ -15,7 +16,8 @@ from .download_counter import DownloadCounter
 
 @click.group()
 def netkan():
-    pass
+    # Set up Discord logger so we can see errors
+    setup_log_handler()
 
 
 @click.command()

--- a/netkan/netkan/notifications.py
+++ b/netkan/netkan/notifications.py
@@ -1,0 +1,24 @@
+import os
+import logging
+import discord
+
+
+class DiscordLogHandler(logging.Handler):
+
+    def __init__(self, webhook_id, webhook_token):
+        super().__init__()
+        self.webhook = discord.Webhook.partial(webhook_id, webhook_token,
+                                               adapter=discord.RequestsWebhookAdapter())
+
+    def emit(self, record):
+        self.webhook.send(self.format(record))
+
+
+def setup_log_handler():
+    # Set up Discord logger so we can see errors
+    discord_webhook_id = os.environ.get('DISCORD_WEBHOOK_ID')
+    discord_webhook_token = os.environ.get('DISCORD_WEBHOOK_TOKEN')
+    if discord_webhook_id and discord_webhook_token:
+        handler = DiscordLogHandler(discord_webhook_id, discord_webhook_token)
+        handler.setLevel(logging.ERROR)
+        logging.getLogger('').addHandler(handler)

--- a/netkan/netkan/webhooks/__init__.py
+++ b/netkan/netkan/webhooks/__init__.py
@@ -1,8 +1,10 @@
 import os
+import logging
 import boto3
 from flask import Flask
 
 from ..utils import init_repo
+from ..notifications import setup_log_handler
 from .inflate import inflate
 from .spacedock_inflate import spacedock_inflate
 from .github_inflate import github_inflate
@@ -23,5 +25,8 @@ def create_app():
     app.register_blueprint(inflate)
     app.register_blueprint(spacedock_inflate, url_prefix='/sd')
     app.register_blueprint(github_inflate, url_prefix='/gh')
+
+    # Set up Discord logger so we can see errors
+    setup_log_handler()
 
     return app

--- a/netkan/setup.py
+++ b/netkan/setup.py
@@ -20,6 +20,7 @@ setup(
         'flask',
         'internetarchive',
         'gunicorn',
+        'discord',
     ],
     entry_points={
         'console_scripts': [

--- a/prod-stack.py
+++ b/prod-stack.py
@@ -568,7 +568,6 @@ services = [
         'memory': '156',
         'secrets': [
             'SSH_KEY', 'GH_Token',
-            'DISCORD_WEBHOOK_ID', 'DISCORD_WEBHOOK_TOKEN',
         ],
         'env': [
             ('CKANMETA_REMOTE', CKANMETA_REMOTE),
@@ -585,7 +584,6 @@ services = [
         'name': 'Scheduler',
         'command': 'scheduler',
         'memory': '156',
-        'secrets': ['DISCORD_WEBHOOK_ID', 'DISCORD_WEBHOOK_TOKEN'],
         'env': [
             ('SQS_QUEUE', GetAtt(inbound, 'QueueName')),
             ('NETKAN_REMOTE', NETKAN_REMOTE),
@@ -599,7 +597,6 @@ services = [
             'clean-cache',
             '--days', '30',
         ],
-        'secrets': ['DISCORD_WEBHOOK_ID', 'DISCORD_WEBHOOK_TOKEN'],
         'env': [],
         'volumes': [
             ('ckan_cache', '/home/netkan/ckan_cache')
@@ -628,7 +625,6 @@ services = [
     {
         'name': 'StatusDumper',
         'command': 'export-status-s3',
-        'secrets': ['DISCORD_WEBHOOK_ID', 'DISCORD_WEBHOOK_TOKEN'],
         'env': [
             ('STATUS_BUCKET', STATUS_BUCKET),
             ('STATUS_KEY', status_key),
@@ -642,7 +638,6 @@ services = [
         'memory': '156',
         'secrets': [
             'SSH_KEY', 'GH_Token',
-            'DISCORD_WEBHOOK_ID', 'DISCORD_WEBHOOK_TOKEN',
         ],
         'env': [
             ('NETKAN_REMOTE', NETKAN_REMOTE),
@@ -670,7 +665,6 @@ services = [
             '--cluster', 'NetKANCluster',
             '--service-name', 'WebhooksService',
         ],
-        'secrets': ['DISCORD_WEBHOOK_ID', 'DISCORD_WEBHOOK_TOKEN'],
         'env': [
             ('AWS_DEFAULT_REGION', Sub('${AWS::Region}')),
         ],
@@ -703,10 +697,7 @@ services = [
                     '-b', '0.0.0.0:5000', '--access-logfile', '-',
                     'netkan.webhooks:create_app()'
                 ],
-                'secrets': [
-                    'XKAN_GHSECRET',
-                    'DISCORD_WEBHOOK_ID', 'DISCORD_WEBHOOK_TOKEN',
-                ],
+                'secrets': ['XKAN_GHSECRET'],
                 'env': [
                     ('NETKAN_REMOTE', NETKAN_REMOTE),
                     ('AWS_DEFAULT_REGION', Sub('${AWS::Region}')),
@@ -740,7 +731,10 @@ for service in services:
     )
 
     for container in containers:
-        secrets = container.get('secrets', [])
+        secrets = [
+            'DISCORD_WEBHOOK_ID', 'DISCORD_WEBHOOK_TOKEN',
+            *container.get('secrets', [])
+        ]
         envs = container.get('env', [])
         entrypoint = container.get('entrypoint')
         command = container.get('command')

--- a/prod-stack.py
+++ b/prod-stack.py
@@ -566,7 +566,10 @@ services = [
         'name': 'Indexer',
         'command': 'indexer',
         'memory': '156',
-        'secrets': ['SSH_KEY', 'GH_Token'],
+        'secrets': [
+            'SSH_KEY', 'GH_Token',
+            'DISCORD_WEBHOOK_ID', 'DISCORD_WEBHOOK_TOKEN',
+        ],
         'env': [
             ('CKANMETA_REMOTE', CKANMETA_REMOTE),
             ('CKANMETA_USER', CKANMETA_USER),
@@ -582,7 +585,7 @@ services = [
         'name': 'Scheduler',
         'command': 'scheduler',
         'memory': '156',
-        'secrets': [],
+        'secrets': ['DISCORD_WEBHOOK_ID', 'DISCORD_WEBHOOK_TOKEN'],
         'env': [
             ('SQS_QUEUE', GetAtt(inbound, 'QueueName')),
             ('NETKAN_REMOTE', NETKAN_REMOTE),
@@ -596,7 +599,7 @@ services = [
             'clean-cache',
             '--days', '30',
         ],
-        'secrets': [],
+        'secrets': ['DISCORD_WEBHOOK_ID', 'DISCORD_WEBHOOK_TOKEN'],
         'env': [],
         'volumes': [
             ('ckan_cache', '/home/netkan/ckan_cache')
@@ -625,6 +628,7 @@ services = [
     {
         'name': 'StatusDumper',
         'command': 'export-status-s3',
+        'secrets': ['DISCORD_WEBHOOK_ID', 'DISCORD_WEBHOOK_TOKEN'],
         'env': [
             ('STATUS_BUCKET', STATUS_BUCKET),
             ('STATUS_KEY', status_key),
@@ -636,7 +640,10 @@ services = [
         'name': 'DownloadCounter',
         'command': 'download-counter',
         'memory': '156',
-        'secrets': ['SSH_KEY', 'GH_Token'],
+        'secrets': [
+            'SSH_KEY', 'GH_Token',
+            'DISCORD_WEBHOOK_ID', 'DISCORD_WEBHOOK_TOKEN',
+        ],
         'env': [
             ('NETKAN_REMOTE', NETKAN_REMOTE),
             ('CKANMETA_REMOTE', CKANMETA_REMOTE),
@@ -663,7 +670,7 @@ services = [
             '--cluster', 'NetKANCluster',
             '--service-name', 'WebhooksService',
         ],
-        'secrets': [],
+        'secrets': ['DISCORD_WEBHOOK_ID', 'DISCORD_WEBHOOK_TOKEN'],
         'env': [
             ('AWS_DEFAULT_REGION', Sub('${AWS::Region}')),
         ],
@@ -698,6 +705,7 @@ services = [
                 ],
                 'secrets': [
                     'XKAN_GHSECRET',
+                    'DISCORD_WEBHOOK_ID', 'DISCORD_WEBHOOK_TOKEN',
                 ],
                 'env': [
                     ('NETKAN_REMOTE', NETKAN_REMOTE),


### PR DESCRIPTION
## Motivation

See #52, we'd like to see error messages in Discord. It provides several advantages:

- Ease of listing and reviewing recent errors
- Instant notifications
- Convenient discussion of how to address them

## Background

Discord supports two methods of programmatic interaction:

- "Bots" (?) that can receive messages and react to them
- "Webhooks" that can send messages to a given channel on demand
  **NOTE**: Not to be confused with GitHub webhooks, which are not related in any way!

Both methods are provided by the `discord.py` module, but "Webhooks" are much less prominent in the documentation. They're also much easier to use (no `async`/`await`) and are a much closer fit for our requirements.

- https://discordpy.readthedocs.io/en/async/api.html
- https://techwithtim.net/tutorials/discord-py/setup/
- https://hackaday.com/2018/02/15/creating-a-discord-webhook-in-python/

## Changes

Now `notifications.py` contains:

- A `DiscordLogHandler` class that can be used to listen to `logging` calls and send them to Discord
- A `setup_log_handler` function that installs the above class for `error` level and higher messages if environment variables `DISCORD_WEBHOOK_ID` and `DISCORD_WEBHOOK_TOKEN` are defined

Now `cli.py` and `webhooks.create_app` call `setup_log_handler` to enable Discord logging for the existing toolkit.

Now the Indexer calls `logging.error` when inflation fails for a module with a new error message. This would allow it to appear on Discord, notifying developers immediately when there's a new problem. Note that some inflation errors include text that changes every time (temp file paths), so we may want to clean those up.

`setup.py` is updated to install the `discord` module.

Fixes #52.

## Setup

I did these parts already:

- [X] Create a `#netkan-bot` channel in the CKAN Discord
- [X] Add a Discord webhook in the channel

To be done at or after merge:

- [x] Move the `#netkan-bot` channel into the `NOTIFICATIONS` category (I don't have privileges to do this)
- [ ] Provide the `DISCORD_WEBHOOK_ID` and `DISCORD_WEBHOOK_TOKEN` environment variables to the containers

I have the ID and token for the Discord webhook I created and will share them privately as needed.