### PR TITLE
Restore Console Logging

### DIFF
--- a/netkan/Dockerfile
+++ b/netkan/Dockerfile
@@ -5,6 +5,7 @@ WORKDIR /netkan
 USER netkan
 RUN pip install --user . --no-warn-script-location
 RUN python -m unittest -v
+RUN /home/netkan/.local/bin/netkan --help
 
 FROM python:3.7 as production
 COPY --from=base /home/netkan /home/netkan

--- a/netkan/netkan/notifications.py
+++ b/netkan/netkan/notifications.py
@@ -23,7 +23,13 @@ class DiscordLogHandler(logging.Handler):
         self.webhook.send(f'```{fmt}```' if "\n" in fmt else fmt)
 
 
-def setup_log_handler():
+def setup_log_handler(debug=False):
+    level = logging.DEBUG if debug else logging.INFO
+    logging.basicConfig(
+        format='[%(asctime)s] [%(levelname)-8s] %(message)s', level=level
+    )
+    logging.info('Logging started for \'%s\' at log level %s', sys.argv[1], level)
+
     # Set up Discord logger so we can see errors
     discord_webhook_id = os.environ.get('DISCORD_WEBHOOK_ID')
     discord_webhook_token = os.environ.get('DISCORD_WEBHOOK_TOKEN')

--- a/netkan/netkan/notifications.py
+++ b/netkan/netkan/notifications.py
@@ -24,11 +24,12 @@ class DiscordLogHandler(logging.Handler):
 
 
 def setup_log_handler(debug=False):
-    level = logging.DEBUG if debug else logging.INFO
-    logging.basicConfig(
-        format='[%(asctime)s] [%(levelname)-8s] %(message)s', level=level
-    )
-    logging.info('Logging started for \'%s\' at log level %s', sys.argv[1], level)
+    if not sys.argv[0].endswith('gunicorn'):
+        level = logging.DEBUG if debug else logging.INFO
+        logging.basicConfig(
+            format='[%(asctime)s] [%(levelname)-8s] %(message)s', level=level
+        )
+        logging.info('Logging started for \'%s\' at log level %s', sys.argv[1], level)
 
     # Set up Discord logger so we can see errors
     discord_webhook_id = os.environ.get('DISCORD_WEBHOOK_ID')

--- a/netkan/setup.py
+++ b/netkan/setup.py
@@ -21,6 +21,7 @@ setup(
         'internetarchive',
         'gunicorn>=19.9,<20.0.0',
         'discord',
+        'PyGithub',
     ],
     entry_points={
         'console_scripts': [
@@ -34,7 +35,6 @@ setup(
             'pylint',
             'autopep8',
             'troposphere',
-            'PyGithub',
         ]
     },
 )


### PR DESCRIPTION
Console logging was lost in #77, this restores console logging and makes it consistent across all the commands.

The only drawback being that the `--debug` flag is on the group and must be passed before the command, ie
```bash
netkan@bef8cb5997ae:~/workspace$ netkan --debug indexer --help
[2019-11-11 09:14:41,812] [INFO    ] Logging started for '--debug' at log level 10
Usage: netkan indexer [OPTIONS]

Options:
  --queue TEXT       SQS Queue to poll for metadata
  --metadata TEXT    Path/URL/SSH to Metadata Repo
  --token TEXT       GitHub Token for PRs  [required]
  --repo TEXT        GitHub repo to raise PR against (Org Repo: CKAN-meta)
  --user TEXT        GitHub user/org repo resides under (Org User: KSP-CKAN)
  --timeout INTEGER  Reduce message visibility timeout for testing
  --key TEXT         [required]
  --help             Show this message and exit.
netkan@bef8cb5997ae:~/workspace$ netkan indexer --debug --help
[2019-11-11 09:14:48,690] [INFO    ] Logging started for 'indexer' at log level 20
Usage: netkan indexer [OPTIONS]
Try "netkan indexer --help" for help.

Error: no such option: --debug
```
There are few ways to work around it, but it's only useful in dev and rare to need it even then. So I'm comfortable to leave it as is unless it becomes annoying.