### PR TITLE
Enable `init` on Indexer

### DIFF
--- a/prod-stack.py
+++ b/prod-stack.py
@@ -7,7 +7,7 @@ from troposphere.dynamodb import Table, KeySchema, AttributeDefinition, \
     ProvisionedThroughput
 from troposphere.ecs import Cluster, TaskDefinition, ContainerDefinition, \
     Service, Secret, Environment, DeploymentConfiguration, Volume, \
-    Host, MountPoint, PortMapping, ContainerDependency
+    Host, MountPoint, PortMapping, ContainerDependency, LinuxParameters
 from troposphere.ec2 import Instance, CreditSpecification, Tag, \
     BlockDeviceMapping, EBSBlockDevice
 from troposphere.cloudformation import Init, InitFile, InitFiles, \
@@ -605,6 +605,7 @@ services = [
         'volumes': [
             ('ckan_cache', '/home/netkan/ckan_cache')
         ],
+        'linux_parameters': LinuxParameters(InitProcessEnabled=True),
     },
     {
         'name': 'Scheduler',
@@ -823,6 +824,7 @@ for service in services:
         volumes = container.get('volumes', [])
         ports = container.get('ports', [])
         depends = container.get('depends', [])
+        linux_parameters = container.get('linux_parameters')
         definition = ContainerDefinition(
             Image=container.get('image', 'kspckan/netkan'),
             Memory=container.get('memory', '96'),
@@ -851,6 +853,8 @@ for service in services:
         if command:
             command = command if isinstance(command, list) else [command]
             definition.Command = command
+        if linux_parameters:
+            definition.LinuxParameters = linux_parameters
         for volume in volumes:
             volume_name = '{}{}'.format(
                 name,


### PR DESCRIPTION
ECS has support for linux parameters, one of them being the `init` flag. Docker included tini as an init option, that will take care of the usual tasks an init system would do, in this case reaping zombie processes.

Long term using GitPython may not be sustainable as we lose visibility to problems as it uses the git binary directly. But this should avoid the indexer crashing every other day due to 1000s of defunct ssh sessions.

*Note:* This was a stack update and has already been manually applied and is working.

```
~$ ps waux
USER       PID %CPU %MEM    VSZ   RSS TTY      STAT START   TIME COMMAND
netkan       1  0.1  0.0    944     8 ?        Ss   02:05   0:00 /dev/init -- .local/bin/netkan indexer
netkan       7  1.0  5.6  79240 55488 ?        S    02:05   0:01 /usr/local/bin/python .local/bin/netkan indexer
netkan      13  7.5  0.3   5756  3492 pts/0    Ss   02:06   0:00 bash
netkan      19  0.0  0.2   9396  2900 pts/0    R+   02:06   0:00 ps waux
```