### PR TITLE
Fix error message comparison again

### DIFF
--- a/netkan/netkan/indexer.py
+++ b/netkan/netkan/indexer.py
@@ -137,9 +137,9 @@ class CkanMessage:
         try:
             status = ModStatus.get(self.ModIdentifier)
             attrs = self.status_attrs()
-            if not self.Success and status.get('last_error') != attrs.last_error:
+            if not self.Success and getattr(status, 'last_error', None) != self.ErrorMessage:
                 logging.error('New inflation error for %s: %s',
-                              self.ModIdentifier, attrs.last_error)
+                              self.ModIdentifier, self.ErrorMessage)
             actions = [
                 getattr(ModStatus, key).set(
                     attrs[key]


### PR DESCRIPTION
## Problem

Despite #68 and #72 having been merged and new errors having shown up on the status page, no inflation errors have been posted to the new Discord channel.

## Cause

I think the error message attributes are still being accessed the wrong way.

- `status` is a `pynamodb.Model` object, and we're calling `get`, which I think is for `dict`s. In `status.py`, working code uses `getattr` instead:
  https://github.com/KSP-CKAN/NetKAN-Infra/blob/5d500033ab47f995b2bf5a78c389e91ee6617f0c/netkan/netkan/status.py#L44
- `attrs` is a `dict`, and we're trying to access its `.last_error` property, which is for objects. Python `dicts` use `[key]` or `.get('key')`. Working code currently uses `[key]`:
  https://github.com/KSP-CKAN/NetKAN-Infra/blob/5d500033ab47f995b2bf5a78c389e91ee6617f0c/netkan/netkan/indexer.py#L145
  (I think I got confused with Javascript, where `obj.prop` is valid syntactic sugar for `obj['prop']`.)

Basically we have them flipped. I'm surprised neither is throwing an exception, but if both are always returning `None`, then the error comparison would detect no change and suppress the message.

In short, it's very important to know the type of a variable in Python (and often not easy).

## Changes

Now:

- We use `getattr` to access `status.last_error` safely
- We use `self.ErrorMessage` instead of `attrs.last_error`, which contains the same value and is shown safe to use by being used already in several places

This should finally get the inflation error notifications off the ground.