### PR TITLE
Ignore webhook requests for non-master branch

### DIFF
--- a/netkan/netkan/webhooks/github_inflate.py
+++ b/netkan/netkan/webhooks/github_inflate.py
@@ -14,6 +14,10 @@ github_inflate = Blueprint('github_inflate', __name__)  # pylint: disable=invali
 @signature_required
 def inflate_hook():
     raw = request.get_json(silent=True)
+    branch = raw.get('ref')
+    if branch != current_app.config['netkan_repo'].head.ref.path:
+        current_app.logger.info('Received inflation request for wrong ref %s, ignoring', branch)
+        return jsonify({'message': 'Wrong branch'}), 200
     commits = raw.get('commits')
     if not commits:
         current_app.logger.info('No commits received')


### PR DESCRIPTION
## Problem

```
Uncaught exception:
Traceback (most recent call last):
  File "/home/netkan/.local/lib/python3.7/site-packages/flask/app.py", line 1949, in full_dispatch_request
    rv = self.dispatch_request()
  File "/home/netkan/.local/lib/python3.7/site-packages/flask/app.py", line 1935, in dispatch_request
    return self.view_functions[rule.endpoint](**req.view_args)
  File "/home/netkan/.local/lib/python3.7/site-packages/netkan/webhooks/github_utils.py", line 14, in decorated_function
    return func(*args, **kwargs)
  File "/home/netkan/.local/lib/python3.7/site-packages/netkan/webhooks/github_inflate.py", line 21, in inflate_hook
    inflate(ids_from_commits(commits))
  File "/home/netkan/.local/lib/python3.7/site-packages/netkan/webhooks/github_inflate.py", line 56, in inflate
    for batch in sqs_batch_entries(messages):
  File "/home/netkan/.local/lib/python3.7/site-packages/netkan/common.py", line 10, in sqs_batch_entries
    for msg in messages:
  File "/home/netkan/.local/lib/python3.7/site-packages/netkan/webhooks/github_inflate.py", line 54, in <genexpr>
    messages = (nk.sqs_message()
  File "/home/netkan/.local/lib/python3.7/site-packages/netkan/common.py", line 5, in <genexpr>
    return (Netkan(f'{path}/NetKAN/{id}.netkan') for id in ids)
  File "/home/netkan/.local/lib/python3.7/site-packages/netkan/metadata.py", line 15, in __init__
    self.contents = self.filename.read_text()
  File "/usr/local/lib/python3.7/pathlib.py", line 1206, in read_text
    with self.open(mode='r', encoding=encoding, errors=errors) as f:
  File "/usr/local/lib/python3.7/pathlib.py", line 1193, in open
    opener=self._opener)
  File "/usr/local/lib/python3.7/pathlib.py", line 1046, in _opener
    return self._accessor.open(self, flags, mode)
FileNotFoundError: [Errno 2] No such file or directory: '/tmp/NetKAN/NetKAN/NewPolandBall.netkan'
```

## Cause

KSP-CKAN/NetKAN#7508 renamed a file in a branch in the main KSP-CKAN/NetKAN repo. This triggered the inflation webhook, which tried to access the new file on the master branch. It wasn't there.

## Changes

Now we check request's ref and ignore if it doesn't match our current HEAD (which will be master).

If we ever want to run these webhooks on another branch for some reason (prerelease metadata?), all we'll have to do is check out the appropriate branch and it will work as desired.

Used this SpaceDock code as a reference because it works:

https://github.com/KSP-SpaceDock/SpaceDock/blob/34cf8db57d875799c51b7493767bf942b1b6d8ba/KerbalStuff/app.py#L145-L157