### PR TITLE
Notify on SpaceDock deletion

### DIFF
--- a/netkan/netkan/webhooks/spacedock_inflate.py
+++ b/netkan/netkan/webhooks/spacedock_inflate.py
@@ -12,7 +12,9 @@ spacedock_inflate = Blueprint('spacedock_inflate', __name__)  # pylint: disable=
 # Handles: https://netkan.ksp-ckan.space/sd/inflate
 # POST form parameters:
 #     mod_id:     The mod's ID number on SpaceDock
-#     event_type: update
+#     event_type: update         - New version of mod was uploaded
+#                 version-update - Default version changed
+#                 delete         - Mod was deleted from SpaceDock
 @spacedock_inflate.route('/inflate', methods=['POST'])
 def inflate_hook():
     # Make sure our NetKAN and CKAN-meta repos are up to date
@@ -20,15 +22,22 @@ def inflate_hook():
     # Get the relevant netkans
     nks = find_netkans(request.form.get('mod_id'))
     if nks:
-        # Submit them to the queue
-        messages = (nk.sqs_message(CkanGroup(current_app.config['ckanmeta_repo'].working_dir, nk.identifier))
-                    for nk in nks)
-        for batch in sqs_batch_entries(messages):
-            current_app.config['client'].send_message_batch(
-                QueueUrl=current_app.config['inflation_queue'].url,
-                Entries=batch
-            )
-        return '', 204
+        if request.form.get('event_type') == 'delete':
+            # Just let the team know on Discord
+            nk_msg = ', '.join(nk.identifier for nk in nks)
+            current_app.logger.error(
+                f'A SpaceDock mod has been deleted, affected netkans: {nk_msg}')
+            return '', 204
+        else:
+            # Submit them to the queue
+            messages = (nk.sqs_message(CkanGroup(current_app.config['ckanmeta_repo'].working_dir, nk.identifier))
+                        for nk in nks)
+            for batch in sqs_batch_entries(messages):
+                current_app.config['client'].send_message_batch(
+                    QueueUrl=current_app.config['inflation_queue'].url,
+                    Entries=batch
+                )
+            return '', 204
     return 'No such module', 404
 
 


### PR DESCRIPTION
## Motivation

While working on KSP-SpaceDock/SpaceDock#257, I finally spotted the other `event_type`s that SpaceDock can send via the webhooks: `version-update` and `delete`.

`version-update` can be treated the same as a normal inflation request, but `delete` probably shouldn't be.

## Changes

- Now the `event_type` parameter is fully documented.
- Now if a `delete` request comes in, we log an error so we can see it on Discord.
  - I'm not 100% happy with logging an error for this, please suggest something better.