### PR TITLE
Fix Build + Adder f-strings

### DIFF
--- a/netkan/Dockerfile
+++ b/netkan/Dockerfile
@@ -2,6 +2,7 @@ FROM python:3.7 as base
 RUN useradd -ms /bin/bash netkan
 ADD . /netkan
 WORKDIR /netkan
+RUN chown -R netkan:netkan /netkan
 USER netkan
 RUN pip install --user . --no-warn-script-location
 RUN python -m unittest -v

--- a/netkan/netkan/spacedock_adder.py
+++ b/netkan/netkan/spacedock_adder.py
@@ -72,8 +72,10 @@ class SpaceDockAdder:
 
         # Commit
         self.netkan_repo.index.commit(
-            f'Add {info.get('name')} from {info.get('site_name')}'
-            + f'\n\nThis is an automated commit on behalf of {info.get('username')}',
+            (
+                f"Add {info.get('name')} from {info.get('site_name')}"
+                f"\n\nThis is an automated commit on behalf of {info.get('username')}"
+            ),
             author=git.Actor(info.get('username'), info.get('email'))
         )
 
@@ -82,7 +84,7 @@ class SpaceDockAdder:
 
         # Create pull request
         self.github_pr.create_pull_request(
-            title=f'Add {info.get('name')} from {info.get('site_name')}',
+            title=f"Add {info.get('name')} from {info.get('site_name')}",
             branch=branch_name,
             body=self.PR_BODY_TEMPLATE.substitute(info)
         )
@@ -98,8 +100,8 @@ class SpaceDockAdder:
     def make_netkan(self, info):
         return {
             'spec_version': 'v1.4',
-            'identifier':   re.sub(r'\W+', '', info.get('name'),
-            '$kref':        f'#/ckan/spacedock/{info.get('id')}',
-            'license':      info.get('license').replace(' ', '-'),
-            'x_via':        f'Automated {info.get('site_name')} CKAN submission'
+            'identifier': re.sub(r'\W+', '', info.get('name')),
+            '$kref': f"#/ckan/spacedock/{info.get('id')}",
+            'license': info.get('license').replace(' ', '-'),
+            'x_via': f"Automated {info.get('site_name')} CKAN submission"
         }


### PR DESCRIPTION
The most recent build has begun failing. Looking at it, it appears like it couldn't write to the path during the build process.
```
Installing collected packages: jmespath, six, python-dateutil, urllib3, docutils, botocore, s3transfer, boto3, click, smmap, gitdb, gitpython, pynamodb, certifi, idna, chardet, requests, Werkzeug, itsdangerous, MarkupSafe, Jinja2, flask, backports.csv, docopt, jsonpointer, jsonpatch, tqdm, total-ordering, contextlib2, schema, internetarchive, gunicorn, attrs, multidict, yarl, async-timeout, aiohttp, websockets, discord.py, discord, pyjwt, wrapt, deprecated, PyGithub, netkan-indexer
409    Running setup.py install for netkan-indexer: started
410    Running setup.py install for netkan-indexer: finished with status 'error'
411    ERROR: Command errored out with exit status 1:
412     command: /usr/local/bin/python -u -c 'import sys, setuptools, tokenize; sys.argv[0] = '"'"'/netkan/setup.py'"'"'; __file__='"'"'/netkan/setup.py'"'"';f=getattr(tokenize, '"'"'open'"'"', open)(__file__);code=f.read().replace('"'"'\r\n'"'"', '"'"'\n'"'"');f.close();exec(compile(code, __file__, '"'"'exec'"'"'))' install --record /tmp/pip-record-yiduot8l/install-record.txt --single-version-externally-managed --user --prefix= --compile --install-headers /home/netkan/.local/include/python3.7m/netkan-indexer
413         cwd: /netkan/
414    Complete output (5 lines):
415    running install
416    running build
417    running build_py
418    creating build
419    error: could not create 'build': Permission denied
```
`/netkan` is thrown away after the first build stage, so allowing it to be written to will work around this.

There were also some errors in  the adder which were causing the tests to fail.