### PR TITLE
Add recover-status-timestamps command

### DIFF
--- a/netkan/netkan/cli.py
+++ b/netkan/netkan/cli.py
@@ -161,6 +161,15 @@ def restore_status(filename):
 
 @click.command()
 @click.option(
+    '--ckanmeta-remote', envvar='CKANMETA_REMOTE',
+    help='Path/URL/SSH to Metadata Repo',
+)
+def recover_status_timestamps(ckanmeta_remote):
+    ModStatus.recover_timestamps(init_repo(ckanmeta_remote, '/tmp/CKAN-meta'))
+
+
+@click.command()
+@click.option(
     '--cluster', help='ECS Cluster running the service'
 )
 @click.option(
@@ -260,6 +269,7 @@ netkan.add_command(scheduler)
 netkan.add_command(dump_status)
 netkan.add_command(export_status_s3)
 netkan.add_command(restore_status)
+netkan.add_command(recover_status_timestamps)
 netkan.add_command(redeploy_service)
 netkan.add_command(clean_cache)
 netkan.add_command(download_counter)

--- a/netkan/netkan/status.py
+++ b/netkan/netkan/status.py
@@ -108,7 +108,7 @@ class ModStatus(Model):
     @classmethod
     def last_indexed_from_git(cls, ckanmeta_repo, identifier):
         try:
-            return parse(ckanmeta_repo.git.log('--', identifier, format='%aI').split("\n")[0])
+            return parse(ckanmeta_repo.git.log('--', identifier, format='%aI', max_count=1).split("\n")[0])
         except Exception as exc:  # pylint: disable=broad-except
             logging.error('Unable to recover last_indexed for %s',
                           identifier, exc_info=exc)

--- a/netkan/netkan/status.py
+++ b/netkan/netkan/status.py
@@ -104,3 +104,22 @@ class ModStatus(Model):
                     time.sleep(1)
 
                 batch.save(ModStatus(**item))
+
+    @classmethod
+    def last_indexed_from_git(cls, ckanmeta_repo, identifier):
+        try:
+            return parse(ckanmeta_repo.git.log('--', identifier, format='%aI').split("\n")[0])
+        except Exception as exc:  # pylint: disable=broad-except
+            logging.error('Unable to recover last_indexed for %s',
+                          identifier, exc_info=exc)
+            return None
+
+    @classmethod
+    def recover_timestamps(cls, ckanmeta_repo):
+        with cls.batch_write() as batch:
+            for mod in cls.scan(rate_limit=5):
+                if not mod.last_indexed:
+                    mod.last_indexed = cls.last_indexed_from_git(
+                        ckanmeta_repo, mod.ModIdentifier)
+                    if mod.last_indexed:
+                        batch.save(mod)


### PR DESCRIPTION
Some mods have `null` timestamps, usually because they were only ever inflated by the legacy webhooks, which did not update the status file. This is inconvenient for changes that use these timestamps, such as #96.

Now a new `recover-status-timestamps` command is added that sets each null `ModStatus.last_indexed` to the timestamp of the newest commit in CKAN-meta for that module. This command is a one-off script and so it is not configured to run automatically; we would need to run it once on the server manually to backfill these timestamps.