### PR TITLE
Check Volume Stats before Scheduling

### DIFF
--- a/netkan/netkan/scheduler.py
+++ b/netkan/netkan/scheduler.py
@@ -10,7 +10,8 @@ from .common import sqs_batch_entries
 
 class NetkanScheduler:
 
-    def __init__(self, path, ckan_meta_path, queue, base='NetKAN/', nonhooks_group=False, webhooks_group=False):
+    def __init__(self, path, ckan_meta_path, queue,
+                 base='NetKAN/', nonhooks_group=False, webhooks_group=False):
         self.path = Path(path, base)
         self.nonhooks_group = nonhooks_group
         self.webhooks_group = webhooks_group
@@ -48,6 +49,52 @@ class NetkanScheduler:
         for batch in sqs_batch_entries(messages):
             self.client.send_message_batch(**self.sqs_batch_attrs(batch))
 
+    def cpu_credits(self, cloudwatch, instance_id, start, end):
+        stats = cloudwatch.get_metric_statistics(
+            Dimensions=[{'Name': 'InstanceId', 'Value': instance_id}],
+            MetricName='CPUCreditBalance',
+            Namespace='AWS/EC2',
+            StartTime=start.strftime("%Y-%m-%dT%H:%MZ"),
+            EndTime=end.strftime("%Y-%m-%dT%H:%MZ"),
+            Period=10,
+            Statistics=['Average'],
+        )
+        # A pass consumes around 40 credits, with an accrue rate of 24/hr.
+        # So running every 2 hours should see using just a touch less than
+        # we gain in that time period.
+        creds = 0
+        try:
+            creds = stats['Datapoints'][0]['Average']
+        except IndexError:
+            logging.error("Couldn't acquire CPU Credit Stats")
+        return int(creds)
+
+    def volume_credits(self, cloudwatch, instance_id, start, end):
+        client = boto3.client('ec2')
+        response = client.describe_volumes(
+            Filters=[{
+                'Name': 'attachment.instance-id',
+                'Values': [instance_id]
+            }]
+        )
+        # If we add a second gp2 volume, this may break
+        volume = list(filter(lambda x: x['VolumeType'] == 'gp2', response['Volumes']))[0]
+        volume_id = volume['Attachments'][0]['VolumeId']
+        stats = cloudwatch.get_metric_statistics(
+            Dimensions=[{'Name': 'VolumeId', 'Value': 'vol-02cdb3dfd4b2a69f9'}],
+            MetricName='BurstBalance',
+            Namespace='AWS/EBS',
+            StartTime=start.strftime("%Y-%m-%dT%H:%MZ"),
+            EndTime=end.strftime("%Y-%m-%dT%H:%MZ"),
+            Period=10, Statistics=['Average'],
+        )
+        creds = 0
+        try:
+            creds = stats['Datapoints'][0]['Average']
+        except IndexError:
+            logging.error("Couldn't acquire Volume Credit Stats")
+        return int(creds)
+
     def can_schedule(self, max_queued, dev=False, min_credits=200):
         if not dev:
             end = datetime.datetime.utcnow()
@@ -57,26 +104,21 @@ class NetkanScheduler:
             )
             instance_id = response.text
             cloudwatch = boto3.client('cloudwatch')
-            stats = cloudwatch.get_metric_statistics(
-                Dimensions=[{'Name': 'InstanceId', 'Value': instance_id}],
-                MetricName='CPUCreditBalance',
-                Namespace='AWS/EC2',
-                StartTime=start.strftime("%Y-%m-%dT%H:%MZ"),
-                EndTime=end.strftime("%Y-%m-%dT%H:%MZ"),
-                Period=10,
-                Statistics=['Average'],
-            )
-            # A pass consumes around 40 credits, with an accrue rate of 24/hr.
-            # So running every 2 hours should see using just a touch less than
-            # we gain in that time period.
-            creds = 0
-            try:
-                creds = stats['Datapoints'][0]['Average']
-            except IndexError:
-                logging.error("Couldn't acquire CPU Credit Stats")
-            if int(creds) < min_credits:
+
+            cpu_credits = self.cpu_credits(cloudwatch, instance_id, start, end)
+            if cpu_credits < min_credits:
                 logging.info(
-                    "Run skipped, below credit target (Current Avg: %s)", creds
+                    "Run skipped, below cpu credit target (Current Avg: %s)", cpu_credits
+                )
+                return False
+
+            # Volume Burst balance measured in a percentage of 5.4million credits. Credits are
+            # accrued at a rate of 3 per GB, per second. If we are are down to 30 percent of
+            # our max, something has gone wrong and we should not queue any more inflations.
+            vol_credits = self.volume_credits(cloudwatch, instance_id, start, end)
+            if vol_credits < 30:
+                logging.info(
+                    "Run skipped, below volume credit target (Current Avg: %s %)", vol_credits
                 )
                 return False
 

--- a/netkan/netkan/scheduler.py
+++ b/netkan/netkan/scheduler.py
@@ -117,7 +117,7 @@ class NetkanScheduler:
             # our max, something has gone wrong and we should not queue any more inflations.
             vol_credits_percent = self.volume_credits_percent(cloudwatch, instance_id, start, end)
             if vol_credits_percent < 30:
-                logging.info(
+                logging.error(
                     "Run skipped, below volume credit target (Current Avg: %s %)", vol_credits_percent
                 )
                 return False

--- a/netkan/netkan/scheduler.py
+++ b/netkan/netkan/scheduler.py
@@ -95,7 +95,7 @@ class NetkanScheduler:
             logging.error("Couldn't acquire Volume Credit Stats")
         return int(creds)
 
-    def can_schedule(self, max_queued, dev=False, min_credits=200):
+    def can_schedule(self, max_queued, dev=False, min_credits=50):
         if not dev:
             end = datetime.datetime.utcnow()
             start = end - datetime.timedelta(minutes=10)

--- a/netkan/netkan/scheduler.py
+++ b/netkan/netkan/scheduler.py
@@ -59,9 +59,9 @@ class NetkanScheduler:
             Period=10,
             Statistics=['Average'],
         )
-        # A pass consumes around 40 credits, with an accrue rate of 24/hr.
-        # So running every 2 hours should see using just a touch less than
-        # we gain in that time period.
+        # An initial pass after redeployment of the inflator consumes around 15 credits
+        # and followup passes around 5, with an accrue rate of 24/hr. This is a historical
+        # check, but useful to avoid DoS'ing the service when we're doing high CPU operations.
         creds = 0
         try:
             creds = stats['Datapoints'][0]['Average']

--- a/prod-stack.py
+++ b/prod-stack.py
@@ -233,6 +233,7 @@ netkan_role = t.add_resource(Role(
                     {
                         "Action": [
                             "cloudwatch:GetMetricStatistics",
+                            "ec2:DescribeVolumes"
                         ],
                         "Effect": "Allow",
                         "Resource": "*"

--- a/prod-stack.py
+++ b/prod-stack.py
@@ -612,7 +612,7 @@ services = [
         'command': [
             'scheduler', '--group', 'webhooks',
                 '--max-queued', '2000',
-                '--min-credits', '100'
+                '--min-credits', '25'
         ],
         'memory': '156',
         'secrets': ['SSH_KEY'],


### PR DESCRIPTION
Over the weekend we had a situation where there was a bulk update to the metadata. Commits seem to do an awful lot of IO operations, which normally isn't a big deal. But with all the changes to the metadata recently, it slowly pushed down the burnt balance to zero, at which point the system DoS'd itself and was never able to catch up.

![2019-12-16_21-06-42](https://user-images.githubusercontent.com/3467784/70909236-fa295100-2047-11ea-9a37-632589580aa6.png)

This code probably needs a bit of a cleanup, but it does what it says on the tin (I had to fake a few things in dev to get it to access prod):
```
In [4]: NetkanScheduler('.','.','TestyMcTestFace').can_schedule(50,False)                                                                                                                 
[2019-12-16 13:00:47,018] [INFO    ] Found credentials in environment variables.
288.0 <--- Print of CPU Credits
31.4 <--- Print of volume burst credit percentage
```
It might do us well to check the outbound queue as well. But as a general rule the indexer is not the bottle neck as most inflations don't involve metadata changes (lucky to get a handful per run) and thus is normally processing them at a much faster rate than the inflator can inflate them.