### PR TITLE
Default Shallow Clones

### DIFF
--- a/netkan/netkan/cli/common.py
+++ b/netkan/netkan/cli/common.py
@@ -23,6 +23,8 @@ _COMMON_OPTIONS = [
                  help='SQS Queue to poll for metadata', callback=ctx_callback),
     click.option('--ssh-key', envvar='SSH_KEY', expose_value=False,
                  help='SSH key for accessing repositories', callback=ctx_callback),
+    click.option('--deep-clone', is_flag=True, default=False, expose_value=False,
+                 help='Perform a deep clone of the git repos', callback=ctx_callback),
     click.option('--ckanmeta-remote', envvar='CKANMETA_REMOTE', expose_value=False,
                  help='Path/URL/SSH to Metadata Repo', callback=ctx_callback),
     click.option('--netkan-remote', envvar='NETKAN_REMOTE', expose_value=False,
@@ -92,7 +94,8 @@ class SharedArgs(object):
     @property
     def ckanmeta_remote(self):
         if not self._ckanmeta_remote_repo:
-            self._ckanmeta_remote_repo = init_repo(self._ckanmeta_remote, '/tmp/CKAN-meta')
+            self._ckanmeta_remote_repo = init_repo(self._ckanmeta_remote, '/tmp/CKAN-meta',
+                                                   self.deep_clone)
         return self._ckanmeta_remote_repo
 
     @ckanmeta_remote.setter
@@ -102,7 +105,8 @@ class SharedArgs(object):
     @property
     def netkan_remote(self):
         if not self._netkan_remote_repo:
-            self._netkan_remote_repo = init_repo(self._netkan_remote, '/tmp/NetKAN')
+            self._netkan_remote_repo = init_repo(self._netkan_remote, '/tmp/NetKAN',
+                                                 self.deep_clone)
         return self._netkan_remote_repo
 
     @netkan_remote.setter

--- a/netkan/netkan/utils.py
+++ b/netkan/netkan/utils.py
@@ -1,14 +1,17 @@
 import logging
 import subprocess
-from git import Repo
 from pathlib import Path
+from git import Repo
 
 
-def init_repo(metadata, path):
+def init_repo(metadata, path, deep_clone):
     clone_path = Path(path)
     if not clone_path.exists():
-        logging.info('Cloning {}'.format(metadata))
-        repo = Repo.clone_from(metadata, clone_path)
+        logging.info('Cloning %s', metadata)
+        extra_kwargs = {}
+        if not deep_clone:
+            extra_kwargs['depth'] = 1
+        repo = Repo.clone_from(metadata, clone_path, **extra_kwargs)
     else:
         repo = Repo(clone_path)
     return repo


### PR DESCRIPTION
#147 has cleaned up our ever sprawling defunct ssh process issue with the indexer, but whilst improved, the disk thrashing still persists after a period of time.

Shallow clones may or may not improve this, but I do note when trying to check the repo health I was unable to fit the checks into the container's memory allocation. Shallow clones may help here and are an order of magnitude less objects that are being tracked.