### PR TITLE
Change absolute pathes to cache and .ssh to relative ones

### DIFF
--- a/netkan/Dockerfile
+++ b/netkan/Dockerfile
@@ -1,7 +1,6 @@
 FROM python:3.7 as base
 RUN useradd -ms /bin/bash netkan
 ADD . /netkan
-RUN chown -R netkan:netkan /netkan
 WORKDIR /netkan
 USER netkan
 RUN pip install --user . --no-warn-script-location
@@ -22,7 +21,6 @@ CMD ["--help"]
 FROM production as dev
 USER root
 ADD . /netkan
-RUN chown -R netkan:netkan /netkan
 ADD run_dev.sh /usr/local/bin/
 USER netkan
 RUN pip install --user /netkan/.[development]

--- a/netkan/Dockerfile
+++ b/netkan/Dockerfile
@@ -1,6 +1,7 @@
 FROM python:3.7 as base
 RUN useradd -ms /bin/bash netkan
 ADD . /netkan
+RUN chown -R netkan:netkan /netkan
 WORKDIR /netkan
 USER netkan
 RUN pip install --user . --no-warn-script-location
@@ -21,6 +22,7 @@ CMD ["--help"]
 FROM production as dev
 USER root
 ADD . /netkan
+RUN chown -R netkan:netkan /netkan
 ADD run_dev.sh /usr/local/bin/
 USER netkan
 RUN pip install --user /netkan/.[development]

--- a/netkan/netkan/cli.py
+++ b/netkan/netkan/cli.py
@@ -60,7 +60,7 @@ def netkan(debug):
     help='SSH key for accessing repositories',
 )
 def indexer(queue, ckanmeta_remote, token, repo, user, key, timeout):
-    init_ssh(key,  str(Path.home()) + '/.ssh')
+    init_ssh(key,  Path(Path.home(), '.ssh'))
     ckan_meta = init_repo(ckanmeta_remote, '/tmp/CKAN-meta')
 
     github_pr = GitHubPR(token, repo, user)
@@ -120,7 +120,7 @@ def indexer(queue, ckanmeta_remote, token, repo, user, key, timeout):
     help='Only schedule if we have at least this many credits remaining',
 )
 def scheduler(queue, netkan_remote, ckanmeta_remote, key, max_queued, dev, group, min_credits):
-    init_ssh(key, str(Path.home()) + '/.ssh')
+    init_ssh(key, Path(Path.home(), '.ssh'))
     sched = NetkanScheduler(
         Path('/tmp/NetKAN'), Path('/tmp/CKAN-meta'), queue,
         nonhooks_group=(group == 'all' or group == 'nonhooks'),
@@ -228,7 +228,8 @@ def redeploy_service(cluster, service_name):
 )
 @click.option(
     '--cache', envvar='NETKAN_CACHE', default=str(Path.home()) + '/ckan_cache/',
-    help='Absolute path to the mod download cache',
+    type=click.Path(exists=True, writable=True),
+    help='Absolute path to the mod download cache'
 )
 def clean_cache(days, cache):
     older_than = (
@@ -261,7 +262,7 @@ def clean_cache(days, cache):
     help='SSH key for accessing repositories',
 )
 def download_counter(netkan_remote, ckanmeta_remote, token, key):
-    init_ssh(key, str(Path.home()) + '/.ssh')
+    init_ssh(key, Path(Path.home(), '.ssh'))
     init_repo(netkan_remote, '/tmp/NetKAN')
     meta = init_repo(ckanmeta_remote, '/tmp/CKAN-meta')
     logging.info('Starting Download Count Calculation...')
@@ -312,7 +313,7 @@ def ticket_closer(token, days_limit):
     help='SSH key for accessing repositories',
 )
 def auto_freezer(netkan_remote, token, repo, user, days_limit, key):
-    init_ssh(key, str(Path.home()) + '/.ssh')
+    init_ssh(key, Path(Path.home(), '.ssh'))
     af = AutoFreezer(
         init_repo(netkan_remote, '/tmp/NetKAN'),
         GitHubPR(token, repo, user)

--- a/netkan/netkan/cli.py
+++ b/netkan/netkan/cli.py
@@ -60,7 +60,7 @@ def netkan(debug):
     help='SSH key for accessing repositories',
 )
 def indexer(queue, ckanmeta_remote, token, repo, user, key, timeout):
-    init_ssh(key, '/home/netkan/.ssh')
+    init_ssh(key,  str(Path.home()) + '/.ssh')
     ckan_meta = init_repo(ckanmeta_remote, '/tmp/CKAN-meta')
 
     github_pr = GitHubPR(token, repo, user)
@@ -120,7 +120,7 @@ def indexer(queue, ckanmeta_remote, token, repo, user, key, timeout):
     help='Only schedule if we have at least this many credits remaining',
 )
 def scheduler(queue, netkan_remote, ckanmeta_remote, key, max_queued, dev, group, min_credits):
-    init_ssh(key, '/home/netkan/.ssh')
+    init_ssh(key, str(Path.home()) + '/.ssh')
     sched = NetkanScheduler(
         Path('/tmp/NetKAN'), Path('/tmp/CKAN-meta'), queue,
         nonhooks_group=(group == 'all' or group == 'nonhooks'),
@@ -226,12 +226,16 @@ def redeploy_service(cluster, service_name):
 @click.option(
     '--days', help='Purge items older than X from cache',
 )
-def clean_cache(days):
+@click.option(
+    '--cache', envvar='NETKAN_CACHE', default=str(Path.home()) + '/ckan_cache/',
+    help='Absolute path to the mod download cache',
+)
+def clean_cache(days, cache):
     older_than = (
         datetime.datetime.now() - datetime.timedelta(days=int(days))
     ).timestamp()
     click.echo('Checking cache for files older than {} days'.format(days))
-    for item in Path('/home/netkan/ckan_cache/').glob('*'):
+    for item in Path(cache).glob('*'):
         if item.is_file() and item.stat().st_mtime < older_than:
             click.echo('Purging {} from ckan cache'.format(
                 item.name
@@ -257,7 +261,7 @@ def clean_cache(days):
     help='SSH key for accessing repositories',
 )
 def download_counter(netkan_remote, ckanmeta_remote, token, key):
-    init_ssh(key, '/home/netkan/.ssh')
+    init_ssh(key, str(Path.home()) + '/.ssh')
     init_repo(netkan_remote, '/tmp/NetKAN')
     meta = init_repo(ckanmeta_remote, '/tmp/CKAN-meta')
     logging.info('Starting Download Count Calculation...')
@@ -308,7 +312,7 @@ def ticket_closer(token, days_limit):
     help='SSH key for accessing repositories',
 )
 def auto_freezer(netkan_remote, token, repo, user, days_limit, key):
-    init_ssh(key, '/home/netkan/.ssh')
+    init_ssh(key, str(Path.home()) + '/.ssh')
     af = AutoFreezer(
         init_repo(netkan_remote, '/tmp/NetKAN'),
         GitHubPR(token, repo, user)

--- a/netkan/netkan/utils.py
+++ b/netkan/netkan/utils.py
@@ -1,6 +1,5 @@
 import logging
 import subprocess
-import sys
 from git import Repo
 from pathlib import Path
 

--- a/netkan/netkan/utils.py
+++ b/netkan/netkan/utils.py
@@ -14,12 +14,11 @@ def init_repo(metadata, path):
     return repo
 
 
-def init_ssh(key, path):
+def init_ssh(key, key_path: Path):
     if not key:
         logging.warning('Private Key required for SSH Git')
         return
     logging.info('Private Key found, writing to disk')
-    key_path = Path(path)
     key_path.mkdir(exist_ok=True)
     key_file = Path(key_path, 'id_rsa')
     if not key_file.exists():

--- a/netkan/netkan/webhooks/__init__.py
+++ b/netkan/netkan/webhooks/__init__.py
@@ -2,6 +2,7 @@ import os
 import sys
 import boto3
 from flask import Flask
+from pathlib import Path
 
 from ..utils import init_repo, init_ssh
 from ..notifications import setup_log_handler, catch_all
@@ -18,7 +19,7 @@ def create_app():
 
     app = Flask(__name__)
 
-    init_ssh(os.environ.get('SSH_KEY'), '/home/netkan/.ssh')
+    init_ssh(os.environ.get('SSH_KEY'), str(Path.home()) + '/.ssh')
 
     # Set up config
     app.config['secret'] = os.environ.get('XKAN_GHSECRET')

--- a/netkan/netkan/webhooks/__init__.py
+++ b/netkan/netkan/webhooks/__init__.py
@@ -19,7 +19,7 @@ def create_app():
 
     app = Flask(__name__)
 
-    init_ssh(os.environ.get('SSH_KEY'), str(Path.home()) + '/.ssh')
+    init_ssh(os.environ.get('SSH_KEY'), Path(Path.home(), '.ssh'))
 
     # Set up config
     app.config['secret'] = os.environ.get('XKAN_GHSECRET')

--- a/netkan/tests/cli.py
+++ b/netkan/tests/cli.py
@@ -5,22 +5,21 @@ from time import time
 from os import utime
 from pathlib import Path, PurePath
 from shutil import copy2
+from tempfile import TemporaryDirectory
 from click.testing import CliRunner
 
 
 # This file is intended to test the commands in cli.py, running them directly via click.testing.CliRunner().invoke().
 class TestCleanCache(unittest.TestCase):
 
-    cache_path = Path(PurePath(__file__).parent, 'test_cache')
+    cache_path = TemporaryDirectory()
     testdata_path = Path(PurePath(__file__).parent, 'testdata/NetKAN/NetKAN/')
-
-    cache_path.mkdir(exist_ok=True)
 
     source_file_1 = Path(testdata_path, 'DogeCoinFlag.netkan')
     source_file_2 = Path(testdata_path, 'FlagCoinDoge.netkan')
     # Pretend they are zip files.
-    target_file_1 = Path(cache_path, 'DogeCoinFlag.zip')
-    target_file_2 = Path(cache_path, 'FlagCoinDoge.zip')
+    target_file_1 = Path(cache_path.name, 'DogeCoinFlag.zip')
+    target_file_2 = Path(cache_path.name, 'FlagCoinDoge.zip')
 
     def setUp(self):
 
@@ -38,14 +37,11 @@ class TestCleanCache(unittest.TestCase):
 
     def tearDown(self):
 
-        if self.target_file_1.exists():
-            self.target_file_1.unlink()
-        if self.target_file_2.exists():
-            self.target_file_2.unlink()
+        self.cache_path.cleanup()
 
     def test_clean_all(self):
 
-        result = self.runner.invoke(clean_cache, ['--days', '42', '--cache', str(self.cache_path)])
+        result = self.runner.invoke(clean_cache, ['--days', '42', '--cache', self.cache_path.name])
 
         self.assertEqual(result.exit_code, 0)
         self.assertFalse(Path.exists(self.target_file_1))

--- a/netkan/tests/cli.py
+++ b/netkan/tests/cli.py
@@ -8,10 +8,10 @@ from shutil import copy2
 from click.testing import CliRunner
 
 
-# This file is intended to test the command in cli.py, running them directly via click.testing.CliRunner().invoke().
+# This file is intended to test the commands in cli.py, running them directly via click.testing.CliRunner().invoke().
 class TestCleanCache(unittest.TestCase):
 
-    cache_path = Path('/home/netkan/ckan_cache/')
+    cache_path = Path(PurePath(__file__).parent, 'test_cache')
     testdata_path = Path(PurePath(__file__).parent, 'testdata/NetKAN/NetKAN/')
 
     cache_path.mkdir(exist_ok=True)
@@ -45,7 +45,7 @@ class TestCleanCache(unittest.TestCase):
 
     def test_clean_all(self):
 
-        result = self.runner.invoke(clean_cache, ['--days', '42'])
+        result = self.runner.invoke(clean_cache, ['--days', '42', '--cache', str(self.cache_path)])
 
         self.assertEqual(result.exit_code, 0)
         self.assertFalse(Path.exists(self.target_file_1))


### PR DESCRIPTION
## Problem
In #76 I added a test for `cli.clean_cache()`. Because `clean_cache()` uses an absolute path to the cache (`/home/netkan/ckan_cache`) this thest failed when running the tests outside a Docker container.

## Changes
All paths beginning with `/home/netkan` have been replaced with `Path.home()`.
Those were only pointing either to `/home/netkan/.ssh/` or `/home/netkan/ckan_cache/`.
`clean_cache()` takes another argument, `--cache` which is the path to the cache directory it should use. It defaults to `str(Path.home()) + '/ckan_cache/`.

The `test_clean_cache()` creates a `test_cache` folder in it's parent directory, which is used to run the test (better than running them in `/home/{user}/ckan_cache` which will be used for production later on, and creating folders on the host machine of devs running the tests).

The Dockerfile needed an update to `chown -R netkan:netkan` the `/netkan` folder in which the `test_cache` folder is created during the tests in the container.