### PR TITLE
Allow Builder permissions to Restart Adder

### DIFF
--- a/prod-stack.py
+++ b/prod-stack.py
@@ -402,7 +402,7 @@ netkan_scheduler_role = t.add_resource(Role(
 # redeployment of services.
 ksp_builder_group = t.add_resource(Group("KspCkanBuilderGroup"))
 builder_services = []
-for service in ['Indexer', 'Inflator', 'Webhooks']:
+for service in ['Indexer', 'Inflator', 'Webhooks', 'Adder']:
     builder_services.append(
         Sub(
             'arn:aws:ecs:${AWS::Region}:${AWS::AccountId}:service/NetKANCluster/${service}',


### PR DESCRIPTION
Missed this in the last PR. Noted by the failed build.