### PR TITLE
Fix Webhooks Pass

### DIFF
--- a/prod-stack.py
+++ b/prod-stack.py
@@ -608,7 +608,6 @@ services = [
                 '--max-queued', '2000',
                 '--min-credits', '100'
         ],
-        'command': ['scheduler', '--group', 'webhooks', '--min-credits', '100'],
         'memory': '156',
         'env': [
             ('SQS_QUEUE', GetAtt(inbound, 'QueueName')),


### PR DESCRIPTION
When fixing a merge conflict on my rebase I missed the second command definition in the dict.

This PR removes it, this matches what is now in production.