### PR TITLE
Schedule inflation of webhook-only mods once a day

### DIFF
--- a/netkan/netkan/common.py
+++ b/netkan/netkan/common.py
@@ -1,4 +1,4 @@
-from ..metadata import Netkan
+from .metadata import Netkan
 
 
 def netkans(path, ids):

--- a/netkan/netkan/webhooks/github_inflate.py
+++ b/netkan/netkan/webhooks/github_inflate.py
@@ -1,7 +1,7 @@
 from pathlib import Path
 from flask import Blueprint, current_app, request, jsonify
 
-from .common import netkans, sqs_batch_entries
+from ..common import netkans, sqs_batch_entries
 from .github_utils import signature_required
 
 

--- a/netkan/netkan/webhooks/inflate.py
+++ b/netkan/netkan/webhooks/inflate.py
@@ -1,6 +1,6 @@
 from flask import Blueprint, current_app, request
 
-from .common import netkans, sqs_batch_entries
+from ..common import netkans, sqs_batch_entries
 
 
 inflate = Blueprint('inflate', __name__)  # pylint: disable=invalid-name

--- a/netkan/netkan/webhooks/spacedock_inflate.py
+++ b/netkan/netkan/webhooks/spacedock_inflate.py
@@ -2,7 +2,7 @@ from pathlib import Path
 from flask import Blueprint, current_app, request
 
 from ..metadata import Netkan
-from .common import sqs_batch_entries
+from ..common import sqs_batch_entries
 
 
 spacedock_inflate = Blueprint('spacedock_inflate', __name__)  # pylint: disable=invalid-name

--- a/prod-stack.py
+++ b/prod-stack.py
@@ -330,7 +330,7 @@ netkan_ecs_role = t.add_resource(Role(
 # the tasks.
 scheduler_resources = []
 for task in [
-        'Scheduler', 'SchedulerFullPass', 'CertBot', 'StatusDumper', 'DownloadCounter']:
+        'Scheduler', 'SchedulerWebhooksPass', 'CertBot', 'StatusDumper', 'DownloadCounter']:
     scheduler_resources.append(Sub(
         'arn:aws:ecs:*:${AWS::AccountId}:task-definition/NetKANBot${Task}:*',
         Task=task
@@ -592,9 +592,8 @@ services = [
         'schedule': 'rate(2 hours)',
     },
     {
-        'name': 'SchedulerFullPass',
+        'name': 'SchedulerWebhooksPass',
         'command': ['scheduler', '--group', 'webhooks', '--min-credits', '100'],
-        'memory': '156',
         'env': [
             ('SQS_QUEUE', GetAtt(inbound, 'QueueName')),
             ('NETKAN_REMOTE', NETKAN_REMOTE),

--- a/prod-stack.py
+++ b/prod-stack.py
@@ -330,7 +330,7 @@ netkan_ecs_role = t.add_resource(Role(
 # the tasks.
 scheduler_resources = []
 for task in [
-        'Scheduler', 'CertBot', 'StatusDumper', 'DownloadCounter']:
+        'Scheduler', 'SchedulerFullPass', 'CertBot', 'StatusDumper', 'DownloadCounter']:
     scheduler_resources.append(Sub(
         'arn:aws:ecs:*:${AWS::AccountId}:task-definition/NetKANBot${Task}:*',
         Task=task
@@ -590,6 +590,17 @@ services = [
             ('AWS_DEFAULT_REGION', Sub('${AWS::Region}')),
         ],
         'schedule': 'rate(2 hours)',
+    },
+    {
+        'name': 'SchedulerFullPass',
+        'command': ['scheduler', '--schedule-all'],
+        'memory': '156',
+        'env': [
+            ('SQS_QUEUE', GetAtt(inbound, 'QueueName')),
+            ('NETKAN_REMOTE', NETKAN_REMOTE),
+            ('AWS_DEFAULT_REGION', Sub('${AWS::Region}')),
+        ],
+        'schedule': 'cron(0 2 ? * MON *)',
     },
     {
         'name': 'CleanCache',

--- a/prod-stack.py
+++ b/prod-stack.py
@@ -593,14 +593,14 @@ services = [
     },
     {
         'name': 'SchedulerFullPass',
-        'command': ['scheduler', '--schedule-all'],
+        'command': ['scheduler', '--group', 'webhooks', '--min-credits', '100'],
         'memory': '156',
         'env': [
             ('SQS_QUEUE', GetAtt(inbound, 'QueueName')),
             ('NETKAN_REMOTE', NETKAN_REMOTE),
             ('AWS_DEFAULT_REGION', Sub('${AWS::Region}')),
         ],
-        'schedule': 'cron(0 2 ? * MON *)',
+        'schedule': 'rate(1 day)',
     },
     {
         'name': 'CleanCache',


### PR DESCRIPTION
## Motivation

In #40 we suppressed scheduling of modules that are adequately handled by webhook notifications.

In normal operation this helpfully reduces resource consumption, but sometimes we develop things like #70 that add functionality that depends on fresh inflations, which leaves the excluded modules behind. And there's always the possibility that we miss a webhook inflation due to some glitch on our side or SpaceDock's.

## Changes

Now modules that are excluded from normal passes will be scheduled for inflation once per day.