### PR TITLE
Lazy-load Ckan.version

### DIFF
--- a/netkan/netkan/metadata.py
+++ b/netkan/netkan/metadata.py
@@ -84,7 +84,6 @@ class Ckan:
         else:
             self.contents = contents
         self._raw = json.loads(self.contents)
-        self.version = self.Version(self._raw.get('version'))
 
     def __getattr__(self, name):
         if name in self._raw:
@@ -92,6 +91,11 @@ class Ckan:
         if name == 'kind':
             return self._raw.get('kind', 'package')
         raise AttributeError
+
+    @property
+    def version(self):
+        if self._raw.get('version'):
+            return self.Version(self._raw.get('version'))
 
     @property
     def cache_prefix(self):

--- a/netkan/tests/metadata.py
+++ b/netkan/tests/metadata.py
@@ -179,6 +179,21 @@ class TestCkanComplex(unittest.TestCase):
         self.assertEqual('1.0.0', self.ckan.version.string)
 
 
+class TestCkanEmpty(unittest.TestCase):
+
+    def setUp(self):
+        self.ckan = Ckan(contents='{}')
+
+    def test_version_none(self):
+        self.assertIsNone(self.ckan.version)
+
+    def test_cache_prefix(self):
+        self.assertIsNone(self.ckan.cache_prefix)
+
+    def test_cache_filename(self):
+        self.assertIsNone(self.ckan.cache_filename)
+
+
 class TestVersionConstruction(unittest.TestCase):
 
     def test_str(self):


### PR DESCRIPTION
## Problem
```
Uncaught exception:
Traceback (most recent call last):
  File ".local/bin/netkan", line 8, in <module>
    sys.exit(netkan())
  File "/home/netkan/.local/lib/python3.7/site-packages/click/core.py", line 764, in __call__
    return self.main(*args, **kwargs)
  File "/home/netkan/.local/lib/python3.7/site-packages/click/core.py", line 717, in main
    rv = self.invoke(ctx)
  File "/home/netkan/.local/lib/python3.7/site-packages/click/core.py", line 1137, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/home/netkan/.local/lib/python3.7/site-packages/click/core.py", line 956, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "/home/netkan/.local/lib/python3.7/site-packages/click/core.py", line 555, in invoke
    return callback(*args, **kwargs)
  File "/home/netkan/.local/lib/python3.7/site-packages/netkan/cli.py", line 81, in indexer
    handler.append(message)
  File "/home/netkan/.local/lib/python3.7/site-packages/netkan/indexer.py", line 219, in append
    self.github_pr
  File "/home/netkan/.local/lib/python3.7/site-packages/netkan/indexer.py", line 18, in __init__
    self.ckan = Ckan(contents=self.body)
  File "/home/netkan/.local/lib/python3.7/site-packages/netkan/metadata.py", line 87, in __init__
    self.version = self.Version(self._raw.get('version'))
  File "/home/netkan/.local/lib/python3.7/site-packages/netkan/metadata.py", line 134, in __init__
    match = self.PATTERN.fullmatch(self.string)
TypeError: expected string or bytes-like object
```

If an inflation fails, the sqs message which represents the .ckan file content is "empty" (`{}`).
During the message processing, the indexer generates a `Ckan` object from the message. This fails as of #101, because the `version` property can't handle a version "string" which is not a string but `None`.

## Changes
Lazy-load/generate the version property, and return `None` if the ckan content does not contain any `version` attribute.
Also added some tests for an empty ckan.