### PR TITLE
Create netkan after switching to branch

### DIFF
--- a/netkan/netkan/spacedock_adder.py
+++ b/netkan/netkan/spacedock_adder.py
@@ -51,8 +51,6 @@ class SpaceDockAdder:
         if netkan_path.exists():
             # Already exists, we are done
             return True
-        # Otherwise create
-        netkan_path.write_text(json.dumps(netkan, indent=4))
 
         # Create branch
         branch_name = f"add-{netkan.get('identifier')}"
@@ -72,6 +70,9 @@ class SpaceDockAdder:
             )
         # Checkout branch
         self.netkan_repo.heads[branch_name].checkout()
+
+        # Create file
+        netkan_path.write_text(json.dumps(netkan, indent=4))
 
         # Add netkan to branch
         self.netkan_repo.index.add([netkan_path.as_posix()])


### PR DESCRIPTION
## Problem

```
Uncaught exception:
Traceback (most recent call last):
  File ".local/bin/netkan", line 8, in <module>
    sys.exit(netkan())
  File "/home/netkan/.local/lib/python3.7/site-packages/click/core.py", line 829, in __call__
    return self.main(*args, **kwargs)
  File "/home/netkan/.local/lib/python3.7/site-packages/click/core.py", line 782, in main
    rv = self.invoke(ctx)
  File "/home/netkan/.local/lib/python3.7/site-packages/click/core.py", line 1259, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/home/netkan/.local/lib/python3.7/site-packages/click/core.py", line 1066, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "/home/netkan/.local/lib/python3.7/site-packages/click/core.py", line 610, in invoke
    return callback(*args, **kwargs)
  File "/home/netkan/.local/lib/python3.7/site-packages/click/decorators.py", line 73, in new_func
    return ctx.invoke(f, obj, *args, **kwargs)
  File "/home/netkan/.local/lib/python3.7/site-packages/click/core.py", line 610, in invoke
    return callback(*args, **kwargs)
  File "/home/netkan/.local/lib/python3.7/site-packages/netkan/cli/services.py", line 85, in spacedock_adder
    sd_adder.run()
  File "/home/netkan/.local/lib/python3.7/site-packages/netkan/spacedock_adder.py", line 38, in run
    if self.try_add(json.loads(msg.body)):
  File "/home/netkan/.local/lib/python3.7/site-packages/netkan/spacedock_adder.py", line 74, in try_add
    self.netkan_repo.heads[branch_name].checkout()
  File "/home/netkan/.local/lib/python3.7/site-packages/git/refs/head.py", line 219, in checkout
    self.repo.git.checkout(self, **kwargs)
  File "/home/netkan/.local/lib/python3.7/site-packages/git/cmd.py", line 542, in <lambda>
    return lambda *args, **kwargs: self._call_process(name, *args, **kwargs)
  File "/home/netkan/.local/lib/python3.7/site-packages/git/cmd.py", line 1005, in _call_process
    return self.execute(call, **exec_kwargs)
  File "/home/netkan/.local/lib/python3.7/site-packages/git/cmd.py", line 822, in execute
    raise GitCommandError(command, status, stderr_value, stdout_value)
git.exc.GitCommandError: Cmd('git') failed due to: exit code(1)
  cmdline: git checkout add-PhoenixIndustries
  stderr: 'error: The following untracked working tree files would be overwritten by checkout:
    NetKAN/PhoenixIndustries.netkan
Please move or remove them before you switch branches.
Aborting'
```

## Cause

This file was created on its own branch for KSP-CKAN/NetKAN#7889 but has not yet been merged to master. A second request apparently came in from SpaceDock, but when we tried to check out the branch, we had already saved the file to the working directory, which caused a conflict.

## Changes

Now we will save the file after checking out the branch. This should avoid this problem.