### PR TITLE
Pull both repos before handling webhooks

### DIFF
--- a/netkan/netkan/common.py
+++ b/netkan/netkan/common.py
@@ -14,3 +14,8 @@ def sqs_batch_entries(messages, batch_size=10):
             batch = []
     if len(batch) > 0:
         yield batch
+
+
+def pull_all(repos):
+    for r in repos:
+        r.remotes.origin.pull('master', strategy_option='theirs')

--- a/netkan/netkan/webhooks/__init__.py
+++ b/netkan/netkan/webhooks/__init__.py
@@ -19,6 +19,7 @@ def create_app():
     app.config['secret'] = os.environ.get('XKAN_GHSECRET')
     app.config['netkan_repo'] = init_repo(os.environ.get('NETKAN_REMOTE'), '/tmp/NetKAN')
     app.config['ckanmeta_repo'] = init_repo(os.environ.get('CKANMETA_REMOTE'), '/tmp/CKAN-meta')
+    app.config['repos'] = [app.config['netkan_repo'], app.config['ckanmeta_repo']]
     app.config['client'] = boto3.client('sqs')
     sqs = boto3.resource('sqs')
     app.config['inflation_queue'] = sqs.get_queue_by_name(

--- a/netkan/netkan/webhooks/github_inflate.py
+++ b/netkan/netkan/webhooks/github_inflate.py
@@ -1,7 +1,7 @@
 from pathlib import Path
 from flask import Blueprint, current_app, request, jsonify
 
-from ..common import netkans, sqs_batch_entries
+from ..common import netkans, sqs_batch_entries, pull_all
 from .github_utils import signature_required
 from ..metadata import CkanGroup
 
@@ -54,8 +54,8 @@ def ids_from_commits(commits):
 
 
 def inflate(ids):
-    # Make sure our NetKAN repo is up to date
-    current_app.config['netkan_repo'].remotes.origin.pull('master', strategy_option='theirs')
+    # Make sure our NetKAN and CKAN-meta repos are up to date
+    pull_all(current_app.config['repos'])
     messages = (nk.sqs_message(CkanGroup(current_app.config['ckanmeta_repo'].working_dir, nk.identifier))
                 for nk in netkans(current_app.config['netkan_repo'].working_dir, ids))
     for batch in sqs_batch_entries(messages):

--- a/netkan/netkan/webhooks/inflate.py
+++ b/netkan/netkan/webhooks/inflate.py
@@ -1,6 +1,6 @@
 from flask import Blueprint, current_app, request
 
-from ..common import netkans, sqs_batch_entries
+from ..common import netkans, sqs_batch_entries, pull_all
 from ..metadata import CkanGroup
 
 
@@ -17,8 +17,8 @@ def inflate_hook():
     if not ids:
         current_app.logger.info('No identifiers received')
         return 'An array of identifiers is required', 400
-    # Make sure our NetKAN repo is up to date
-    current_app.config['netkan_repo'].remotes.origin.pull('master', strategy_option='theirs')
+    # Make sure our NetKAN and CKAN-meta repos are up to date
+    pull_all(current_app.config['repos'])
     messages = (nk.sqs_message(CkanGroup(current_app.config['ckanmeta_repo'].working_dir, nk.identifier))
                 for nk in netkans(current_app.config['netkan_repo'].working_dir, ids))
     for batch in sqs_batch_entries(messages):

--- a/netkan/netkan/webhooks/spacedock_inflate.py
+++ b/netkan/netkan/webhooks/spacedock_inflate.py
@@ -1,8 +1,8 @@
 from pathlib import Path
 from flask import Blueprint, current_app, request
 
+from ..common import sqs_batch_entries, pull_all
 from ..metadata import Netkan, CkanGroup
-from ..common import sqs_batch_entries
 
 
 spacedock_inflate = Blueprint('spacedock_inflate', __name__)  # pylint: disable=invalid-name
@@ -13,8 +13,8 @@ spacedock_inflate = Blueprint('spacedock_inflate', __name__)  # pylint: disable=
 # POST form parameters: mod_id=1234&event_type=update
 @spacedock_inflate.route('/inflate', methods=['POST'])
 def inflate_hook():
-    # Make sure our NetKAN repo is up to date
-    current_app.config['netkan_repo'].remotes.origin.pull('master', strategy_option='theirs')
+    # Make sure our NetKAN and CKAN-meta repos are up to date
+    pull_all(current_app.config['repos'])
     # Get the relevant netkans
     nks = find_netkans(request.form.get('mod_id'))
     if nks:


### PR DESCRIPTION
## Problem

![screenshot](https://cdn.discordapp.com/attachments/601455398553387008/655546455682973731/unknown.png)

This module should have been auto-epoched because `1.6_alpha` came out before `0.17_Alpha`, but it wasn't.

## Cause

The Webhooks have a CKAN-meta repo cloned so they can find the highest versions of mods to be inflated (see #102), but they never update it. This mod was indexed after the latest time the Infra was restarted, so the `1.6_alpha` version was not available, and `0.17_Alpha` did not get compared to it.

## Changes

Now a new `netkan.common.pull_all` function accepts a list of repos to pull, and the Webhooks put all of their repos into `current_app.config['repos']` for ease of access. Then in the places where we currently pull the NetKAN repo, we instead pull all of the repos in that list. This will ensure that CKAN-meta is up to date before the Webhook submits a mod for inflation.