### PR TITLE
Fix cache hashes

### DIFF
--- a/netkan/netkan/metadata.py
+++ b/netkan/netkan/metadata.py
@@ -119,7 +119,7 @@ class Ckan:
     def cache_prefix(self):
         if 'download' not in self._raw:
             return None
-        return sha1(self.download.encode()).hexdigest().upper()[0:8]
+        return sha1(urllib.parse.unquote(self.download).encode()).hexdigest().upper()[0:8]
 
     @property
     def cache_find_file(self):

--- a/netkan/tests/metadata.py
+++ b/netkan/tests/metadata.py
@@ -164,6 +164,24 @@ class TestCkanSimple(unittest.TestCase):
         self.assertEqual(self.ckan.cache_filename, "3C69B375-AwesomeMod-1.0.0.zip")
 
 
+class TestCkanSpacesInDownload(unittest.TestCase):
+
+    def setUp(self):
+        self.ckan = Ckan(contents="""{
+            "spec_version": "v1.4",
+            "identifier":   "NASA-CountDown",
+            "version":      "1.3.9.1",
+            "ksp_version":  "1.8",
+            "author":       "linuxgurugamer",
+            "license":      "CC-BY-NC-SA",
+            "download":     "https://spacedock.info/mod/1462/NASA%20CountDown%20Clock%20Updated/download/1.3.9.1",
+            "download_content_type": "application/zip"
+        }""")
+
+    def test_cache(self):
+        self.assertEqual(self.ckan.cache_prefix,   "25B8A610")
+        self.assertEqual(self.ckan.cache_filename, "25B8A610-NASA-CountDown-1.3.9.1.zip")
+
 class TestCkanComplex(unittest.TestCase):
 
     def setUp(self):


### PR DESCRIPTION
## Problem

The Mirrorer is re-downloading (some) files that the Inflator already downloaded. Prior to #137, this was in the `else` block for when the download isn't found in the cache, which shouldn't happen:

```
  File "/home/netkan/.local/lib/python3.7/site-packages/netkan/mirrorer.py", line 80, in try_mirror
    return self.try_upload(ckan, tmp.file)
```

## Cause

Verbose Inflator output and the Python REPL reveal that they're using different hashes:

![netkan](https://user-images.githubusercontent.com/1559108/73620577-86a8c680-462a-11ea-8283-2cc4be82b49a.png)

![python](https://user-images.githubusercontent.com/1559108/73620557-6d077f00-462a-11ea-9386-91489aff7a23.png)

The Inflator unencodes URLs (replaces `%20` with spaces) before it hashes them, and the Infra doesn't.

## Changes

Now `Ckan.cache_prefix` uses `urllib.parse.unquote` to emulate the Inflator's use of `Uri.ToString()`, and the hashes are the same, so cached downloads will be found.

Fixes #137.