### PR TITLE
Cast header values to string

### DIFF
--- a/netkan/netkan/mirrorer.py
+++ b/netkan/netkan/mirrorer.py
@@ -105,8 +105,8 @@ class Mirrorer:
             **({'licenseurl': lic_urls} if lic_urls else {}),
         }, {
             'Content-Type':           ckan.download_content_type,
-            'Content-Length':         ckan.download_size,
-            'x-amz-auto-make-bucket': 1,
+            'Content-Length':         str(ckan.download_size),
+            'x-amz-auto-make-bucket': str(1),
         })
 
     @staticmethod


### PR DESCRIPTION
## Problem

When attempting to archive a mod:

```
Uncaught exception:
Traceback (most recent call last):
  File "/home/netkan/.local/lib/python3.7/site-packages/requests/utils.py", line 941, in check_header_validity
    if not pat.match(value):
TypeError: expected string or bytes-like object

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File ".local/bin/netkan", line 8, in <module>
    sys.exit(netkan())
  File "/home/netkan/.local/lib/python3.7/site-packages/click/core.py", line 764, in __call__
    return self.main(*args, **kwargs)
  File "/home/netkan/.local/lib/python3.7/site-packages/click/core.py", line 717, in main
    rv = self.invoke(ctx)
  File "/home/netkan/.local/lib/python3.7/site-packages/click/core.py", line 1137, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/home/netkan/.local/lib/python3.7/site-packages/click/core.py", line 956, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "/home/netkan/.local/lib/python3.7/site-packages/click/core.py", line 555, in invoke
    return callback(*args, **kwargs)
  File "/home/netkan/.local/lib/python3.7/site-packages/netkan/cli.py", line 366, in mirrorer
    ).process_queue(timeout)
  File "/home/netkan/.local/lib/python3.7/site-packages/netkan/mirrorer.py", line 54, in process_queue
    if self.try_mirror(CkanMirror(path)):
  File "/home/netkan/.local/lib/python3.7/site-packages/netkan/mirrorer.py", line 82, in try_mirror
    return self.try_upload(ckan, tmp.file)
  File "/home/netkan/.local/lib/python3.7/site-packages/netkan/mirrorer.py", line 110, in try_upload
    'x-amz-auto-make-bucket': 1,
  File "/home/netkan/.local/lib/python3.7/site-packages/internetarchive/item.py", line 840, in upload_file
    prepared_request = request.prepare()
  File "/home/netkan/.local/lib/python3.7/site-packages/internetarchive/iarequest.py", line 84, in prepare
    queue_derive=self.queue_derive,
  File "/home/netkan/.local/lib/python3.7/site-packages/internetarchive/iarequest.py", line 100, in prepare
    self.prepare_headers(headers, metadata, queue_derive)
  File "/home/netkan/.local/lib/python3.7/site-packages/internetarchive/iarequest.py", line 158, in prepare_headers
    super(S3PreparedRequest, self).prepare_headers(headers)
  File "/home/netkan/.local/lib/python3.7/site-packages/requests/models.py", line 448, in prepare_headers
    check_header_validity(header)
  File "/home/netkan/.local/lib/python3.7/site-packages/requests/utils.py", line 945, in check_header_validity
    "bytes, not %s" % (name, value, type(value)))
requests.exceptions.InvalidHeader: Value for header {Content-Length: 88593} must be of type str or bytes, not <class 'int'>
```

## Cause

We pass integers for `Content-Length` and `x-amz-auto-make-bucket`. Apparently `internetarchive` doesn't like that?

## Changes

Now they're strings.