### PR TITLE
Allow gunicorns after 20.0.0

### DIFF
--- a/netkan/setup.py
+++ b/netkan/setup.py
@@ -19,7 +19,7 @@ setup(
         'requests',
         'flask',
         'internetarchive',
-        'gunicorn>=19.9,<20.0.0',
+        'gunicorn>=19.9,!=20.0.0',
         'discord',
         'PyGithub',
     ],


### PR DESCRIPTION
## Problem

gunicorn is currently pinned to version 19.9.0.

## Cause

The 20.0.0 release broke support for the factory pattern, which we use: benoitc/gunicorn#2159

## Changes

Version 20.0.1 fixed the issue (20.0.2 includes notes for 20.0.1):

https://github.com/benoitc/gunicorn/releases/tag/20.0.2

> fixed support of applications loaded from a factory function

I tried it out (with 20.0.3) and it seems to work, so now the pin is changed to just exclude 20.0.0.

Fixes #85.