### PR TITLE
Fix AttributeError in Mirrorer for ckans without download_content_type

### DIFF
--- a/netkan/netkan/mirrorer.py
+++ b/netkan/netkan/mirrorer.py
@@ -255,7 +255,7 @@ class CkanMirror(Ckan):
     def can_mirror(self):
         return (
             self.kind == 'package'
-            and self.download_content_type in Ckan.MIME_TO_EXTENSION
+            and getattr(self, 'download_content_type', '') in Ckan.MIME_TO_EXTENSION
             and self.redistributable
         )
 


### PR DESCRIPTION
## Problem
https://github.com/KSP-CKAN/CKAN-meta/pull/1819 merged some changes to ckan files that didn't have `download_content_type` specified.
We got these exceptions thrown by the mirrorer:
```
Uncaught exception:
Traceback (most recent call last):
  File ".local/bin/netkan", line 8, in <module>
    sys.exit(netkan())
  File "/home/netkan/.local/lib/python3.7/site-packages/click/core.py", line 764, in __call__
    return self.main(*args, **kwargs)
  File "/home/netkan/.local/lib/python3.7/site-packages/click/core.py", line 717, in main
    rv = self.invoke(ctx)
  File "/home/netkan/.local/lib/python3.7/site-packages/click/core.py", line 1137, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/home/netkan/.local/lib/python3.7/site-packages/click/core.py", line 956, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "/home/netkan/.local/lib/python3.7/site-packages/click/core.py", line 555, in invoke
    return callback(*args, **kwargs)
  File "/home/netkan/.local/lib/python3.7/site-packages/click/decorators.py", line 64, in new_func
    return ctx.invoke(f, obj, *args, **kwargs)
  File "/home/netkan/.local/lib/python3.7/site-packages/click/core.py", line 555, in invoke
    return callback(*args, **kwargs)
  File "/home/netkan/.local/lib/python3.7/site-packages/netkan/cli/services.py", line 72, in mirrorer
    ).process_queue(common.queue, common.timeout)
  File "/home/netkan/.local/lib/python3.7/site-packages/netkan/mirrorer.py", line 53, in process_queue
    if self.try_mirror(CkanMirror(self.ia_collection, path)):
  File "/home/netkan/.local/lib/python3.7/site-packages/netkan/mirrorer.py", line 61, in try_mirror
    if not ckan.can_mirror:
  File "/home/netkan/.local/lib/python3.7/site-packages/netkan/metadata.py", line 110, in __getattr__
    raise AttributeError
AttributeError
```
Although the stack trace makes it look like Python tries call `__getattr__` when looking for `ckan.can_mirror`, I suspect it actually _finds_ `can_mirror` and throws the error inside `can_mirror` when trying to access `self.download_content_type`, which then calls `__getattr__` of the `Ckan` class, which raises an `AttributeError` if the source JSON doesn't have that property (which, in this case, is true for `download_content_type`).

## Changes
Now we use `getattr(self, 'download_content_type', '')` in `can_mirror`.
This will return `False`, so the files don't get mirrored:
```
>>> '' in {
...         'application/x-gzip':           'gz',
...         'application/x-tar':            'tar',
...         'application/x-compressed-tar': 'tar.gz',
...         'application/zip':              'zip',
...     }
False
```