### PR TITLE
Limit batch IDs to 80 chars

### DIFF
--- a/netkan/netkan/metadata.py
+++ b/netkan/netkan/metadata.py
@@ -76,7 +76,7 @@ class Netkan:
 
     def sqs_message(self, ckan_group=None):
         return {
-            'Id': self.identifier,
+            'Id': self.identifier[0:80],
             'MessageBody': self.contents,
             'MessageGroupId': '1',
             'MessageDeduplicationId': uuid.uuid4().hex,

--- a/netkan/netkan/webhooks/github_mirror.py
+++ b/netkan/netkan/webhooks/github_mirror.py
@@ -45,7 +45,7 @@ forbidden_id_chars = re.compile('[^-_A-Za-z0-9]')  # pylint: disable=invalid-nam
 def batch_message(path):
     body = path.as_posix()
     return {
-        'Id':                     forbidden_id_chars.sub('_', body),
+        'Id':                     forbidden_id_chars.sub('_', body)[0:80],
         'MessageBody':            body,
         'MessageGroupId':         '1',
         'MessageDeduplicationId': md5(body.encode()).hexdigest()


### PR DESCRIPTION
## Problem

After https://github.com/KSP-CKAN/CKAN-meta/commit/ffa80679ded15522ec8843dc706ad297a93bbbce :

```
Uncaught exception:
Traceback (most recent call last):
  File "/home/netkan/.local/lib/python3.7/site-packages/flask/app.py", line 1949, in full_dispatch_request
    rv = self.dispatch_request()
  File "/home/netkan/.local/lib/python3.7/site-packages/flask/app.py", line 1935, in dispatch_request
    return self.view_functions[rule.endpoint](**req.view_args)
  File "/home/netkan/.local/lib/python3.7/site-packages/netkan/webhooks/github_utils.py", line 14, in decorated_function
    return func(*args, **kwargs)
  File "/home/netkan/.local/lib/python3.7/site-packages/netkan/webhooks/github_mirror.py", line 37, in mirror_hook
    Entries=batch
  File "/home/netkan/.local/lib/python3.7/site-packages/botocore/client.py", line 276, in _api_call
    return self._make_api_call(operation_name, kwargs)
  File "/home/netkan/.local/lib/python3.7/site-packages/botocore/client.py", line 586, in _make_api_call
    raise error_class(parsed_response, operation_name)
botocore.errorfactory.InvalidBatchEntryId: An error occurred (AWS.SimpleQueueService.InvalidBatchEntryId) when calling the SendMessageBatch operation: A batch entry id can only contain alphanumeric characters, hyphens and underscores. It can be at most 80 letters long.
```

## Cause

This time the 80 character limit bit us. `ContractConfigurator-EpicSpaceProgram/ContractConfigurator-EpicSpaceProgram-0.1.ckan` is 84 characters long. 

## Changes

Now we truncate batch IDs to 80 chars.