### PR TITLE
Archive source code

### DIFF
--- a/netkan/netkan/mirrorer.py
+++ b/netkan/netkan/mirrorer.py
@@ -50,7 +50,7 @@ class Mirrorer:
                 to_delete = []
                 for msg in messages:
                     path = Path(self.ckan_meta_repo.working_dir, msg.body)
-                    if self.try_mirror(CkanMirror(path, self.ia_collection)):
+                    if self.try_mirror(CkanMirror(self.ia_collection, path)):
                         # Successfully handled -> OK to delete
                         to_delete.append(self.deletion_msg(msg))
                 queue.delete_messages(Entries=to_delete)
@@ -247,8 +247,8 @@ class CkanMirror(Ckan):
 
     EPOCH_VERSION_REGEXP = re.compile('^[0-9]+:')
 
-    def __init__(self, filename, collection):
-        Ckan.__init__(self, filename)
+    def __init__(self, collection, filename=None, contents=None):
+        Ckan.__init__(self, filename, contents)
         self.collection = collection
 
     @property

--- a/netkan/tests/mirrorer.py
+++ b/netkan/tests/mirrorer.py
@@ -19,6 +19,7 @@ class TestCkanMirrorRedistributable(unittest.TestCase):
             "author":       [ "techman83", "DasSkelett", "politas" ],
             "license":      [ "CC-BY-NC-SA-4.0", "GPL-3.0", "MIT" ],
             "download_content_type": "application/zip",
+            "download_size": 33333,
             "download_hash": {
                 "sha1": "DF564E21929EA07C624F822E5C43B7D0A3B0DBDF"
             }
@@ -41,7 +42,31 @@ class TestCkanMirrorRedistributable(unittest.TestCase):
         self.assertEqual(self.ckan_mirror.mirror_title(), "Awesome Mod - 1.0.0")
         self.assertEqual(self.ckan_mirror.mirror_description,
                          "A great mod<br><br>License(s): CC-BY-NC-SA-4.0 GPL-3.0 MIT")
+        self.assertEqual(self.ckan_mirror.mirror_source_filename(),
+                         "AwesomeMod-1.0.0.source.zip")
 
+    def test_ia_data(self):
+        self.assertEqual(self.ckan_mirror.item_metadata,
+                         {
+                             'title':       "Awesome Mod - 1.0.0",
+                             'description':
+                                 "A great mod<br><br>License(s): CC-BY-NC-SA-4.0 GPL-3.0 MIT",
+                             'creator':     ["techman83", "DasSkelett", "politas"],
+                             'collection':  "kspckanmods",
+                             'subject':     'ksp; kerbal space program; mod',
+                             'mediatype':   'software',
+                             'licenseurl':  [
+                                 'http://creativecommons.org/licenses/by-nc-sa/4.0',
+                                 'http://www.gnu.org/licenses/gpl-3.0.en.html',
+                                 'https://opensource.org/licenses/MIT',
+                             ],
+                         })
+        self.assertEqual(self.ckan_mirror.download_headers,
+                         {
+                             'Content-Type':           "application/zip",
+                             'Content-Length':         "33333",
+                             'x-amz-auto-make-bucket': "1",
+                         })
 
 class TestCkanMirrorRestricted(unittest.TestCase):
 
@@ -59,3 +84,45 @@ class TestCkanMirrorRestricted(unittest.TestCase):
     def test_can_mirror(self):
         self.assertFalse(self.ckan_mirror.redistributable)
         self.assertFalse(self.ckan_mirror.can_mirror)
+
+class TestCkanMirrorGitHub(unittest.TestCase):
+
+    def setUp(self):
+        self.ckan_mirror = CkanMirror("kspckanmods", contents="""{
+            "spec_version": "v1.4",
+            "resources": {
+                "repository": "https://github.com/HebaruSan/Astrogator/releases"
+            }
+        }""")
+
+    def test_source_download(self):
+        self.assertEqual(self.ckan_mirror.source_download,
+                         "https://github.com/HebaruSan/Astrogator/archive/master.zip")
+
+class TestCkanMirrorGitLab(unittest.TestCase):
+
+    def setUp(self):
+        self.ckan_mirror = CkanMirror("kspckanmods", contents="""{
+            "spec_version": "v1.4",
+            "resources": {
+                "repository": "https://gitlab.com/N70/Kerbalism/"
+            }
+        }""")
+
+    def test_source_download(self):
+        self.assertEqual(self.ckan_mirror.source_download,
+                         "https://gitlab.com/N70/Kerbalism/-/archive/master/Kerbalism-master.zip")
+
+class TestCkanMirrorButBucket(unittest.TestCase):
+
+    def setUp(self):
+        self.ckan_mirror = CkanMirror("kspckanmods", contents="""{
+            "spec_version": "v1.4",
+            "resources": {
+                "repository": "https://bitbucket.org/blowfishpro/b9-aerospace/src"
+            }
+        }""")
+
+    def test_source_download(self):
+        self.assertEqual(self.ckan_mirror.source_download,
+                         "https://bitbucket.org/blowfishpro/b9-aerospace/get/master.zip")

--- a/netkan/tests/mirrorer.py
+++ b/netkan/tests/mirrorer.py
@@ -9,7 +9,7 @@ from netkan.mirrorer import CkanMirror
 class TestCkanMirrorRedistributable(unittest.TestCase):
 
     def setUp(self):
-        self.ckan_mirror = CkanMirror(contents="""{
+        self.ckan_mirror = CkanMirror("kspckanmods", contents="""{
             "spec_version": "v1.4",
             "identifier":   "AwesomeMod",
             "name":         "Awesome Mod",
@@ -46,7 +46,7 @@ class TestCkanMirrorRedistributable(unittest.TestCase):
 class TestCkanMirrorRestricted(unittest.TestCase):
 
     def setUp(self):
-        self.ckan_mirror = CkanMirror(contents="""{
+        self.ckan_mirror = CkanMirror("kspckanmods", contents="""{
             "spec_version": "v1.4",
             "identifier":   "AwesomeMod",
             "version":      "1.0.0",


### PR DESCRIPTION
## Motivation

`Mirrorer` uploads mods with redistributable licenses to archive.org. However, some redistributable licenses are conditional; with the GPL, the source code must be available. If an author indexes a GPL-licensed mod on CKAN and then deletes the original source code repo, then it's not clear whether it's OK for our mirror to remain on archive.org.

## Changes

Now we attempt to archive source code as well.

- A bunch of logic is moved from `Mirrorer` to `Ckan` and `CkanMirror` ([~~which reminds me I forgot to add tests, will do that in a bit~~](https://github.com/KSP-CKAN/NetKAN-Infra/pull/136/commits/0f2b0afa584b6738a660be3bc6088487cc33986c))
- New property `Ckan.source_download` gives the URL to download a module's source based on `resources.repository`
- Most of what was once `Mirrorer.try_upload` is now farmed out to helper functions in `CkanMirror`, leaving behind only the core of the uploading logic, which is moved into `Mirrorer.try_mirror`
- `Mirrorer.try_mirror` now also has a new block that retrieves the source code and uploads it to the same item as an additional file
- If we download a module to a temp file, we now copy it to the cache and upload from the cache rather than uploading the temp file. This may or may not help with #133.

Fixes #111.