### PR TITLE
Copy resources to status objects

### DIFF
--- a/netkan/netkan/indexer.py
+++ b/netkan/netkan/indexer.py
@@ -1,3 +1,4 @@
+import json
 import hashlib
 import logging
 from pathlib import Path, PurePath
@@ -29,6 +30,7 @@ class CkanMessage:
         self.receipt_handle = msg.receipt_handle
         self.ckan_meta = ckan_meta
         self.github_pr = github_pr
+        self._raw = json.loads(self.body)
 
     def __str__(self):
         return '{}: {}'.format(self.ModIdentifier, self.CheckTime)
@@ -123,6 +125,8 @@ class CkanMessage:
             # If we have perfomed an inflation, we certainly
             # have checked the mod!
             'last_checked': inflation_time,
+            # Copy the links to the status page
+            **(self._raw.get('resources', {})),
         }
         if new:
             attrs['ModIdentifier'] = self.ModIdentifier

--- a/netkan/netkan/indexer.py
+++ b/netkan/netkan/indexer.py
@@ -126,9 +126,10 @@ class CkanMessage:
             # If we have perfomed an inflation, we certainly
             # have checked the mod!
             'last_checked': inflation_time,
-            # Copy the links to the status page
-            **(getattr(self.ckan, 'resources', {})),
         }
+        resources = getattr(self.ckan, 'resources', None)
+        if resources:
+            attrs.resources = resources
         if new:
             attrs['ModIdentifier'] = self.ModIdentifier
         if self.indexed:

--- a/netkan/netkan/indexer.py
+++ b/netkan/netkan/indexer.py
@@ -129,7 +129,7 @@ class CkanMessage:
         }
         resources = getattr(self.ckan, 'resources', None)
         if resources:
-            attrs.resources = resources
+            attrs['resources'] = resources
         if new:
             attrs['ModIdentifier'] = self.ModIdentifier
         if self.indexed:

--- a/netkan/netkan/indexer.py
+++ b/netkan/netkan/indexer.py
@@ -8,6 +8,7 @@ from contextlib import contextmanager
 from dateutil.parser import parse
 from git import GitCommandError
 
+from .metadata import Ckan
 from .status import ModStatus
 
 
@@ -15,6 +16,7 @@ class CkanMessage:
 
     def __init__(self, msg, ckan_meta, github_pr=None):
         self.body = msg.body
+        self.ckan = Ckan(contents=self.body)
         self.ErrorMessage = None
         self.indexed = False
         for item in msg.message_attributes.items():
@@ -30,7 +32,6 @@ class CkanMessage:
         self.receipt_handle = msg.receipt_handle
         self.ckan_meta = ckan_meta
         self.github_pr = github_pr
-        self._raw = json.loads(self.body)
 
     def __str__(self):
         return '{}: {}'.format(self.ModIdentifier, self.CheckTime)
@@ -126,7 +127,7 @@ class CkanMessage:
             # have checked the mod!
             'last_checked': inflation_time,
             # Copy the links to the status page
-            **(self._raw.get('resources', {})),
+            **(getattr(self.ckan, 'resources', {})),
         }
         if new:
             attrs['ModIdentifier'] = self.ModIdentifier

--- a/netkan/netkan/indexer.py
+++ b/netkan/netkan/indexer.py
@@ -1,4 +1,3 @@
-import json
 import hashlib
 import logging
 from pathlib import Path, PurePath

--- a/netkan/netkan/status.py
+++ b/netkan/netkan/status.py
@@ -36,6 +36,12 @@ class ModStatus(Model):
     last_inflated = UTCDateTimeAttribute(null=True)
     success = BooleanAttribute()
 
+    homepage = UnicodeAttribute(null=True)
+    spacedock = UnicodeAttribute(null=True)
+    repository = UnicodeAttribute(null=True)
+    curse = UnicodeAttribute(null=True)
+    bugtracker = UnicodeAttribute(null=True)
+
     def mod_attrs(self):
         attributes = {}
         for key in self.get_attributes().keys():

--- a/netkan/netkan/status.py
+++ b/netkan/netkan/status.py
@@ -1,11 +1,11 @@
-import boto3
 import json
 import logging
 import os
 import time
 from datetime import datetime
-from dateutil.parser import parse
 from pathlib import Path
+import boto3
+from dateutil.parser import parse
 from pynamodb.models import Model
 from pynamodb.attributes import (
     UnicodeAttribute, UTCDateTimeAttribute, BooleanAttribute, MapAttribute
@@ -73,7 +73,7 @@ class ModStatus(Model):
             Key=key,
             Body=json.dumps(cls.export_all_mods(compat)).encode(),
         )
-        logging.info('Exported to s3://{}/{}'.format(bucket, key))
+        logging.info('Exported to s3://%s/%s', bucket, key)
 
     # This likely isn't super effecient, but we really should only have to use
     # this operation once to seed the existing history.

--- a/netkan/netkan/status.py
+++ b/netkan/netkan/status.py
@@ -8,7 +8,7 @@ from dateutil.parser import parse
 from pathlib import Path
 from pynamodb.models import Model
 from pynamodb.attributes import (
-    UnicodeAttribute, UTCDateTimeAttribute, BooleanAttribute
+    UnicodeAttribute, UTCDateTimeAttribute, BooleanAttribute, MapAttribute
 )
 
 
@@ -35,12 +35,7 @@ class ModStatus(Model):
     last_indexed = UTCDateTimeAttribute(null=True)
     last_inflated = UTCDateTimeAttribute(null=True)
     success = BooleanAttribute()
-
-    homepage = UnicodeAttribute(null=True)
-    spacedock = UnicodeAttribute(null=True)
-    repository = UnicodeAttribute(null=True)
-    curse = UnicodeAttribute(null=True)
-    bugtracker = UnicodeAttribute(null=True)
+    resources = MapAttribute(default={})
 
     def mod_attrs(self):
         attributes = {}


### PR DESCRIPTION
## Motivation

In KSP-CKAN/NetKAN-status#9 the status page is gaining the ability to show additional links for mods by extracting them from the status objects. The idea is to save steps in getting to all the various pages that are relevant to investigating a mod.

## Changes

This pull request copies the `resources` object's properties from an inflated module into the status object. Note that the `resources` property will be unavailable if inflation fails, but values saved from previous successful passes will still be there to aid in investigation.