### PR TITLE
Fix exceptions, mark required options as required

### DIFF
--- a/netkan/netkan/cli.py
+++ b/netkan/netkan/cli.py
@@ -32,23 +32,23 @@ def netkan(debug):
 
 @click.command()
 @click.option(
-    '--queue', envvar='SQS_QUEUE',
-    help='SQS Queue to poll for metadata'
+    '--queue', envvar='SQS_QUEUE', required=True,
+    help='SQS Queue to poll for metadata',
 )
 @click.option(
-    '--ckanmeta-remote', '--metadata', envvar='CKANMETA_REMOTE',
+    '--ckanmeta-remote', '--metadata', envvar='CKANMETA_REMOTE', required=True,
     help='Path/URL/SSH to Metadata Repo',
 )
 @click.option(
-    '--token', help='GitHub Token for PRs',
-    required=True, envvar='GH_Token'
+    '--token', envvar='GH_Token', required=True,
+    help='GitHub Token for PRs',
 )
 @click.option(
-    '--repo', envvar='CKANMETA_REPO',
+    '--repo', envvar='CKANMETA_REPO', required=True,
     help='GitHub repo to raise PR against (Org Repo: CKAN-meta)',
 )
 @click.option(
-    '--user', envvar='CKANMETA_USER',
+    '--user', envvar='CKANMETA_USER', required=True,
     help='GitHub user/org repo resides under (Org User: KSP-CKAN)',
 )
 @click.option(
@@ -57,7 +57,7 @@ def netkan(debug):
 )
 @click.option(
     '--key', envvar='SSH_KEY', required=True,
-    help='SSH key for accessing repositories'
+    help='SSH key for accessing repositories',
 )
 def indexer(queue, ckanmeta_remote, token, repo, user, key, timeout):
     init_ssh(key, '/home/netkan/.ssh')
@@ -87,24 +87,24 @@ def indexer(queue, ckanmeta_remote, token, repo, user, key, timeout):
 
 @click.command()
 @click.option(
-    '--queue', envvar='SQS_QUEUE',
-    help='SQS Queue to send netkan metadata for scheduling'
+    '--queue', envvar='SQS_QUEUE', required=True,
+    help='SQS Queue to send netkan metadata for scheduling',
 )
 @click.option(
-    '--netkan-remote', '--netkan', envvar='NETKAN_REMOTE',
+    '--netkan-remote', '--netkan', envvar='NETKAN_REMOTE', required=True,
     help='Path/URL to NetKAN Repo for dev override',
 )
 @click.option(
-    '--ckanmeta-remote', envvar='CKANMETA_REMOTE',
+    '--ckanmeta-remote', envvar='CKANMETA_REMOTE', required=True,
     help='Path/URL/SSH to Metadata Repo',
 )
 @click.option(
     '--key', envvar='SSH_KEY', required=True,
-    help='SSH key for accessing repositories'
+    help='SSH key for accessing repositories',
 )
 @click.option(
     '--max-queued', default=20, envvar='MAX_QUEUED',
-    help='SQS Queue to send netkan metadata for scheduling'
+    help='SQS Queue to send netkan metadata for scheduling',
 )
 @click.option(
     '--dev', is_flag=True, default=False,
@@ -113,11 +113,11 @@ def indexer(queue, ckanmeta_remote, token, repo, user, key, timeout):
 @click.option(
     '--group',
     type=click.Choice(['all', 'webhooks', 'nonhooks']), default="nonhooks",
-    help='Which mods to schedule'
+    help='Which mods to schedule',
 )
 @click.option(
     '--min-credits', default=200,
-    help='Only schedule if we have at least this many credits remaining'
+    help='Only schedule if we have at least this many credits remaining',
 )
 def scheduler(queue, netkan_remote, ckanmeta_remote, key, max_queued, dev, group, min_credits):
     init_ssh(key, '/home/netkan/.ssh')
@@ -136,15 +136,15 @@ def scheduler(queue, netkan_remote, ckanmeta_remote, key, max_queued, dev, group
 @click.command()
 @click.option(
     '--status-bucket', envvar='STATUS_BUCKET', required=True,
-    help='Bucket to Dump status.json'
+    help='Bucket to Dump status.json',
 )
 @click.option(
     '--status-key', envvar='STATUS_KEY', default='status/netkan.json',
-    help='Overwrite bucket key, defaults to `status/netkan.json`'
+    help='Overwrite bucket key, defaults to `status/netkan.json`',
 )
 @click.option(
     '--interval', envvar='STATUS_INTERVAL', default=300,
-    help='Dump status to S3 every `interval` seconds'
+    help='Dump status to S3 every `interval` seconds',
 )
 def export_status_s3(status_bucket, status_key, interval):
     frequency = 'every {} seconds'.format(
@@ -185,10 +185,10 @@ def recover_status_timestamps(ckanmeta_remote):
 
 @click.command()
 @click.option(
-    '--cluster', help='ECS Cluster running the service'
+    '--cluster', help='ECS Cluster running the service',
 )
 @click.option(
-    '--service-name', help='Name of ECS Service to restart'
+    '--service-name', help='Name of ECS Service to restart',
 )
 def redeploy_service(cluster, service_name):
     click.secho(
@@ -224,7 +224,7 @@ def redeploy_service(cluster, service_name):
 
 @click.command()
 @click.option(
-    '--days', help='Purge items older than X from cache'
+    '--days', help='Purge items older than X from cache',
 )
 def clean_cache(days):
     older_than = (
@@ -241,11 +241,11 @@ def clean_cache(days):
 
 @click.command()
 @click.option(
-    '--netkan-remote', '--netkan', envvar='NETKAN_REMOTE',
+    '--netkan-remote', '--netkan', envvar='NETKAN_REMOTE', required=True,
     help='Path/URL/SSH to NetKAN repo for mod list',
 )
 @click.option(
-    '--ckanmeta-remote', '--ckan-meta', envvar='CKANMETA_REMOTE',
+    '--ckanmeta-remote', '--ckan-meta', envvar='CKANMETA_REMOTE', required=True,
     help='Path/URL/SSH to CKAN-meta repo for output',
 )
 @click.option(
@@ -254,7 +254,7 @@ def clean_cache(days):
 )
 @click.option(
     '--key', envvar='SSH_KEY', required=True,
-    help='SSH key for accessing repositories'
+    help='SSH key for accessing repositories',
 )
 def download_counter(netkan_remote, ckanmeta_remote, token, key, debug):
     init_ssh(key, '/home/netkan/.ssh')
@@ -284,7 +284,7 @@ def ticket_closer(token, days_limit):
 
 @click.command()
 @click.option(
-    '--netkan-remote', '--netkan', envvar='NETKAN_REMOTE',
+    '--netkan-remote', '--netkan', envvar='NETKAN_REMOTE', required=True,
     help='Path/URL/SSH to NetKAN repo for mod list',
 )
 @click.option(
@@ -292,11 +292,11 @@ def ticket_closer(token, days_limit):
     help='GitHub token for querying and closing issues',
 )
 @click.option(
-    '--repo', envvar='NETKAN_REPO',
+    '--repo', envvar='NETKAN_REPO', required=True,
     help='GitHub repo to raise PR against (Org Repo: NetKAN)',
 )
 @click.option(
-    '--user', envvar='NETKAN_USER',
+    '--user', envvar='NETKAN_USER', required=True,
     help='GitHub user/org repo resides under (Org User: KSP-CKAN)',
 )
 @click.option(
@@ -305,7 +305,7 @@ def ticket_closer(token, days_limit):
 )
 @click.option(
     '--key', envvar='SSH_KEY', required=True,
-    help='SSH key for accessing repositories'
+    help='SSH key for accessing repositories',
 )
 def auto_freezer(netkan_remote, token, repo, user, days_limit, key):
     init_ssh(key, '/home/netkan/.ssh')

--- a/netkan/netkan/metadata.py
+++ b/netkan/netkan/metadata.py
@@ -59,10 +59,16 @@ class Netkan:
             return False
         return self.on_spacedock
 
+    def string_attrib(self, val):
+        return {
+            'DataType': 'String',
+            'StringValue': val,
+        }
+
     def sqs_message_attribs(self, ckan_group=None):
         attribs = {}
         if ckan_group and not getattr(self, 'x_netkan_allow_out_of_order', False):
-            attribs['HighestVersion'] = ckan_group.highest_version().string
+            attribs['HighestVersion'] = self.string_attrib(ckan_group.highest_version().string)
         return attribs
 
     def sqs_message(self, ckan_group=None):

--- a/prod-stack.py
+++ b/prod-stack.py
@@ -618,6 +618,7 @@ services = [
         'env': [
             ('SQS_QUEUE', GetAtt(inbound, 'QueueName')),
             ('NETKAN_REMOTE', NETKAN_REMOTE),
+            ('CKANMETA_REMOTE', CKANMETA_REMOTE),
             ('AWS_DEFAULT_REGION', Sub('${AWS::Region}')),
         ],
         'schedule': 'rate(1 day)',


### PR DESCRIPTION
## Problems

```
Uncaught exception:
Traceback (most recent call last):
  File ".local/bin/netkan", line 8, in <module>
    sys.exit(netkan())
  File "/home/netkan/.local/lib/python3.7/site-packages/click/core.py", line 764, in __call__
    return self.main(*args, **kwargs)
  File "/home/netkan/.local/lib/python3.7/site-packages/click/core.py", line 717, in main
    rv = self.invoke(ctx)
  File "/home/netkan/.local/lib/python3.7/site-packages/click/core.py", line 1137, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/home/netkan/.local/lib/python3.7/site-packages/click/core.py", line 956, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "/home/netkan/.local/lib/python3.7/site-packages/click/core.py", line 555, in invoke
    return callback(*args, **kwargs)
  File "/home/netkan/.local/lib/python3.7/site-packages/netkan/cli.py", line 131, in scheduler
    init_repo(ckanmeta_remote, '/tmp/CKAN-meta')
  File "/home/netkan/.local/lib/python3.7/site-packages/netkan/utils.py", line 12, in init_repo
    repo = Repo.clone_from(metadata, clone_path)
  File "/home/netkan/.local/lib/python3.7/site-packages/git/repo/base.py", line 1023, in clone_from
    return cls._clone(git, url, to_path, GitCmdObjectDB, progress, multi_options, **kwargs)
  File "/home/netkan/.local/lib/python3.7/site-packages/git/repo/base.py", line 957, in _clone
    proc = git.clone(multi, Git.polish_url(url), clone_path, with_extended_output=True, as_process=True,
  File "/home/netkan/.local/lib/python3.7/site-packages/git/cmd.py", line 333, in polish_url
    url = os.path.expandvars(url)
  File "/usr/local/lib/python3.7/posixpath.py", line 288, in expandvars
    path = os.fspath(path)
TypeError: expected str, bytes or os.PathLike object, not NoneType
```

```
Uncaught exception:
Traceback (most recent call last):
  File "/home/netkan/.local/lib/python3.7/site-packages/flask/app.py", line 1949, in full_dispatch_request
    rv = self.dispatch_request()
  File "/home/netkan/.local/lib/python3.7/site-packages/flask/app.py", line 1935, in dispatch_request
    return self.view_functions[rule.endpoint](**req.view_args)
  File "/home/netkan/.local/lib/python3.7/site-packages/netkan/webhooks/github_utils.py", line 14, in decorated_function
    return func(*args, **kwargs)
  File "/home/netkan/.local/lib/python3.7/site-packages/netkan/webhooks/github_inflate.py", line 26, in inflate_hook
    inflate(ids_from_commits(commits))
  File "/home/netkan/.local/lib/python3.7/site-packages/netkan/webhooks/github_inflate.py", line 64, in inflate
    Entries=batch
  File "/home/netkan/.local/lib/python3.7/site-packages/botocore/client.py", line 357, in _api_call
    return self._make_api_call(operation_name, kwargs)
  File "/home/netkan/.local/lib/python3.7/site-packages/botocore/client.py", line 634, in _make_api_call
    api_params, operation_model, context=request_context)
  File "/home/netkan/.local/lib/python3.7/site-packages/botocore/client.py", line 682, in _convert_to_request_dict
    api_params, operation_model)
  File "/home/netkan/.local/lib/python3.7/site-packages/botocore/validate.py", line 297, in serialize_to_request
    raise ParamValidationError(report=report.generate_report())
botocore.exceptions.ParamValidationError: Parameter validation failed:
Invalid type for parameter Entries[0].MessageAttributes.HighestVersion, value: 2:release-1.7.3-2, type: <class 'str'>, valid types: <class 'dict'>
```

## Cause

The `--ckanmeta-remote` parameter isn't being passed to the scheduler (because ~~the stack needs to be updated~~ the environment variable was missing for the web hooks pass), but it's running anyway. This is a problem because that parameter is needed for the scheduler to do its work. There are some other instances of this problem in `cli.py`.

The `HighestVersion` message attribute from #102 was passed as a string. Apparently it's supposed to be a dict:

https://boto3.amazonaws.com/v1/documentation/api/latest/guide/sqs.html

```js
    {
        'Id': '2',
        'MessageBody': 'boto3',
        'MessageAttributes': {
            'Author': {
                'StringValue': 'Daniel',
                'DataType': 'String'
            }
        }
    }
```

## Changes

Now all required Click options in `cli.py` are marked as required. As well, some minor formatting tweaks (trailing commas) are made for consistency and ease of maintenance.

Now `CKANMETA_REMOTE` is passed to the scheduler web hooks pass, which will fix the root cause of the above error.

Now we generate a dict for `HighestVersion`.