### PR TITLE
Preload flask app before forking

### DIFF
--- a/prod-stack.py
+++ b/prod-stack.py
@@ -755,7 +755,7 @@ services = [
                 'entrypoint': '.local/bin/gunicorn',
                 'command': [
                     '-b', '0.0.0.0:5000', '--access-logfile', '-',
-                    'netkan.webhooks:create_app()'
+                    '--preload', 'netkan.webhooks:create_app()'
                 ],
                 'secrets': [
                     'XKAN_GHSECRET', 'SSH_KEY',


### PR DESCRIPTION
@HebaruSan pointed out there is a `--preload` option in Gunicorn.

> Or, I was just looking at `--preload` today. Maybe this would allow the setup to complete before the workers are spawned.
>
> https://docs.gunicorn.org/en/stable/settings.html#preload-app
>
> _Originally posted by @HebaruSan in https://github.com/KSP-CKAN/NetKAN-Infra/issues/123#issuecomment-578372372_

Applying it to the stack, it appears to do what it says on the tin.

```
$ docker logs -f 764473186f02
# github.com:22 SSH-2.0-babeld-1f0633a6
[2020-01-27 02:47:58 +0000] [1] [INFO] Starting gunicorn 20.0.4
[2020-01-27 02:47:58 +0000] [1] [INFO] Listening at: http://0.0.0.0:5000 (1)
[2020-01-27 02:47:58 +0000] [1] [INFO] Using worker: sync
[2020-01-27 02:47:58 +0000] [30] [INFO] Booting worker with pid: 30
```
Fixes #123