### PR TITLE
Fix redeploy webhooks job

### DIFF
--- a/prod-stack.py
+++ b/prod-stack.py
@@ -706,7 +706,7 @@ services = [
         'command': [
             'redeploy-service',
             '--cluster', 'NetKANCluster',
-            '--service-name', 'WebhooksService',
+            '--service-name', 'Webhooks',
         ],
         'env': [
             ('AWS_DEFAULT_REGION', Sub('${AWS::Region}')),

--- a/prod-stack.py
+++ b/prod-stack.py
@@ -346,7 +346,7 @@ netkan_ecs_role = t.add_resource(Role(
 scheduler_resources = []
 for task in [
         'Scheduler', 'SchedulerWebhooksPass', 'CertBot', 'StatusDumper',
-        'DownloadCounter', 'TicketCloser', 'AutoFreezer']:
+        'DownloadCounter', 'TicketCloser', 'AutoFreezer', 'RestartWebhooks']:
     scheduler_resources.append(Sub(
         'arn:aws:ecs:*:${AWS::AccountId}:task-definition/NetKANBot${Task}:*',
         Task=task


### PR DESCRIPTION
## Background

The service redeploy command uses a `--service-name` argument, which is generally passed the name of the service without a `Service` suffix:

https://github.com/KSP-CKAN/NetKAN-Infra/blob/a374d2187f38285e9f6306bc8cb9a99d97794851/bin/push_deploy_containers.sh#L18-L19

https://github.com/KSP-CKAN/NetKAN-Infra/blob/a374d2187f38285e9f6306bc8cb9a99d97794851/bin/push_deploy_containers.sh#L24-L25

https://github.com/KSP-CKAN/NetKAN-Infra/blob/a374d2187f38285e9f6306bc8cb9a99d97794851/bin/push_deploy_containers.sh#L30-L31

https://github.com/KSP-CKAN/NetKAN-Infra/blob/a374d2187f38285e9f6306bc8cb9a99d97794851/bin/push_deploy_containers.sh#L36-L37

https://github.com/KSP-CKAN/CKAN/blob/16994590ee0318d6bb93c90455e1dead093a02cc/build.cake#L88-L90

## Problem

The job to restart the webhooks once per week is not working, see #158.

## Cause

The prod stack setup file has a list of schedulable tasks, which does not include `RestartWebhooks`:

https://github.com/KSP-CKAN/NetKAN-Infra/blob/a374d2187f38285e9f6306bc8cb9a99d97794851/prod-stack.py#L347-L349

As a point of minor inconsistency, the command for `RestartWebhooks` includes a `Service` suffix:

https://github.com/KSP-CKAN/NetKAN-Infra/blob/a374d2187f38285e9f6306bc8cb9a99d97794851/prod-stack.py#L707-L709

## Changes

- Now `RestartWebhooks` is added to the list of schedulable tasks
- Now the scheduled task redeploys `Webhooks` instead of `WebhooksService`

Fixes #158.