### PR TITLE
Only mirror on master branch

### DIFF
--- a/netkan/netkan/webhooks/github_mirror.py
+++ b/netkan/netkan/webhooks/github_mirror.py
@@ -16,6 +16,11 @@ github_mirror = Blueprint('github_mirror', __name__)  # pylint: disable=invalid-
 @signature_required
 def mirror_hook():
     raw = request.get_json(silent=True)
+    branch = raw.get('ref')
+    if branch != 'ref/heads/master':
+        current_app.logger.info(
+            "Wrong branch. Expected '%s', got '%s'", 'ref/heads/master', branch)
+        return jsonify({'message': 'Wrong branch'}), 200
     commits = raw.get('commits')
     if not commits:
         current_app.logger.info('No commits received')


### PR DESCRIPTION
## Problem

```
Uncaught exception:
Traceback (most recent call last):
  File ".local/bin/netkan", line 8, in <module>
    sys.exit(netkan())
  File "/home/netkan/.local/lib/python3.7/site-packages/click/core.py", line 764, in __call__
    return self.main(*args, **kwargs)
  File "/home/netkan/.local/lib/python3.7/site-packages/click/core.py", line 717, in main
    rv = self.invoke(ctx)
  File "/home/netkan/.local/lib/python3.7/site-packages/click/core.py", line 1137, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/home/netkan/.local/lib/python3.7/site-packages/click/core.py", line 956, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "/home/netkan/.local/lib/python3.7/site-packages/click/core.py", line 555, in invoke
    return callback(*args, **kwargs)
  File "/home/netkan/.local/lib/python3.7/site-packages/click/decorators.py", line 64, in new_func
    return ctx.invoke(f, obj, *args, **kwargs)
  File "/home/netkan/.local/lib/python3.7/site-packages/click/core.py", line 555, in invoke
    return callback(*args, **kwargs)
  File "/home/netkan/.local/lib/python3.7/site-packages/netkan/cli/services.py", line 72, in mirrorer
    ).process_queue(common.queue, common.timeout)
  File "/home/netkan/.local/lib/python3.7/site-packages/netkan/mirrorer.py", line 53, in process_queue
    if self.try_mirror(CkanMirror(self.ia_collection, path)):
  File "/home/netkan/.local/lib/python3.7/site-packages/netkan/mirrorer.py", line 251, in __init__
    Ckan.__init__(self, filename, contents)
  File "/home/netkan/.local/lib/python3.7/site-packages/netkan/metadata.py", line 100, in __init__
    self.contents = self.filename.read_text()
  File "/usr/local/lib/python3.7/pathlib.py", line 1216, in read_text
    with self.open(mode='r', encoding=encoding, errors=errors) as f:
  File "/usr/local/lib/python3.7/pathlib.py", line 1203, in open
    opener=self._opener)
  File "/usr/local/lib/python3.7/pathlib.py", line 1058, in _opener
    return self._accessor.open(self, flags, mode)
FileNotFoundError: [Errno 2] No such file or directory: '/tmp/CKAN-meta/LessRealThanReal/LessRealThanReal-v1.0.ckan'
```

## Cause

This fired after KSP-CKAN/CKAN-meta#1776 was submitted. The file existed, but it was on a staging branch instead of master, where the Mirrorer looks for it.

## Changes

Now the `/gh/mirror` web hook checks the event's ref and stops processing if it's for a branch other than master.