### PR TITLE
Always schedule the webhook pass

### DIFF
--- a/prod-stack.py
+++ b/prod-stack.py
@@ -593,7 +593,11 @@ services = [
     },
     {
         'name': 'SchedulerWebhooksPass',
-        'command': ['scheduler', '--group', 'webhooks', '--min-credits', '100'],
+        'command': [
+            'scheduler', '--group', 'webhooks',
+                '--max-queued', '2000',
+                '--min-credits', '100'
+        ],
         'env': [
             ('SQS_QUEUE', GetAtt(inbound, 'QueueName')),
             ('NETKAN_REMOTE', NETKAN_REMOTE),


### PR DESCRIPTION
## Problem

Currently the webhooks pass from #79 won't run if there are 20 or more messages in the inflation queue. This can happen anytime the webhooks pass starts while the main pass is in progress, which I think happened last time.

## Changes

Now we pass `--max-queued 2000` to ensure that the daily pass won't be missed.
(Should we use a special value like `-1` to force it to run regardless? Let me know, I was going for minimal changes but that sort of thing might make sense too.)

In addition, a TODO item that should have been pruned from `scheduler.py` in #79 is trimmed down to only info that's still applicable, and linter fixes requested by VSCode are applied in that file. (If they look familiar, that's because they were initially done in #58 and then rolled back).