### PR TITLE
More descriptive log entries for JSONDecodeErrors

### DIFF
--- a/netkan/netkan/download_counter.py
+++ b/netkan/netkan/download_counter.py
@@ -74,8 +74,8 @@ class NetkanDownloads(Netkan):
         if self.has_kref:
             try:
                 count = getattr(self, f'count_from_{self.kref_src}')()
-            except JSONDecodeError:
-                logging.error(f'Failed decoding count for {self.identifier}')
+            except JSONDecodeError as e:
+                logging.error(f'Failed decoding count for {self.identifier}: {e}')
             except KeyError as e:
                 logging.error(f'Download count key \'{e}\' missing from api for {self.identifier}')
             except AttributeError:


### PR DESCRIPTION
## Motivation
The Discord notification feature from #68 works really great so far (we didn't have new inflation errors, so that part is still TBD, but download count errors do work!).
If there are netkan files with invalid JSON syntax, the message is the following:
```
Failed decoding count for ProtonMBreezeM
Failed decoding count for KerbalSports
Failed decoding count for OuterPlanetsMod
Failed decoding count for Strategia
```
A more descriptive error message would be helpful to be able to quickly investigate the problem.

## Changes
Append the message of the `JSONDecodeError` to the log entry.
It'll look like this:
```
Failed decoding count for Strategia: Expecting property name enclosed in double quotes: line 26 column 5 (char 876)
Failed decoding count for KerbalSports: Expecting property name enclosed in double quotes: line 21 column 5 (char 755)
Failed decoding count for OuterPlanetsMod: Expecting value: line 20 column 5 (char 734)
Failed decoding count for ProtonMBreezeM: Expecting property name enclosed in double quotes: line 13 column 2 (char 452)
```

The line numbers are really helpful to find missing/superfluous commas ;)