### PR TITLE
Lock gunicorn to < 20.0.0

### DIFF
--- a/netkan/setup.py
+++ b/netkan/setup.py
@@ -19,7 +19,7 @@ setup(
         'requests',
         'flask',
         'internetarchive',
-        'gunicorn',
+        'gunicorn>=19.9,<20.0.0',
         'discord',
     ],
     entry_points={


### PR DESCRIPTION
Noticed the webhooks had stopped working after the recent release. Gunicorn has a new major version and there must be a breaking change. Locking to below 20 while we investigate.