### PR TITLE
Autofreezer Fixes for Indexing

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -31,6 +31,7 @@ services:
       target: dev
     environment:
       NETKAN_REMOTE: ${NETKAN_METADATA_PATH}
+      SSH_KEY: ${CKAN_NETKAN_SSHKEY}
       AWS_DEFAULT_REGION: ${CKAN_AWS_DEFAULT_REGION}
       AWS_SECRET_ACCESS_KEY: ${CKAN_AWS_SECRET_ACCESS_KEY}
       AWS_ACCESS_KEY_ID: ${CKAN_AWS_ACCESS_KEY_ID}
@@ -74,6 +75,7 @@ services:
       target: dev
     environment:
       XKAN_GHSECRET: test
+      SSH_KEY: ${CKAN_NETKAN_SSHKEY}
       NETKAN_REMOTE: ${NETKAN_METADATA_PATH}
       INFLATION_SQS_QUEUE: InboundDev.fifo
       AWS_DEFAULT_REGION: ${CKAN_AWS_DEFAULT_REGION}

--- a/netkan/netkan/auto_freezer.py
+++ b/netkan/netkan/auto_freezer.py
@@ -1,5 +1,5 @@
 import logging
-import datetime
+from datetime import datetime, timezone, timedelta
 from pathlib import Path
 import git
 
@@ -17,7 +17,7 @@ class AutoFreezer:
         self.github_pr = github_pr
 
     def freeze_idle_mods(self, days_limit):
-        update_cutoff = datetime.datetime.now() - datetime.timedelta(days=days_limit)
+        update_cutoff = datetime.now(timezone.utc) - timedelta(days=days_limit)
         self.netkan_repo.remotes.origin.pull('master', strategy_option='ours')
         ids_to_freeze = [ident for ident in self._ids() if self._too_old(ident, update_cutoff)]
         if ids_to_freeze:

--- a/netkan/netkan/cli.py
+++ b/netkan/netkan/cli.py
@@ -55,7 +55,10 @@ def netkan(debug):
     '--timeout', default=300, envvar='SQS_TIMEOUT',
     help='Reduce message visibility timeout for testing',
 )
-@click.option('--key', envvar='SSH_KEY', required=True)
+@click.option(
+    '--key', envvar='SSH_KEY', required=True,
+    help='SSH key for accessing repositories'
+)
 def indexer(queue, metadata, token, repo, user, key, timeout):
     init_ssh(key, '/home/netkan/.ssh')
     ckan_meta = init_repo(metadata, '/tmp/CKAN-meta')
@@ -92,6 +95,10 @@ def indexer(queue, metadata, token, repo, user, key, timeout):
     help='Path/URL to NetKAN Repo for dev override',
 )
 @click.option(
+    '--key', envvar='SSH_KEY', required=True,
+    help='SSH key for accessing repositories'
+)
+@click.option(
     '--max-queued', default=20, envvar='MAX_QUEUED',
     help='SQS Queue to send netkan metadata for scheduling'
 )
@@ -108,7 +115,8 @@ def indexer(queue, metadata, token, repo, user, key, timeout):
     '--min-credits', default=200,
     help='Only schedule if we have at least this many credits remaining'
 )
-def scheduler(queue, netkan_remote, max_queued, dev, group, min_credits):
+def scheduler(queue, netkan_remote, key, max_queued, dev, group, min_credits):
+    init_ssh(key, '/home/netkan/.ssh')
     sched = NetkanScheduler(
         Path('/tmp/NetKAN'), queue,
         nonhooks_group=(group == 'all' or group == 'nonhooks'),
@@ -239,7 +247,10 @@ def clean_cache(days):
     '--token', envvar='GH_Token', required=True,
     help='GitHub token for API calls',
 )
-@click.option('--key', envvar='SSH_KEY', required=True)
+@click.option(
+    '--key', envvar='SSH_KEY', required=True,
+    help='SSH key for accessing repositories'
+)
 def download_counter(netkan_remote, ckan_meta, token, key):
     init_ssh(key, '/home/netkan/.ssh')
     init_repo(netkan_remote, '/tmp/NetKAN')
@@ -288,7 +299,8 @@ def ticket_closer(token, days_limit):
     help='Number of days to wait before freezing a mod as idle',
 )
 @click.option(
-    '--key', envvar='SSH_KEY', required=True
+    '--key', envvar='SSH_KEY', required=True,
+    help='SSH key for accessing repositories'
 )
 def auto_freezer(netkan_remote, token, repo, user, days_limit, key):
     init_ssh(key, '/home/netkan/.ssh')

--- a/netkan/netkan/webhooks/__init__.py
+++ b/netkan/netkan/webhooks/__init__.py
@@ -2,7 +2,7 @@ import os
 import boto3
 from flask import Flask
 
-from ..utils import init_repo
+from ..utils import init_repo, init_ssh
 from ..notifications import setup_log_handler
 from .errors import errors
 from .inflate import inflate
@@ -12,6 +12,8 @@ from .github_inflate import github_inflate
 
 def create_app():
     app = Flask(__name__)
+
+    init_ssh(os.environ.get('SSH_KEY'), '/home/netkan/.ssh')
 
     # Set up config
     app.config['secret'] = os.environ.get('XKAN_GHSECRET')

--- a/prod-stack.py
+++ b/prod-stack.py
@@ -597,6 +597,7 @@ services = [
         'name': 'Scheduler',
         'command': 'scheduler',
         'memory': '156',
+        'secrets': ['SSH_KEY'],
         'env': [
             ('SQS_QUEUE', GetAtt(inbound, 'QueueName')),
             ('NETKAN_REMOTE', NETKAN_REMOTE),
@@ -612,6 +613,7 @@ services = [
                 '--min-credits', '100'
         ],
         'memory': '156',
+        'secrets': ['SSH_KEY'],
         'env': [
             ('SQS_QUEUE', GetAtt(inbound, 'QueueName')),
             ('NETKAN_REMOTE', NETKAN_REMOTE),
@@ -745,7 +747,9 @@ services = [
                     '-b', '0.0.0.0:5000', '--access-logfile', '-',
                     'netkan.webhooks:create_app()'
                 ],
-                'secrets': ['XKAN_GHSECRET'],
+                'secrets': [
+                    'XKAN_GHSECRET', 'SSH_KEY',
+                ],
                 'env': [
                     ('NETKAN_REMOTE', NETKAN_REMOTE),
                     ('AWS_DEFAULT_REGION', Sub('${AWS::Region}')),

--- a/prod-stack.py
+++ b/prod-stack.py
@@ -716,7 +716,7 @@ services = [
         'secrets': [
             'SSH_KEY', 'GH_Token',
         ],
-        'schedule': 'rate(1 week)',
+        'schedule': 'rate(7 days)',
     },
     {
         'name': 'Webhooks',


### PR DESCRIPTION
Noted an error trying to update the stack
```
Parameter ScheduleExpression is not valid. (Service: AmazonCloudWatchEvents; Status Code: 400; Error Code: ValidationException; Request ID: 31c198c9-8f8e-4129-a3c2-a5186729e7b7)
```
There is a commit that fixes this.

There is also a commit as for the current state of the stack. I've reverted the Change to the NetKAN repo constant and disabled the AutoFreezer task. 

Commits can be added here and I'll re-deploy tomorrow. Issue is that the tasks aren't initialising an SSH Key as HTTP doesn't require it. There was a secondary issue in that the bot has never written to the NetKAN repo and thus didn't have the permissions (I have rectified that).

Some minor adjustments will be required for the last PR to work properly.