### PR TITLE
Stop deduplicating non-duplicate queue messages

### DIFF
--- a/netkan/netkan/metadata.py
+++ b/netkan/netkan/metadata.py
@@ -1,7 +1,8 @@
 import json
 import re
 from pathlib import Path
-from hashlib import md5, sha1
+from hashlib import sha1
+import uuid
 
 
 class Netkan:
@@ -59,10 +60,10 @@ class Netkan:
 
     def sqs_message(self):
         return {
-            'Id': self.filename.stem,
+            'Id': self.identifier,
             'MessageBody': self.contents,
             'MessageGroupId': '1',
-            'MessageDeduplicationId': md5(self.contents.encode()).hexdigest()
+            'MessageDeduplicationId': uuid.uuid4().hex,
         }
 
 


### PR DESCRIPTION
## Problem

If a mod is uploaded to SpaceDock multiple times in 5 minutes, it will only be inflated once, see #80 for details.

## Cause

The `MessageDeduplicationId` is a hash of the netkan file contents, which means it's the same every time we send the same module, and the queue thinks they are duplicates.

https://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSDeveloperGuide/using-messagededuplicationid-property.html

> The message deduplication ID is the token used for deduplication of sent messages. If a message with a particular message deduplication ID is sent successfully, any messages sent with the same message deduplication ID are accepted successfully but aren't delivered during the 5-minute deduplication interval.

## Changes

Now we use a random UUID so every inflation request is treated separately.

https://docs.python.org/3/library/uuid.html

> If all you want is a unique ID, you should probably call uuid1() or uuid4(). Note that uuid1() may compromise privacy since it creates a UUID containing the computer’s network address. uuid4() creates a random UUID.

This should be fine according to the format specifications for the field:

https://docs.aws.amazon.com/AWSSimpleQueueService/latest/APIReference/API_SendMessage.html

> The maximum length of MessageDeduplicationId is 128 characters. MessageDeduplicationId can contain alphanumeric characters (a-z, A-Z, 0-9) and punctuation (!"#$%&'()*+,-./:;<=>?@[\]^_`{|}~).

Fixes #80.