### PR TITLE
Run webhooks-only pass more often

### DIFF
--- a/netkan/netkan/cli/services.py
+++ b/netkan/netkan/cli/services.py
@@ -46,18 +46,22 @@ def indexer(common):
     help='Which mods to schedule',
 )
 @click.option(
-    '--min-credits', default=200,
-    help='Only schedule if we have at least this many credits remaining',
+    '--min-cpu', default=200,
+    help='Only schedule if we have at least this many CPU credits remaining',
+)
+@click.option(
+    '--min-io', default=70,
+    help='Only schedule if we have at least this many IO credits remaining',
 )
 @common_options
 @pass_state
-def scheduler(common, max_queued, group, min_credits):
+def scheduler(common, max_queued, group, min_cpu, min_io):
     sched = NetkanScheduler(
         common.netkan_remote.working_dir, common.ckanmeta_remote.working_dir, common.queue,
         nonhooks_group=(group == 'all' or group == 'nonhooks'),
         webhooks_group=(group == 'all' or group == 'webhooks'),
     )
-    if sched.can_schedule(max_queued, common.dev, min_credits):
+    if sched.can_schedule(max_queued, common.dev, min_cpu, min_io):
         sched.schedule_all_netkans()
         logging.info("NetKANs submitted to %s", common.queue)
 

--- a/prod-stack.py
+++ b/prod-stack.py
@@ -622,7 +622,8 @@ services = [
         'command': [
             'scheduler', '--group', 'webhooks',
                 '--max-queued', '2000',
-                '--min-credits', '25'
+                '--min-cpu', '25',
+                '--min-io', '60',
         ],
         'memory': '156',
         'secrets': ['SSH_KEY'],


### PR DESCRIPTION
## Problem

The webhooks-only pass has been skipped multiple days in a row, which has meant that (some of) the effects of the fixes in KSP-CKAN/CKAN#3056 and KSP-CKAN/CKAN#3057 haven't been seen yet:

![image](https://user-images.githubusercontent.com/1559108/82598638-995ef100-9b70-11ea-91a4-8e9ba7c1071f.png)

## Cause

The volume credit target percentage check is below 70% (doubled up messages at the same timestamp means one is the normal run and one is the webhooks-only run):

![image](https://user-images.githubusercontent.com/1559108/82598376-31100f80-9b70-11ea-8447-4bb8a9c8a6cc.png)

## Changes

Now the 70% threshold is configurable via a parameter, which is left at 70% for normal runs but set to a more generous but still relatively conservative 60% for the webhook only runs. If there's a serious problem with the server that drops this below 60%, then we'll still skip both, but if the percentage remains between 60% and 70% (as it has been pretty consistently for several days now), we won't skip webhook-only runs.

Also the `min_credits` parameter is renamed to `min_cpu` to distinguish it from the new `min_io` parameter, since as far as I can tell from AWS's documentation this is what these numbers represent.

- https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/burstable-performance-instances-monitoring-cpu-credits.html
- https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ebs-volume-types.html
