### PR TITLE
Ignore branch fetching exceptions in Adder

### DIFF
--- a/netkan/netkan/spacedock_adder.py
+++ b/netkan/netkan/spacedock_adder.py
@@ -55,7 +55,11 @@ class SpaceDockAdder:
 
         # Create branch
         branch_name = f"add-{netkan.get('identifier')}"
-        self.netkan_repo.remotes.origin.fetch(branch_name)
+        try:
+            self.netkan_repo.remotes.origin.fetch(branch_name)
+        except GitCommandError:
+            # *Shrug*
+            pass
         if branch_name not in self.netkan_repo.heads:
             self.netkan_repo.create_head(
                 branch_name,


### PR DESCRIPTION
GitPython uses exceptions for normal flow control; to avoid this one you would have to know ahead of time whether the branch exists remotely.