### PR TITLE
Fix branch check

### DIFF
--- a/netkan/netkan/webhooks/github_mirror.py
+++ b/netkan/netkan/webhooks/github_mirror.py
@@ -16,10 +16,11 @@ github_mirror = Blueprint('github_mirror', __name__)  # pylint: disable=invalid-
 @signature_required
 def mirror_hook():
     raw = request.get_json(silent=True)
-    branch = raw.get('ref')
-    if branch != 'ref/heads/master':
+    ref = raw.get('ref')
+    expected_ref = current_app.config['ckanmeta_repo'].heads.master.path
+    if ref != expected_ref:
         current_app.logger.info(
-            "Wrong branch. Expected '%s', got '%s'", 'ref/heads/master', branch)
+            "Wrong branch. Expected '%s', got '%s'", expected_ref, ref)
         return jsonify({'message': 'Wrong branch'}), 200
     commits = raw.get('commits')
     if not commits:


### PR DESCRIPTION
## Problem

Mirroring stopped 4-5 days ago.

https://archive.org/details/kspckanmods?sort=-publicdate

## Cause

We used the string `ref/heads/master` in #144 to represent the master branch. Git uses `refs/heads/master`, so right now we consider all web hook requests to be on the wrong branch.

Compare the same check for SpaceDock:

https://github.com/KSP-SpaceDock/SpaceDock/blob/ccb56f7d876ebf40057669fa60720d29e62f5d78/KerbalStuff/app.py#L152-L157

## Changes

Now it says `refs/heads/master` instead.