### PR TITLE
Schedule backports

### DIFF
--- a/netkan/netkan/scheduler.py
+++ b/netkan/netkan/scheduler.py
@@ -26,9 +26,7 @@ class NetkanScheduler:
             self.queue_url = self.queue.url
 
     def netkans(self):
-        # This can easily be recursive with '**/*.netkan', however
-        # implementing like for like initially.
-        return (Netkan(f) for f in sorted(self.path.glob('*.netkan'),
+        return (Netkan(f) for f in sorted(self.path.glob('**/*.netkan'),
                                           key=lambda p: p.stem.casefold()))
 
     def sqs_batch_attrs(self, batch):


### PR DESCRIPTION
## Background

KSP-CKAN/NetKAN#7219 and KSP-CKAN/NetKAN#7222 added a special netkan for Kopernicus backports in  `NetKAN/NetKAN/Backports/Kopernicus.netkan`. Special properties that make it a backport:

- It shares its identifier with the main `NetKAN/NetKAN/Kopernicus.netkan` file
- Its releases are for older game versions
- The version numbers are intentionally out of order

The Scheduler currently skips these; only files in the main `NetKAN/NetKAN` folder are submitted for inflation.

## Motivation

The subject of backports has come up again in KSP-CKAN/NetKAN#7707. The SmokeScreen-RO module was created for a backport stream, but with a separate identifier, which is now causing problems for the RealismOverhaul team's upgrade plans. Better support for backports would be helpful.

Unfortunately, the SmokeScreen-RO situation specifically cannot be helped this way; its version numbers overlap exactly with versions from the main SmokeScreen release stream, so we can't merge the two into one module.

However, Kopernicus can still benefit, and hopefully we can steer other future backport attempts in this direction.

## Changes

Now the scheduler's search for `.netkan` files is recursive, so the `Backports` directory will be included. This will allow backport modules to be created and checked with for updates.

(The Webhooks already use a recursive search for the one case where they need one, which is the SpaceDock upload trigger.)