### PR TITLE
Don't mount cache for Indexer

### DIFF
--- a/prod-stack.py
+++ b/prod-stack.py
@@ -602,9 +602,6 @@ services = [
             ('SQS_QUEUE', GetAtt(outbound, 'QueueName')),
             ('AWS_DEFAULT_REGION', Sub('${AWS::Region}')),
         ],
-        'volumes': [
-            ('ckan_cache', '/home/netkan/ckan_cache')
-        ],
         'linux_parameters': LinuxParameters(InitProcessEnabled=True),
     },
     {


### PR DESCRIPTION
Currently the Indexer container has access to the shared download cache, but it doesn't need or use it. This probably doesn't cause any problems (other than making the infra slightly more confusing).

This PR removes the cache volume from the Indexer definition.
(Really just submitting this to get it out of my persistent git stash that I carry from one branch to the next.)