### PR TITLE
Regularly restart GitPython-based services

### DIFF
--- a/prod-stack.py
+++ b/prod-stack.py
@@ -346,7 +346,8 @@ netkan_ecs_role = t.add_resource(Role(
 scheduler_resources = []
 for task in [
         'Scheduler', 'SchedulerWebhooksPass', 'CertBot', 'StatusDumper',
-        'DownloadCounter', 'TicketCloser', 'AutoFreezer', 'RestartWebhooks']:
+        'DownloadCounter', 'TicketCloser', 'AutoFreezer', 'RestartWebhooks',
+        'RestartAdder', 'RestartIndexer', 'RestartMirrorer']:
     scheduler_resources.append(Sub(
         'arn:aws:ecs:*:${AWS::AccountId}:task-definition/NetKANBot${Task}:*',
         Task=task

--- a/prod-stack.py
+++ b/prod-stack.py
@@ -714,6 +714,42 @@ services = [
         'schedule': 'cron(30 0 ? * MON *)',
     },
     {
+        'name': 'RestartIndexer',
+        'command': [
+            'redeploy-service',
+            '--cluster', 'NetKANCluster',
+            '--service-name', 'Indexer',
+        ],
+        'env': [
+            ('AWS_DEFAULT_REGION', Sub('${AWS::Region}')),
+        ],
+        'schedule': 'rate(3 days)',
+    },
+    {
+        'name': 'RestartAdder',
+        'command': [
+            'redeploy-service',
+            '--cluster', 'NetKANCluster',
+            '--service-name', 'Adder',
+        ],
+        'env': [
+            ('AWS_DEFAULT_REGION', Sub('${AWS::Region}')),
+        ],
+        'schedule': 'rate(3 days)',
+    },
+    {
+        'name': 'RestartMirrorer',
+        'command': [
+            'redeploy-service',
+            '--cluster', 'NetKANCluster',
+            '--service-name', 'Mirrorer',
+        ],
+        'env': [
+            ('AWS_DEFAULT_REGION', Sub('${AWS::Region}')),
+        ],
+        'schedule': 'rate(3 days)',
+    },
+    {
         'name': 'TicketCloser',
         'command': 'ticket-closer',
         'env': [],


### PR DESCRIPTION
## Problems

The bot has been skipping a lot of runs for months now based on the checks from #112 and #115:

![image](https://user-images.githubusercontent.com/1559108/79027856-6262ec00-7b7d-11ea-95ec-7ccec716d13c.png)

And the current pass is taking an extremely long time to complete, over 10 hours to get from 'A' to 'P' (where it used to be 10-20 minutes for 'A' to 'Z'):

![image](https://user-images.githubusercontent.com/1559108/79028128-73602d00-7b7e-11ea-9c61-551880ee5f6a.png)

![image](https://user-images.githubusercontent.com/1559108/79028120-6c391f00-7b7e-11ea-83d6-35f3470efbf9.png)

This has meant a very long delay in the post-merge handling of KSP-CKAN/NetKAN#7831 (and who knows what else).

## Cause

We still don't know exactly why this happens, but based on graphs that @techman83 has shared previously, it seems to be something that starts out mild and then gets gradually worse the longer the containers run. May be due to some aspect of GitPython, but we don't quite have proof of that, and rewriting to use another tool is a big project (see #148).

## Changes

There's already a RestartWebhooks service to handle changes in certs once a week.

Now some new duplicates of that service are created to automatically restart the Indexer, Adder, and Mirrorer every 3 days. This should reset whatever the problem is with the Python-based services and hopefully give us better service availability.