### PR TITLE
Set More Conservative Burst Limit

### DIFF
--- a/netkan/netkan/scheduler.py
+++ b/netkan/netkan/scheduler.py
@@ -113,12 +113,14 @@ class NetkanScheduler:
                 return False
 
             # Volume Burst balance measured in a percentage of 5.4million credits. Credits are
-            # accrued at a rate of 3 per GB, per second. If we are are down to 30 percent of
-            # our max, something has gone wrong and we should not queue any more inflations.
+            # accrued at a rate of 3 per GB, per second. If we are are down to 70 percent of
+            # our max, something has likely gone wrong and we should not queue any more
+            # inflations. A regular run seems to cosume between 10-15%
             vol_credits_percent = self.volume_credits_percent(cloudwatch, instance_id, start, end)
-            if vol_credits_percent < 30:
+            if vol_credits_percent < 70:
                 logging.error(
-                    "Run skipped, below volume credit target (Current Avg: %s %)", vol_credits_percent
+                    "Run skipped, below volume credit target pertcentage (Current Avg: %s)",
+                    vol_credits_percent
                 )
                 return False
 


### PR DESCRIPTION
We hit a situation where our burst credits dropped below a point where the indexer could recover from it. This PR sets a more conservative limit and also adds a quick fix to the logging line that was possibly preventing the log to show up in our notifications.
![2019-12-28_12-04-19](https://user-images.githubusercontent.com/3467784/71538706-7ab25080-296a-11ea-8a7e-56a32cc7e565.png)
