### PR TITLE
Add missing deletion message code in adder

### DIFF
--- a/netkan/netkan/spacedock_adder.py
+++ b/netkan/netkan/spacedock_adder.py
@@ -88,6 +88,13 @@ class SpaceDockAdder:
         )
         return True
 
+    @staticmethod
+    def deletion_msg(msg):
+        return {
+            'Id':            msg.message_id,
+            'ReceiptHandle': msg.receipt_handle,
+        }
+
     def make_netkan(self, info):
         return {
             'spec_version': 'v1.4',


### PR DESCRIPTION
## Problem

The Adder tries to call an undefined `deletion_msg` function here:

https://github.com/KSP-CKAN/NetKAN-Infra/blob/3eb3b0a98831261119320e73cca6cf081dd67b98/netkan/netkan/spacedock_adder.py#L39

## Cause

I think I created this file by copying the Mirrorer and then deleting everything that wasn't needed for the Adder, and I mistakenly thought `deletion_msg` wasn't needed.

## Changes

Now it's copied over from the Mirrorer.