### PR TITLE
Generate random unique batch ids

### DIFF
--- a/netkan/netkan/metadata.py
+++ b/netkan/netkan/metadata.py
@@ -75,11 +75,12 @@ class Netkan:
         return attribs
 
     def sqs_message(self, ckan_group=None):
+        id = uuid.uuid4().hex
         return {
-            'Id': self.identifier[0:80],
+            'Id': id,
             'MessageBody': self.contents,
             'MessageGroupId': '1',
-            'MessageDeduplicationId': uuid.uuid4().hex,
+            'MessageDeduplicationId': id,
             'MessageAttributes': self.sqs_message_attribs(ckan_group),
         }
 

--- a/netkan/tests/metadata.py
+++ b/netkan/tests/metadata.py
@@ -11,7 +11,6 @@ class TestNetKAN(unittest.TestCase):
         dogecoinflag = Path(self.test_data, 'DogeCoinFlag.netkan')
         netkan = Netkan(dogecoinflag)
         message = netkan.sqs_message()
-        self.assertEqual(message['Id'], 'DogeCoinFlag')
         self.assertEqual(
             message['MessageBody'],
             dogecoinflag.read_text()


### PR DESCRIPTION
## Problem

The Scheduler is only scheduling A–K:

```
Uncaught exception:
Traceback (most recent call last):
  File ".local/bin/netkan", line 8, in <module>
    sys.exit(netkan())
  File "/home/netkan/.local/lib/python3.7/site-packages/click/core.py", line 764, in __call__
    return self.main(*args, **kwargs)
  File "/home/netkan/.local/lib/python3.7/site-packages/click/core.py", line 717, in main
    rv = self.invoke(ctx)
  File "/home/netkan/.local/lib/python3.7/site-packages/click/core.py", line 1137, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/home/netkan/.local/lib/python3.7/site-packages/click/core.py", line 956, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "/home/netkan/.local/lib/python3.7/site-packages/click/core.py", line 555, in invoke
    return callback(*args, **kwargs)
  File "/home/netkan/.local/lib/python3.7/site-packages/click/decorators.py", line 64, in new_func
    return ctx.invoke(f, obj, *args, **kwargs)
  File "/home/netkan/.local/lib/python3.7/site-packages/click/core.py", line 555, in invoke
    return callback(*args, **kwargs)
  File "/home/netkan/.local/lib/python3.7/site-packages/netkan/cli/services.py", line 61, in scheduler
    sched.schedule_all_netkans()
  File "/home/netkan/.local/lib/python3.7/site-packages/netkan/scheduler.py", line 48, in schedule_all_netkans
    self.client.send_message_batch(**self.sqs_batch_attrs(batch))
  File "/home/netkan/.local/lib/python3.7/site-packages/botocore/client.py", line 316, in _api_call
    return self._make_api_call(operation_name, kwargs)
  File "/home/netkan/.local/lib/python3.7/site-packages/botocore/client.py", line 626, in _make_api_call
    raise error_class(parsed_response, operation_name)
botocore.errorfactory.BatchEntryIdsNotDistinct: An error occurred (AWS.SimpleQueueService.BatchEntryIdsNotDistinct) when calling the SendMessageBatch operation: Id Kopernicus repeated.
```

## Cause

After #153, `NetKAN/NetKAN/Backports/Kopernicus.netkan` and `NetKAN/NetKAN/Kopernicus.netkan` ended up in the same batch because we sort by the file stem. Since they have the same identifier, the identifier isn't a good enough `Id` anymore.

## Changes

Now we use random hex strings, just like in #81.