### PR TITLE
Replace absent template keys with empty string

### DIFF
--- a/netkan/netkan/spacedock_adder.py
+++ b/netkan/netkan/spacedock_adder.py
@@ -3,6 +3,7 @@ import re
 from pathlib import Path
 from importlib.resources import read_text
 from string import Template
+from collections import defaultdict
 import git
 import boto3
 
@@ -91,7 +92,7 @@ class SpaceDockAdder:
         self.github_pr.create_pull_request(
             title=f"Add {info.get('name')} from {info.get('site_name')}",
             branch=branch_name,
-            body=self.PR_BODY_TEMPLATE.safe_substitute(info)
+            body=self.PR_BODY_TEMPLATE.safe_substitute(defaultdict(lambda: '', info))
         )
         return True
 


### PR DESCRIPTION
`string.Template` allows us to store a long string document containing substitutable keys, then replace the keys based on the contents of a `dict`. It's nice because the calling code doesn't need to know anything about the document; it can just load the file, receive the parameters, and go. The SpaceDock Adder uses it for generating the pull request body text.

Unfortunately, the `substitute` method throws `KeyError` if the template contains keys that aren't in the input dict, which makes `string.Template` practically useless by default, since now the calling code needs to know what's in the document and take steps to ensure every key is represented (almost worth it to go back to appending together a bunch of ad hoc strings at that point). Naturally, in order to ensure maximum disruption, [the Python documentation makes no mention of this](https://docs.python.org/3.7/library/string.html?highlight=template#string.Template), except in the description of a **different** function, `safe_substitute`, which is apparently Python's attempt at a workaround for this problem. We switched to that in 4fba63074e708face60df2eb1b802aeafd44a917, which avoids the `KeyError` but leaves in the key strings (see KSP-CKAN/NetKAN#7885).

The `collections.defaultdict` class is like `dict` except its constructor has an additional first parameter, a function that returns a default value to be used when a key is not present. Now we convert our parameter `dict` to a `defaultdict` that uses the empty string as the default, which will avoid `KeyError` and simply delete any missing keys.

It's not clear yet which random exceptions `defaultdict` may throw for silly pointless reasons, but I look forward to finding out. :snake: 