### PR TITLE
Fix mirror filenames and epochs

### DIFF
--- a/netkan/netkan/cli.py
+++ b/netkan/netkan/cli.py
@@ -361,9 +361,9 @@ def auto_freezer(netkan_remote, token, repo, user, days_limit, key):
 def mirrorer(queue, timeout, ckan_meta, ia_access, ia_secret, ia_collection, key):
     init_ssh(key, Path(Path.home(), '.ssh'))
     Mirrorer(
-        init_repo(ckan_meta, '/tmp/CKAN-meta'), queue,
+        init_repo(ckan_meta, '/tmp/CKAN-meta'),
         ia_access, ia_secret, ia_collection
-    ).process_queue(timeout)
+    ).process_queue(queue, timeout)
 
 
 @click.command()


### PR DESCRIPTION
## Problems

- https://archive.org/download/EditorExtensionsRedux-3.4.1 is the new mirrorer's first archive and https://archive.org/download/NovaPunchRebalanced-Thor-0.1.7.1 is the legacy mirrorer's last. Comparing them, the new code is using the wrong filename; the hash and extension are missing:
  ![image](https://user-images.githubusercontent.com/1559108/73301998-813a1f00-41d9-11ea-84d5-25657dd89edb.png)
  ![image](https://user-images.githubusercontent.com/1559108/73302018-88f9c380-41d9-11ea-87ff-607ecd6d437c.png)
- The new mirrorer currently drops epochs from names, titles, filenames, etc. This is wrong because we're trying to implement "like-for-like" until we can devise an effective migration strategy for the client to remove epochs. Luckily it has not yet archived a module with an epoch.
- The `mirror_purge_epochs` command is broken, because `Mirrorer`'s constructor requires a `queue` parameter that it cannot provide

## Causes

- We're passing `CkanMirror.mirror_item()`, which is identifier-hyphen-version, as the key, which [the documentation](https://archive.org/services/docs/api/internetarchive/internetarchive.html#internetarchive.Item.upload_file) explains thusly:
  ![image](https://user-images.githubusercontent.com/1559108/73302373-281ebb00-41da-11ea-83c8-83547e184bd9.png)
  Meanwhile the `CkanMirror.mirror_filename()` is not used at all.
- The `with_epoch` params had a default of `False`
- Emergency changes copied from prod in #126 to get the core mirrorer working

## Changes

- Now we pass `CkanMirror.mirror_filename()` as the key instead
- Now the default for `with_epoch` is `True`
- Now `Mirrorer.__init__`'s `queue` param is moved back to `process_queue`

Fixes #128.