### PR TITLE
Set up Discord notifications earlier in Webhooks

### DIFF
--- a/netkan/netkan/webhooks/__init__.py
+++ b/netkan/netkan/webhooks/__init__.py
@@ -1,9 +1,10 @@
 import os
+import sys
 import boto3
 from flask import Flask
 
 from ..utils import init_repo, init_ssh
-from ..notifications import setup_log_handler
+from ..notifications import setup_log_handler, catch_all
 from .errors import errors
 from .inflate import inflate
 from .spacedock_inflate import spacedock_inflate
@@ -12,7 +13,8 @@ from .github_inflate import github_inflate
 
 def create_app():
     # Set up Discord logger so we can see errors
-    setup_log_handler()
+    if setup_log_handler():
+        sys.excepthook = catch_all
 
     app = Flask(__name__)
 

--- a/netkan/netkan/webhooks/__init__.py
+++ b/netkan/netkan/webhooks/__init__.py
@@ -11,6 +11,9 @@ from .github_inflate import github_inflate
 
 
 def create_app():
+    # Set up Discord logger so we can see errors
+    setup_log_handler()
+
     app = Flask(__name__)
 
     init_ssh(os.environ.get('SSH_KEY'), '/home/netkan/.ssh')
@@ -30,8 +33,5 @@ def create_app():
     app.register_blueprint(inflate)
     app.register_blueprint(spacedock_inflate, url_prefix='/sd')
     app.register_blueprint(github_inflate, url_prefix='/gh')
-
-    # Set up Discord logger so we can see errors
-    setup_log_handler()
 
     return app


### PR DESCRIPTION
## Problem

The NetKAN inflation Webhooks are failing currently. GitHub receives:

```html
<html>
<head><title>502 Bad Gateway</title></head>
<body>
<center><h1>502 Bad Gateway</h1></center>
<hr><center>nginx/1.17.6</center>
</body>
</html>
```

## Cause

Researching that error, it seems it can happen if the nginx proxy is unable to connect to the upstream server. This would happen if the Webhooks crashed somehow. No stack traces have been printed to Discord, so whatever the problem is, it must be happening before the Discord hook is initialized.

This suggests there was a problem with #108, which edited the initialization function for the Webhooks and was merged around the time this started happening (Dec 16). Unfortunately I don't see any problems with that change upon auditing the code, so we'll need more information to devise a fix.

## Changes

Now the first thing the Webhooks do is set up the Discord integration. This way we will be notified if there's an exception during the rest of the initialization. We also now set `sys.excepthook` to catch uncaught exceptions, since otherwise I think these might not be reported.