### PR TITLE
Fix SpaceDock API format and docs

### DIFF
--- a/netkan/netkan/webhooks/spacedock_add.py
+++ b/netkan/netkan/webhooks/spacedock_add.py
@@ -10,26 +10,22 @@ spacedock_add = Blueprint('spacedock_add', __name__)  # pylint: disable=invalid-
 
 # For mod creation hook on SpaceDock, creates pull requests
 # Handles: https://netkan.ksp-ckan.space/sd/add
-# POST json input:
-#   {
-#     "name":              "Mod Name Entered by the User on SpaceDock",
-#     "id":                "12345",
-#     "license":           "GPL-3.0",
-#     "username":          "ModAuthor1",
-#     "email":             "modauthor1@gmail.com",
-#     "short_description": "A mod that you should definitely install",
-#     "description":       "A mod that you should definitely install, and so on and so on",
-#     "external_link":     "https://forum.kerbalspaceprogram.com/index.php?/topic/999999-ThreadTitle",
-#     "user_url":          "https://spacedock.info/profile/ModAuthor1",
-#     "mod_url":           "https://spacedock.info/mod/12345",
-#     "site_name":         "SpaceDock"
-#   }
+# POST form parameters:
+#     name:              Mod Name Entered by the User on spacedock
+#     id:                12345
+#     license:           GPL-3.0
+#     username:          modauthor1
+#     email:             modauthor1@gmail.com
+#     short_description: A mod that you should definitely install
+#     description:       A mod that you should definitely install, and so on and so on
+#     external_link:     https://forum.kerbalspaceprogram.com/index.php?/topic/999999-ThreadTitle
+#     user_url:          https://spacedock.info/profile/ModAuthor1
+#     mod_url:           https://spacedock.info/mod/12345
+#     site_name:         SpaceDock
 @spacedock_add.route('/add', methods=['POST'])
 def add_hook():
-    raw = request.get_json(silent=True)
-
     # Submit add requests to queue in batches of <=10
-    messages = [batch_message(raw)]
+    messages = [batch_message(request.form)]
     for batch in sqs_batch_entries(messages):
         current_app.logger.info(f'Queueing add request batch: {batch}')
         current_app.config['client'].send_message_batch(

--- a/netkan/netkan/webhooks/spacedock_inflate.py
+++ b/netkan/netkan/webhooks/spacedock_inflate.py
@@ -10,7 +10,9 @@ spacedock_inflate = Blueprint('spacedock_inflate', __name__)  # pylint: disable=
 
 # For after-upload hook on SpaceDock
 # Handles: https://netkan.ksp-ckan.space/sd/inflate
-# POST form parameters: mod_id=1234&event_type=update
+# POST form parameters:
+#     mod_id:     The mod's ID number on SpaceDock
+#     event_type: update
 @spacedock_inflate.route('/inflate', methods=['POST'])
 def inflate_hook():
     # Make sure our NetKAN and CKAN-meta repos are up to date


### PR DESCRIPTION
## Problem

While investigating KSP-SpaceDock/SpaceDock#232, I noticed some errors in the new (not yet used) SpaceDock web hooks:

- `/sd/inflate`'s documentation makes it look like it receives its parameters from the URL separated by `?` and `=` and `&`, but what I intended (and implemented in code) was for it to match the existing SpaceDock-Notify project (so it could be a drop-in replacement), which retrieves inputs from the form parameters of the POST request
- `/sd/add` extracts its inputs from the POST body as JSON, but I meant for it to use the same method of receiving parameters as `/sd/inflate`, since this would be simpler for both CKAN and SD maintenance

## Changes

- Now `/sd/inflate`'s documentation is updated to make it clearer that its input is from the POST params
- Now `/sd/add` is updated to get its inputs from POST params, and its documentation is updated to match. [`request.form` is an `ImmutableMultiDict`](https://flask.palletsprojects.com/en/1.1.x/api/#flask.Request.form), so it should be OK to pass it to `batch_message` which will make a string out of it using `json.dumps`.

These changes will expedite efforts to migrate SpaceDock over to these new APIs.