### PR TITLE
Port version comparison logic from CKAN-core to metadata.py

### DIFF
--- a/netkan/netkan/metadata.py
+++ b/netkan/netkan/metadata.py
@@ -1,5 +1,6 @@
 import json
 import re
+from functools import total_ordering
 from pathlib import Path
 from hashlib import sha1
 import uuid
@@ -83,6 +84,7 @@ class Ckan:
         else:
             self.contents = contents
         self._raw = json.loads(self.contents)
+        self.version = self.Version(self._raw.get('version'))
 
     def __getattr__(self, name):
         if name in self._raw:
@@ -93,7 +95,7 @@ class Ckan:
 
     @property
     def cache_prefix(self):
-        if not 'download' in self._raw:
+        if 'download' not in self._raw:
             return None
         return sha1(self.download.encode()).hexdigest().upper()[0:8]
 
@@ -104,7 +106,7 @@ class Ckan:
         return '{}-{}-{}.{}'.format(
             self.cache_prefix,
             self.identifier,
-            self.version.replace(':', '-'),
+            self.version.string.replace(':', '-'),
             self.MIME_TO_EXTENSION[self.download_content_type],
         )
 
@@ -121,3 +123,154 @@ class Ckan:
             return lic
         else:
             return [lic]
+
+    @total_ordering
+    class Version:
+
+        PATTERN = re.compile("^(?:(?P<epoch>[0-9]+):)?(?P<version>.*)$")
+
+        def __init__(self, version_string):
+            self.string = version_string
+            match = self.PATTERN.fullmatch(self.string)
+            if not match:
+                raise Exception('Invalid version format')
+            if match.group('epoch') and match.group('epoch').isnumeric():
+                self.epoch = int(match.group('epoch'))
+            else:
+                # https://github.com/KSP-CKAN/CKAN/blob/master/Spec.md#epoch
+                # 0 assumed if no epoch supplied
+                self.epoch = 0
+            self.bare_version = match.group('version')
+            if self.bare_version is None:
+                raise Exception
+
+        # @total_ordering doesn't generate this one right. Maybe it compares the strings?
+        def __eq__(self, other):
+            return not self > other and not other > self
+
+        # The CKAN-Core implementation relies on a __cmp__-like concept. __cmp__ has been deprecated in Python3.
+        # The logic has been adjusted a bit to be run as __gt__. All the other possible relation comparisons
+        # (except __eq__) are deduced from it by @total_ordering.
+        def __gt__(self, other):
+
+            def _string_compare(v1, v2) -> (int, str, str):
+                _result: int
+                _first_remainder = ''
+                _second_remainder = ''
+
+                # Our starting assumptions are, that both versions are completely strings,
+                # with no remainder. We'll then check if they're not.
+                str1 = v1
+                str2 = v2
+
+                # Start by walking along our version string until we find a number,
+                # thereby finding the starting string in both cases. If we fall off
+                # the end, then our assumptions made above hold.
+                for i in range(0, len(v1)):
+                    if v1[i].isdigit():
+                        _first_remainder = v1[i:]
+                        str1 = v1[:i]
+                        break
+
+                for i in range(0, len(v2)):
+                    if v2[i].isdigit():
+                        _second_remainder = v2[i:]
+                        str2 = v2[:i]
+                        break
+
+                # Then compare the two strings, and return our comparison state.
+                # Override sorting of '.' to higher than other characters.
+                if len(str1) > 0 and len(str2) > 0:
+                    if str1[0] != '.' and str2[0] == '.':
+                        _result = -1
+                    elif str1[0] == '.' and str2[0] != '.':
+                        _result = 1
+                    elif str1[0] == '.' and str2[0] == '.':
+                        if len(str1) == 1 and len(str2) > 1:
+                            _result = 1
+                        elif len(str1) > 1 and len(str2) == 1:
+                            _result = -1
+                        else:
+                            _result = 0
+                    else:
+                        # Do an artificial __cmp__
+                        _result = ((str1 > str2)-(str1 < str2))
+                else:
+                    _result = ((str1 > str2)-(str1 < str2))
+
+                return _result, _first_remainder, _second_remainder
+
+            def _number_compare(v1, v2) -> (int, str, str):
+                _result: int
+                _first_remainder = ''
+                _second_remainder = ''
+
+                minimum_length1 = 0
+                for i in range(0, len(v1)):
+                    if not v1[i].isdigit():
+                        _first_remainder = v1[i:]
+                        break
+                    minimum_length1 += 1
+
+                minimum_length2 = 0
+                for i in range(0, len(v2)):
+                    if not v2[i].isdigit():
+                        _second_remainder = v2[i:]
+                        break
+                    minimum_length2 += 1
+
+                if v1[:minimum_length1].isnumeric():
+                    integer1 = int(v1[:minimum_length1])
+                else:
+                    integer1 = 0
+
+                if v2[:minimum_length2].isnumeric():
+                    integer2 = int(v2[:minimum_length2])
+                else:
+                    integer2 = 0
+
+                _result = ((integer1 > integer2)-(integer1 < integer2))
+                return _result, _first_remainder, _second_remainder
+
+            # Here begins the main comparison logic
+            if self is other:
+                return False
+
+            if other.epoch == self.epoch and other.bare_version == self.bare_version:
+                return False
+
+            # Compare epochs first
+            if self.epoch != other.epoch:
+                return self.epoch >= other.epoch
+
+            # Epochs are the same. Do the dance described in
+            # https://github.com/KSP-CKAN/CKAN/blob/master/Spec.md#version-ordering
+            first_remainder = self.bare_version
+            second_remainder = other.bare_version
+
+            # Process our strings while there are characters remaining
+            while len(first_remainder) > 0 and len(second_remainder) > 0:
+                # Start by comparing the string parts.
+                (result, first_remainder, second_remainder) = _string_compare(first_remainder, second_remainder)
+
+                if result != 0:
+                    return result > 0
+
+                # Otherwise, compare the number parts.
+                # It's okay not to check if our strings are exhausted, because
+                # if they are the exhausted parts will return zero.
+                (result, first_remainder, second_remainder) = _number_compare(first_remainder, second_remainder)
+
+                # Again, return difference if found.
+                if result != 0:
+                    return result > 0
+
+            # Oh, we've run out of one or both strings.
+            if len(first_remainder) == 0:
+                # If both remainders are empty, both versions are equal => gt is false.
+                # Else, whichever version is empty first is the smallest. (1.2 < 1.2.3)
+                return False
+            return True
+
+        def __str__(self):
+            return self.string

--- a/netkan/tests/metadata.py
+++ b/netkan/tests/metadata.py
@@ -136,7 +136,7 @@ class TestCkanSimple(unittest.TestCase):
     def test_basic_properties(self):
         self.assertEqual(self.ckan.spec_version, "v1.4")
         self.assertEqual(self.ckan.identifier,   "AwesomeMod")
-        self.assertEqual(self.ckan.version,      "1.0.0")
+        self.assertEqual(self.ckan.version.string,      "1.0.0")
         self.assertEqual(self.ckan.ksp_version,  "1.7.3")
 
     def test_default_kind(self):
@@ -174,3 +174,96 @@ class TestCkanComplex(unittest.TestCase):
 
     def test_licenses(self):
         self.assertEqual(self.ckan.licenses(), ["CC-BY-NC-SA-4.0", "GPL-3.0", "MIT"])
+
+    def test_version(self):
+        self.assertEqual('1.0.0', self.ckan.version.string)
+
+
+class TestVersionConstruction(unittest.TestCase):
+
+    def test_str(self):
+        string = '1.2.3'
+        v1 = Ckan.Version(string)
+
+        self.assertEqual(string, str(v1))
+        self.assertEqual(string, v1.string)
+
+
+class TestVersionComparison(unittest.TestCase):
+
+    def test_alpha(self):
+        v1 = Ckan.Version('apple')
+        v2 = Ckan.Version('banana')
+
+        self.assertLess(v1, v2)
+
+    def test_basic(self):
+        v0 = Ckan.Version('1.2.0')
+        v1 = Ckan.Version('1.2.0')
+        v2 = Ckan.Version('1.2.1')
+
+        self.assertLess(v1, v2)
+        self.assertGreater(v2, v1)
+        self.assertEqual(v1, v0)
+
+    def test_issue1076(self):
+        v0 = Ckan.Version('1.01')
+        v1 = Ckan.Version('1.1')
+
+        self.assertEqual(v1, v0)
+
+    def test_sortAllNumbersBeforeDot(self):
+        v0 = Ckan.Version('1.0_beta')
+        v1 = Ckan.Version('1.0.1_beta')
+
+        self.assertLess(v0, v1)
+        self.assertGreater(v1, v0)
+
+    def test_dotSeparatorForExtraData(self):
+        v0 = Ckan.Version('1.0')
+        v1 = Ckan.Version('1.0.repackaged')
+        v2 = Ckan.Version('1.0.1')
+
+        self.assertLess(v0, v1)
+        self.assertLess(v1, v2)
+        self.assertGreater(v1, v0)
+        self.assertGreater(v2, v1)
+
+    def test_unevenVersioning(self):
+        v0 = Ckan.Version('1.1.0.0')
+        v1 = Ckan.Version('1.1.1')
+
+        self.assertLess(v0, v1)
+        self.assertGreater(v1, v0)
+
+    def test_complex(self):
+        v1 = Ckan.Version('v6a12')
+        v2 = Ckan.Version('v6a5')
+
+        self.assertLess(v2, v1)
+        self.assertGreater(v1,v2)
+        self.assertNotEqual(v1, v2)
+
+    def test_Epoch(self):
+        v1 = Ckan.Version('1.2.0')
+        v2 = Ckan.Version('1:1.2.0')
+
+        self.assertLess(v1, v2)
+
+    def test_agExt(self):
+        v1 = Ckan.Version('1.20')
+        v2 = Ckan.Version('1.22a')
+
+        self.assertGreater(v2, v1)
+
+    def test_differentEpochs(self):
+        v1 = Ckan.Version('1:1')
+        v2 = Ckan.Version('2:1')
+
+        self.assertNotEqual(v1, v2)
+
+    def test_testSuite(self):
+        v1 = Ckan.Version('1.0')
+        v2 = Ckan.Version('2.0')
+
+        self.assertTrue(v1 < v2)


### PR DESCRIPTION
## Motivation
See https://github.com/KSP-CKAN/CKAN/pull/2824, it is planned to implement an auto-epoch feature, which should kick in when an author screws up versioning again (numerous examples linked in the above PR).

Since the version comparison logic is fairly complex, it was first planned to use [CKAN-Core's implementation](https://github.com/KSP-CKAN/CKAN/blob/14ab1522e410c2bb0860d60b8986f625ec42a78e/Core/Versioning/ModuleVersion.cs#L191-L365) for that (via the command line interface f.e.), however spinning up mono multiple times per mod to find the highest version during indexing is rather resource heavy.
So here is the PR that ports the logic to the netkan package.

## Additions & Changes
The `version` attribute of a `Ckan` object is no longer a simple string, but an instance of `Ckan.Version`, a new sub-class.

The only "bigger" difference in the constructor is that it manually assigns a `0` as epoch, if none is given. This is because further down the epochs are checked for equality, and while C# handles that just well and returns `true` is both epochs are `null` or one is `null` and the other isn't and so on, Python really doesn't like `None`s and throws exceptions.
This is totally fine, because our [Spec says](https://github.com/KSP-CKAN/CKAN/blob/master/Spec.md#epoch) that it assumes `0` if no epoch is given.

Else it is still based on the same regex, with just `?` swapped to `P`s for the named groups.

The comparison logic is as close to the C# one as possible. So this is definitely not pythonic.
The biggest problem was, that Python3 deprecated the `__cmp__` method, and the C# implementation is highly built on a similar concept (`-1` means 'less than', `0` means 'equal', `1` means 'greater than'), especially in the `stringComp()` and `numComp` methods.

I built around this by 'simulating' the `__cmp__` return values with this trick:
`_result = ((a > b)-(a < b))`
It's ugly but it works.

Furthermore the logic is not implemented as `__cmp__()` which would match C#'s `CompareTo()`, but as `__gt__()`. This resulted in some changes, like not returning a number indicating the relation of the versions, but simply `True` or `False`. The other possible relationships are all calculated from this.

I implemented the `Comparison` struct as a triple `(result, first_remainder, second_remainder)` which works really well!
I added the `else: return 0` in line 199+200, because the C# code makes use of `0` as default value for ints right there.

---

I also ported all the unit tests of `CKAN/Tests/Core/Versioning/Version.cs`, except two, the one testing construction of `UnmanagedModuleVersion` and the one for `ProvidesModuleVersion`.

---

Please go ahead and review carefully!