### PR TITLE
Make Scheduler sorting case insensitive

### DIFF
--- a/netkan/netkan/scheduler.py
+++ b/netkan/netkan/scheduler.py
@@ -26,7 +26,8 @@ class NetkanScheduler:
     def netkans(self):
         # This can easily be recursive with '**/*.netkan', however
         # implementing like for like initially.
-        return (Netkan(f) for f in sorted(self.path.glob('*.netkan')))
+        return (Netkan(f) for f in sorted(self.path.glob('*.netkan'),
+                                          key=lambda p: p.stem.casefold()))
 
     def sqs_batch_attrs(self, batch):
         return {


### PR DESCRIPTION
## Problem

After #93 we are sorting the modules for scheduling, however the sort is case sensitive so after `ZZZRadioTelescope` we process a bunch of modules that start with a lowercase letter:

![image](https://user-images.githubusercontent.com/1559108/68871885-c06ccf80-06c2-11ea-94d7-785f466ffcfb.png)

## Changes

Now the sort is case insensitive, so lowercase letters will be folded in with their uppercase counterparts.

Python provides `str.casefold` for this, which is like `str.lower`, but it converts `ß` to `ss`. It doesn't accept a `Path` parameter, so we use a `lambda` to casefold the stem.