### PR TITLE
Revert unintentional restoration of debug param to download counter

### DIFF
--- a/netkan/netkan/cli.py
+++ b/netkan/netkan/cli.py
@@ -256,7 +256,7 @@ def clean_cache(days):
     '--key', envvar='SSH_KEY', required=True,
     help='SSH key for accessing repositories',
 )
-def download_counter(netkan_remote, ckanmeta_remote, token, key, debug):
+def download_counter(netkan_remote, ckanmeta_remote, token, key):
     init_ssh(key, '/home/netkan/.ssh')
     init_repo(netkan_remote, '/tmp/NetKAN')
     meta = init_repo(ckanmeta_remote, '/tmp/CKAN-meta')


### PR DESCRIPTION
## Problem

```
Uncaught exception:
Traceback (most recent call last):
  File ".local/bin/netkan", line 8, in <module>
    sys.exit(netkan())
  File "/home/netkan/.local/lib/python3.7/site-packages/click/core.py", line 764, in __call__
    return self.main(*args, **kwargs)
  File "/home/netkan/.local/lib/python3.7/site-packages/click/core.py", line 717, in main
    rv = self.invoke(ctx)
  File "/home/netkan/.local/lib/python3.7/site-packages/click/core.py", line 1137, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/home/netkan/.local/lib/python3.7/site-packages/click/core.py", line 956, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "/home/netkan/.local/lib/python3.7/site-packages/click/core.py", line 555, in invoke
    return callback(*args, **kwargs)
TypeError: download_counter() missing 1 required positional argument: 'debug'
```

## Cause

An unused `debug`param was added to `download_counter` without Click definitions in #102, probably due to conflict resolution with #86.

## Changes

Now the parameter is removed.