### PR TITLE
Inflate mods with no previous versions

### DIFF
--- a/netkan/netkan/metadata.py
+++ b/netkan/netkan/metadata.py
@@ -68,7 +68,9 @@ class Netkan:
     def sqs_message_attribs(self, ckan_group=None):
         attribs = {}
         if ckan_group and not getattr(self, 'x_netkan_allow_out_of_order', False):
-            attribs['HighestVersion'] = self.string_attrib(ckan_group.highest_version().string)
+            highVer = ckan_group.highest_version()
+            if highVer:
+                attribs['HighestVersion'] = self.string_attrib(highVer.string)
         return attribs
 
     def sqs_message(self, ckan_group=None):


### PR DESCRIPTION
## Problem

```
Uncaught exception:
Traceback (most recent call last):
  File "/home/netkan/.local/lib/python3.7/site-packages/flask/app.py", line 1949, in full_dispatch_request
    rv = self.dispatch_request()
  File "/home/netkan/.local/lib/python3.7/site-packages/flask/app.py", line 1935, in dispatch_request
    return self.view_functions[rule.endpoint](**req.view_args)
  File "/home/netkan/.local/lib/python3.7/site-packages/netkan/webhooks/github_utils.py", line 14, in decorated_function
    return func(*args, **kwargs)
  File "/home/netkan/.local/lib/python3.7/site-packages/netkan/webhooks/github_inflate.py", line 26, in inflate_hook
    inflate(ids_from_commits(commits))
  File "/home/netkan/.local/lib/python3.7/site-packages/netkan/webhooks/github_inflate.py", line 61, in inflate
    for batch in sqs_batch_entries(messages):
  File "/home/netkan/.local/lib/python3.7/site-packages/netkan/common.py", line 10, in sqs_batch_entries
    for msg in messages:
  File "/home/netkan/.local/lib/python3.7/site-packages/netkan/webhooks/github_inflate.py", line 60, in <genexpr>
    for nk in netkans(current_app.config['netkan_repo'].working_dir, ids))
  File "/home/netkan/.local/lib/python3.7/site-packages/netkan/metadata.py", line 80, in sqs_message
    'MessageAttributes': self.sqs_message_attribs(ckan_group),
  File "/home/netkan/.local/lib/python3.7/site-packages/netkan/metadata.py", line 71, in sqs_message_attribs
    attribs['HighestVersion'] = self.string_attrib(ckan_group.highest_version().string)
AttributeError: 'NoneType' object has no attribute 'string'
```

## Cause

KSP-CKAN/NetKAN#7532 indexed a new mod. Since it's new, there are no existing .ckan files, so `CkanGroup.highest_version()` returned `None`. Then we tried to access `None.string`, which threw an exception.

Now if it's `None`, we don't try to populate the `HighestVersion` message attribute.