### PR TITLE
Timestamp recovery logging, timezones, required param

### DIFF
--- a/netkan/netkan/cli.py
+++ b/netkan/netkan/cli.py
@@ -161,7 +161,7 @@ def restore_status(filename):
 
 @click.command()
 @click.option(
-    '--ckanmeta-remote', envvar='CKANMETA_REMOTE',
+    '--ckanmeta-remote', required=True, envvar='CKANMETA_REMOTE',
     help='Path/URL/SSH to Metadata Repo',
 )
 def recover_status_timestamps(ckanmeta_remote):


### PR DESCRIPTION
## Problem

#97 was merged and run, but we still have lots of missing `last_indexed` values.

## Cause

Unknown; it seemed to work fine on the test db. We need to know more about what it's doing.

## Changes

- Now we log an info message at the start and end
- Now we log an info message for each mod we check and save
- Now the `--ckanmeta-remote` parameter is marked as required because we can't run without it
- Now we convert timestamps to UTC before saving them