### PR TITLE
Report uncaught exceptions to Discord

### DIFF
--- a/netkan/netkan/cli.py
+++ b/netkan/netkan/cli.py
@@ -6,7 +6,7 @@ from pathlib import Path
 import boto3
 import click
 from .utils import init_repo, init_ssh
-from .notifications import setup_log_handler
+from .notifications import setup_log_handler, catch_all
 from .github import GitHubPR
 from .indexer import MessageHandler
 from .scheduler import NetkanScheduler
@@ -17,7 +17,9 @@ from .download_counter import DownloadCounter
 @click.group()
 def netkan():
     # Set up Discord logger so we can see errors
-    setup_log_handler()
+    if setup_log_handler():
+        # Catch uncaught exceptions and log them
+        sys.excepthook = catch_all
 
 
 @click.command()

--- a/netkan/netkan/notifications.py
+++ b/netkan/netkan/notifications.py
@@ -1,6 +1,14 @@
 import os
+import sys
 import logging
 import discord
+
+
+def catch_all(exception_type, value, stacktrace):
+    # Log an error for Discord
+    logging.error("Uncaught exception:", exc_info=(exception_type, value, stacktrace))
+    # Pass to default handler (prints, exits, etc.)
+    sys.__excepthook__(exception_type, value, stacktrace)
 
 
 class DiscordLogHandler(logging.Handler):
@@ -22,3 +30,5 @@ def setup_log_handler():
         handler = DiscordLogHandler(discord_webhook_id, discord_webhook_token)
         handler.setLevel(logging.ERROR)
         logging.getLogger('').addHandler(handler)
+        return True
+    return False

--- a/netkan/netkan/webhooks/__init__.py
+++ b/netkan/netkan/webhooks/__init__.py
@@ -1,10 +1,10 @@
 import os
-import logging
 import boto3
 from flask import Flask
 
 from ..utils import init_repo
 from ..notifications import setup_log_handler
+from .errors import errors
 from .inflate import inflate
 from .spacedock_inflate import spacedock_inflate
 from .github_inflate import github_inflate
@@ -22,6 +22,7 @@ def create_app():
         QueueName=os.environ.get('INFLATION_SQS_QUEUE'))
 
     # Add the hook handlers
+    app.register_blueprint(errors)
     app.register_blueprint(inflate)
     app.register_blueprint(spacedock_inflate, url_prefix='/sd')
     app.register_blueprint(github_inflate, url_prefix='/gh')

--- a/netkan/netkan/webhooks/errors.py
+++ b/netkan/netkan/webhooks/errors.py
@@ -1,0 +1,10 @@
+from flask import Blueprint, current_app
+
+
+errors = Blueprint('errors', __name__)  # pylint: disable=invalid-name
+
+
+@errors.app_errorhandler(Exception)
+def handle_error(exc):
+    current_app.logger.error("Uncaught exception:", exc_info=exc)
+    return '', 500


### PR DESCRIPTION
## Motivation

When we make silly mistakes that throw unexpected exceptions (see #71), the whole system can come to a stop without a clear indication this has happened. An exception is printed, but @techman83 needs to go check the server to see it, which usually would only happen if we notice missing activity for a long-ish period of time. It would be nice to avoid extended outages.

As of #68, calls to `logging.error` (and `Flask.current_app.logger.error`) are sent to a Discord channel for the team to inspect. This also serves as a convenient form of immediate notification.

## Changes

Now uncaught exceptions are logged as errors and sent to Discord. This is done in two places:

- For `cli.py`, we set `sys.excepthook` to intercept all uncaught exceptions and log them. Then we call the default function for this, `sys.__excepthook__`, to stay consistent with normal exception handling behavior (we just want to add our small logging piece).
- For the webhooks, Flask already handles all exceptions and funnels them into its own framework to avoid server downtime, so a new `errors.py` file creates an `errors` blueprint with an `app_errorhandler` that logs an error and then returns an empty string with an HTTP status of 500.

This will allow us to see uncaught exceptions as soon as they are raised.

Sample messages from testing:

![image](https://user-images.githubusercontent.com/1559108/67870543-05a6d400-fafd-11e9-87ae-06cdc16d27b0.png)