### PR TITLE
Fix Item Uploads

### DIFF
--- a/netkan/netkan/mirrorer.py
+++ b/netkan/netkan/mirrorer.py
@@ -74,7 +74,7 @@ class Mirrorer:
         logging.info('Uploading %s', ckan.mirror_item())
         item = internetarchive.Item(self.ia_session, ckan.mirror_item())
         item.upload_file(download_file.name, ckan.mirror_filename(),
-                         ckan.item_metadata(self.ia_collection),
+                         ckan.item_metadata,
                          ckan.download_headers)
         source_url = ckan.source_download
         if source_url:
@@ -82,7 +82,7 @@ class Mirrorer:
                 logging.info('Attempting to archive source from %s', source_url)
                 urllib.request.urlretrieve(source_url, tmp.name)
                 item.upload_file(tmp.name, ckan.mirror_source_filename(),
-                                 ckan.item_metadata(self.ia_collection),
+                                 ckan.item_metadata,
                                  ckan.source_download_headers(tmp.name))
         return True
 


### PR DESCRIPTION
This fixes a current file upload problem
```
Uncaught exception:
Traceback (most recent call last):
  File ".local/bin/netkan", line 8, in <module>
    sys.exit(netkan())
  File "/home/netkan/.local/lib/python3.7/site-packages/click/core.py", line 764, in __call__
    return self.main(*args, **kwargs)
  File "/home/netkan/.local/lib/python3.7/site-packages/click/core.py", line 717, in main
    rv = self.invoke(ctx)
  File "/home/netkan/.local/lib/python3.7/site-packages/click/core.py", line 1137, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/home/netkan/.local/lib/python3.7/site-packages/click/core.py", line 956, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "/home/netkan/.local/lib/python3.7/site-packages/click/core.py", line 555, in invoke
    return callback(*args, **kwargs)
  File "/home/netkan/.local/lib/python3.7/site-packages/click/decorators.py", line 64, in new_func
    return ctx.invoke(f, obj, *args, **kwargs)
  File "/home/netkan/.local/lib/python3.7/site-packages/click/core.py", line 555, in invoke
    return callback(*args, **kwargs)
  File "/home/netkan/.local/lib/python3.7/site-packages/netkan/cli/services.py", line 72, in mirrorer
    ).process_queue(common.queue, common.timeout)
  File "/home/netkan/.local/lib/python3.7/site-packages/netkan/mirrorer.py", line 53, in process_queue
    if self.try_mirror(CkanMirror(self.ia_collection, path)):
  File "/home/netkan/.local/lib/python3.7/site-packages/netkan/mirrorer.py", line 77, in try_mirror
    ckan.item_metadata(self.ia_collection),
TypeError: 'dict' object is not callable
```