### PR TITLE
Move ticket closer out of Webhooks service

### DIFF
--- a/prod-stack.py
+++ b/prod-stack.py
@@ -697,6 +697,13 @@ services = [
         'schedule': 'cron(30 0 ? * MON *)',
     },
     {
+        'name': 'TicketCloser',
+        'command': 'ticket-closer',
+        'env': [],
+        'secrets': ['GH_Token'],
+        'schedule': 'rate(1 day)',
+    },
+    {
         'name': 'Webhooks',
         'containers': [
             {
@@ -738,13 +745,6 @@ services = [
                     ('letsencrypt', '/etc/letsencrypt')
                 ],
                 'depends': ['webhooks', 'legacyhooks']
-            },
-            {
-                'name': 'TicketCloser',
-                'command': 'ticket-closer',
-                'env': [],
-                'secrets': ['GH_Token'],
-                'schedule': 'rate(1 day)',
             },
         ]
     },


### PR DESCRIPTION
Something I missed during review, the folding of the diff slightly hid that it was sitting as a part of the webhooks services.

Already fixed in prod.