### PR TITLE
Don't inflate frozen modules in GitHub webhook

### DIFF
--- a/netkan/netkan/webhooks/github_inflate.py
+++ b/netkan/netkan/webhooks/github_inflate.py
@@ -40,10 +40,10 @@ def ids_from_commits(commits):
     files = set()
     for commit in commits:
         added = commit.get('added')
-        if added:
+        if added and added.endswith('.netkan'):
             files |= set(added)
         modified = commit.get('modified')
-        if modified:
+        if modified and modified.endswith('.netkan'):
             files |= set(modified)
     return (Path(f).stem for f in files)
 


### PR DESCRIPTION
## Problem

I froze a netkan, and the error channel said:

```
Uncaught exception:
Traceback (most recent call last):
  File "/home/netkan/.local/lib/python3.7/site-packages/flask/app.py", line 1949, in full_dispatch_request
    rv = self.dispatch_request()
  File "/home/netkan/.local/lib/python3.7/site-packages/flask/app.py", line 1935, in dispatch_request
    return self.view_functions[rule.endpoint](**req.view_args)
  File "/home/netkan/.local/lib/python3.7/site-packages/netkan/webhooks/github_utils.py", line 14, in decorated_function
    return func(*args, **kwargs)
  File "/home/netkan/.local/lib/python3.7/site-packages/netkan/webhooks/github_inflate.py", line 21, in inflate_hook
    inflate(ids_from_commits(commits))
  File "/home/netkan/.local/lib/python3.7/site-packages/netkan/webhooks/github_inflate.py", line 56, in inflate
    for batch in sqs_batch_entries(messages):
  File "/home/netkan/.local/lib/python3.7/site-packages/netkan/common.py", line 10, in sqs_batch_entries
    for msg in messages:
  File "/home/netkan/.local/lib/python3.7/site-packages/netkan/webhooks/github_inflate.py", line 54, in <genexpr>
    messages = (nk.sqs_message()
  File "/home/netkan/.local/lib/python3.7/site-packages/netkan/common.py", line 5, in <genexpr>
    return (Netkan(f'{path}/NetKAN/{id}.netkan') for id in ids)
  File "/home/netkan/.local/lib/python3.7/site-packages/netkan/metadata.py", line 15, in __init__
    self.contents = self.filename.read_text()
  File "/usr/local/lib/python3.7/pathlib.py", line 1206, in read_text
    with self.open(mode='r', encoding=encoding, errors=errors) as f:
  File "/usr/local/lib/python3.7/pathlib.py", line 1193, in open
    opener=self._opener)
  File "/usr/local/lib/python3.7/pathlib.py", line 1046, in _opener
    return self._accessor.open(self, flags, mode)
FileNotFoundError: [Errno 2] No such file or directory: '/tmp/NetKAN/NetKAN/DrillActionFix.netkan'
```

## Cause

The file was in `/tmp/NetKAN/NetKAN/DrillActionFix.frozen`, but we assume it ends with `.netkan`. And we shouldn't be inflating frozen modules anyway.

## Changes

Now we ignore changed files that don't end in `.netkan`.