### PR TITLE
Schedule modules in alphabetical order

### DIFF
--- a/netkan/netkan/scheduler.py
+++ b/netkan/netkan/scheduler.py
@@ -26,7 +26,7 @@ class NetkanScheduler:
     def netkans(self):
         # This can easily be recursive with '**/*.netkan', however
         # implementing like for like initially.
-        return (Netkan(f) for f in self.path.glob('*.netkan'))
+        return (Netkan(f) for f in sorted(self.path.glob('*.netkan')))
 
     def sqs_batch_attrs(self, batch):
         return {


### PR DESCRIPTION
## Problems

Currently the Scheduler submits modules in the order of the files on disk (not alphabetically). This is fine, but it looks a little messy on the status page.

In addition, we are trying to investigate these intermittent inflation errors that always affect the same modules but sometimes don't occur:

```
[11:57 PM] BOTNetKAN bot: New inflation error for KSPInterstellarLite: The remote server returned an error: (403) Forbidden.
[11:59 PM] BOTNetKAN bot: New inflation error for HalfRSS-Textures8192: The remote server returned an error: (403) Forbidden.
[11:59 PM] BOTNetKAN bot: New inflation error for KerboKatzSmallUtilities-Afterburner: The remote server returned an error: (403) Forbidden.
[12:00 AM] BOTNetKAN bot: New inflation error for ScottManleyHeadPack: The remote server returned an error: (403) Forbidden.
[12:00 AM] BOTNetKAN bot: New inflation error for QuarterRSS-Textures8192: The remote server returned an error: (403) Forbidden.
[12:02 AM] BOTNetKAN bot: New inflation error for KerboKatzSmallUtilities-DestroyAll: The remote server returned an error: (403) Forbidden.
[12:02 AM] BOTNetKAN bot: New inflation error for KerboKatzSmallUtilities: The remote server returned an error: (403) Forbidden.
[12:04 AM] BOTNetKAN bot: New inflation error for KerboKatzSmallUtilities-AutoBalancingLandingLeg: The remote server returned an error: (403) Forbidden.
[12:05 AM] BOTNetKAN bot: New inflation error for Telemachus: The remote server returned an error: (403) Forbidden.
```

They all have GitHub `$kref`s, but we have confirmed that the GitHub API's rate limiting is not being triggered, so these errors remain a mystery.

## Changes

Now the Scheduler sorts the paths before using them. This will result in a more orderly status page (which admittedly doesn't matter much). Changing the ordering will also show us whether the particular modules in the above error have an issue, or if it's to do with where they fall in the pass, or if maybe one of them ruins it for the rest of its batch, etc.

Note that `self.path.glob` is a generator, and we need to extract the full list from it to sort. This should be cheap, though, because the list of files on disk would have high locality of reference. The loading and parsing of the files will still take place lazily, so there shouldn't be a noticeable performance impact.