### PR TITLE
Break up long Discord messages

### DIFF
--- a/netkan/netkan/notifications.py
+++ b/netkan/netkan/notifications.py
@@ -20,7 +20,17 @@ class DiscordLogHandler(logging.Handler):
 
     def emit(self, record):
         fmt = self.format(record)
-        self.webhook.send(f'```{fmt}```' if "\n" in fmt else fmt)
+        as_code = "\n" in fmt
+        for part in self._message_parts(fmt, as_code):
+            self.webhook.send(part)
+
+
+    @staticmethod
+    def _message_parts(msg, as_code, max_len=2000):
+        if as_code:
+            return (f'```{msg[start:start+max_len-6]}```'
+                    for start in range(0, len(msg), max_len - 6))
+        return (msg[start:start+max_len] for start in range(0, len(msg), max_len))
 
 
 def setup_log_handler(debug=False):


### PR DESCRIPTION
## Problem

If a `logging.error` message is longer than 2000 bytes:

```
Error in sys.excepthook:
Traceback (most recent call last):
  File "/usr/local/lib/python3.7/logging/__init__.py", line 894, in handle
    self.emit(record)
  File "/home/netkan/.local/lib/python3.7/site-packages/netkan/notifications.py", line 23, in emit
    self.webhook.send(f'```{fmt}```' if "\n" in fmt else fmt)
  File "/home/netkan/.local/lib/python3.7/site-packages/discord/webhook.py", line 744, in send
    return self._adapter.execute_webhook(wait=wait, file=file, files=files, payload=payload)
  File "/home/netkan/.local/lib/python3.7/site-packages/discord/webhook.py", line 147, in execute_webhook
    maybe_coro = self.request('POST', url, multipart=multipart, payload=data, files=files_to_pass)
  File "/home/netkan/.local/lib/python3.7/site-packages/discord/webhook.py", line 310, in request
    raise HTTPException(r, response)
discord.errors.HTTPException: 400 BAD REQUEST (error code: 50035): Invalid Form Body
In content: Must be 2000 or fewer in length.
```

## Changes

Now we split an error up into 2000-byte chunks and send them one at a time.
Shorter messages will be treated the same as before.

Fixes #117.