### PR TITLE
Validate filenames correctly in GitHub webhook

### DIFF
--- a/netkan/netkan/webhooks/github_inflate.py
+++ b/netkan/netkan/webhooks/github_inflate.py
@@ -36,15 +36,15 @@ def release_hook():
     return '', 204
 
 
+def ends_with_netkan(filename):
+    return filename.endswith('.netkan')
+
+
 def ids_from_commits(commits):
     files = set()
     for commit in commits:
-        added = commit.get('added')
-        if added and added.endswith('.netkan'):
-            files |= set(added)
-        modified = commit.get('modified')
-        if modified and modified.endswith('.netkan'):
-            files |= set(modified)
+        files |= set(filter(ends_with_netkan,
+                            commit.get('added', []) + commit.get('modified', [])))
     return (Path(f).stem for f in files)
 
 


### PR DESCRIPTION
## Problem

This happened after KSP-CKAN/NetKAN#7496:

```
Traceback (most recent call last):
  File "/home/netkan/.local/lib/python3.7/site-packages/flask/app.py", line 1949, in full_dispatch_request
    rv = self.dispatch_request()
  File "/home/netkan/.local/lib/python3.7/site-packages/flask/app.py", line 1935, in dispatch_request
    return self.view_functions[rule.endpoint](**req.view_args)
  File "/home/netkan/.local/lib/python3.7/site-packages/netkan/webhooks/github_utils.py", line 14, in decorated_function
    return func(*args, **kwargs)
  File "/home/netkan/.local/lib/python3.7/site-packages/netkan/webhooks/github_inflate.py", line 21, in inflate_hook
    inflate(ids_from_commits(commits))
  File "/home/netkan/.local/lib/python3.7/site-packages/netkan/webhooks/github_inflate.py", line 43, in ids_from_commits
    if added and added.endswith('.netkan'):
AttributeError: 'list' object has no attribute 'endswith'
```

## Cause

In #89, I thought `added` and `modified` were strings. They're lists (and Python doesn't have a compiler to catch things like that).

## Changes

Now we apply `endswith` to the elements of the lists instead of the lists themselves.