### PR TITLE
Check SHA1 of mirrored files

### DIFF
--- a/netkan/netkan/mirrorer.py
+++ b/netkan/netkan/mirrorer.py
@@ -278,8 +278,13 @@ class CkanMirror(Ckan):
         )
 
     def mirrored(self, iarchive):
-        results = iarchive.search_items(self.mirror_item())
-        return True if results else False
+        item = iarchive.get_item(self.mirror_item())
+        if not item:
+            return False
+        if not item.exists:
+            return False
+        sha1 = self.download_hash['sha1'].lower()
+        return any(file['sha1'].lower() == sha1 for file in item.files if 'sha1' in file)
 
     def license_urls(self):
         return [self.LICENSE_URLS[lic]


### PR DESCRIPTION
## Problem

`CkanMirror.mirrored()` currently returns `True` if its `Item` exists on archive.org even if the file is not there. The legacy mirror hook checked for a file with a matching SHA1. This is blocking the re-upload of EditorExtensionsRedux-3.4.1.

## Changes

Now `CkanMirror.mirrored()` only returns `True` if it finds a file with a matching SHA1, like the old hook did.

Fixes #131.