### PR TITLE
Stop sending 'None' warnings to Discord

### DIFF
--- a/netkan/netkan/indexer.py
+++ b/netkan/netkan/indexer.py
@@ -149,7 +149,7 @@ class CkanMessage:
             if not self.Success and getattr(status, 'last_error', None) != self.ErrorMessage:
                 logging.error('New inflation error for %s: %s',
                               self.ModIdentifier, self.ErrorMessage)
-            elif getattr(status, 'last_warnings', None) != self.WarningMessages:
+            elif getattr(status, 'last_warnings', None) != self.WarningMessages and self.WarningMessages is not None:
                 logging.error('New inflation warnings for %s: %s',
                               self.ModIdentifier, self.WarningMessages)
             actions = [


### PR DESCRIPTION
## Problem

![image](https://user-images.githubusercontent.com/1559108/82162903-6b766580-986d-11ea-81dc-894a3d2d1d0f.png)

## Cause

The check to determine whether to notify Discord with warnings only checks that it changed. If a module previously had a warning and it clears, that condition is true, but we don't need to see `None`. This logic was copied from the equivalent check for `ErrorMessage` and the `self.Success` check was removed because modules with warnings are allowed to succeed, but that check was also protecting us from `None` error notifications.

## Changes

Now if `WarningMessages` is `None`, we don't send it.