### PR TITLE
Type hints and checking in CI

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@
 *.egg-info
 /pr_tester
 __pycache__
+.mypy_cache/

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -8,6 +8,7 @@
     "--rcfile",
     "/home/netkan/workspace/.pylintrc"
   ],
+  "python.linting.mypyEnabled": true,
   "python.linting.pylintUseMinimalCheckers": false,
   "files.exclude": {
     "**/__pycache__": true

--- a/netkan/Dockerfile
+++ b/netkan/Dockerfile
@@ -2,10 +2,11 @@ FROM python:3.7 as base
 RUN useradd -ms /bin/bash netkan
 ADD . /netkan
 WORKDIR /netkan
+RUN pip install mypy
 RUN chown -R netkan:netkan /netkan
 USER netkan
 RUN pip install --user . --no-warn-script-location
-RUN /home/netkan/.local/bin/mypy .
+RUN mypy .
 RUN python -m unittest -v
 RUN /home/netkan/.local/bin/netkan --help
 
@@ -23,9 +24,11 @@ CMD ["--help"]
 FROM production as dev
 USER root
 ADD . /netkan
+RUN chown -R netkan:netkan /netkan
 ADD run_dev.sh /usr/local/bin/
 USER netkan
 RUN pip install --user /netkan/.[development]
+RUN pip install --user /netkan/.[test]
 ENTRYPOINT ["/usr/local/bin/run_dev.sh"]
 
 FROM production

--- a/netkan/Dockerfile
+++ b/netkan/Dockerfile
@@ -5,6 +5,7 @@ WORKDIR /netkan
 RUN chown -R netkan:netkan /netkan
 USER netkan
 RUN pip install --user . --no-warn-script-location
+RUN /home/netkan/.local/bin/mypy .
 RUN python -m unittest -v
 RUN /home/netkan/.local/bin/netkan --help
 

--- a/netkan/mypy.ini
+++ b/netkan/mypy.ini
@@ -1,0 +1,16 @@
+[mypy]
+ignore_missing_imports = true
+warn_redundant_casts = true
+show_error_context = true
+show_column_numbers = true
+show_error_codes = true
+pretty = true
+
+# Don't increase strictness for tests
+[mypy-netkan.*]
+check_untyped_defs = true
+disallow_incomplete_defs = true
+disallow_untyped_defs = true
+disallow_any_generics = true
+warn_unreachable = true
+strict_equality = true

--- a/netkan/netkan/cli/__init__.py
+++ b/netkan/netkan/cli/__init__.py
@@ -21,7 +21,7 @@ from .utilities import (
 
 
 @click.group()
-def netkan():
+def netkan() -> None:
     pass
 
 

--- a/netkan/netkan/cli/services.py
+++ b/netkan/netkan/cli/services.py
@@ -3,7 +3,7 @@ import logging
 import boto3
 import click
 
-from .common import common_options, pass_state
+from .common import common_options, pass_state, SharedArgs
 
 from ..indexer import MessageHandler
 from ..scheduler import NetkanScheduler
@@ -14,7 +14,7 @@ from ..mirrorer import Mirrorer
 @click.command()
 @common_options
 @pass_state
-def indexer(common):
+def indexer(common: SharedArgs) -> None:
     sqs = boto3.resource('sqs')
     queue = sqs.get_queue_by_name(QueueName=common.queue)
 
@@ -55,7 +55,7 @@ def indexer(common):
 )
 @common_options
 @pass_state
-def scheduler(common, max_queued, group, min_cpu, min_io):
+def scheduler(common: SharedArgs, max_queued: int, group: str, min_cpu: int, min_io: int) -> None:
     sched = NetkanScheduler(
         common.netkan_repo, common.ckanmeta_repo, common.queue,
         nonhooks_group=(group == 'all' or group == 'nonhooks'),
@@ -69,17 +69,17 @@ def scheduler(common, max_queued, group, min_cpu, min_io):
 @click.command()
 @common_options
 @pass_state
-def mirrorer(common):
+def mirrorer(common: SharedArgs) -> None:
     Mirrorer(
         common.ckanmeta_repo, common.ia_access, common.ia_secret,
-        common.ia_collection
+        common.ia_collection, common.token
     ).process_queue(common.queue, common.timeout)
 
 
 @click.command()
 @common_options
 @pass_state
-def spacedock_adder(common):
+def spacedock_adder(common: SharedArgs) -> None:
     sd_adder = SpaceDockAdder(
         common.queue,
         common.timeout,

--- a/netkan/netkan/cli/utilities.py
+++ b/netkan/netkan/cli/utilities.py
@@ -8,7 +8,7 @@ from pathlib import Path
 import boto3
 import click
 
-from .common import common_options, pass_state
+from .common import common_options, pass_state, SharedArgs
 
 from ..status import ModStatus
 from ..download_counter import DownloadCounter
@@ -24,7 +24,7 @@ from ..mirrorer import Mirrorer
 )
 @common_options
 @pass_state
-def auto_freezer(common, days_limit):
+def auto_freezer(common: SharedArgs, days_limit: int) -> None:
     afr = AutoFreezer(
         common.netkan_repo,
         common.github_pr,
@@ -36,7 +36,7 @@ def auto_freezer(common, days_limit):
 @click.command()
 @common_options
 @pass_state
-def download_counter(common):
+def download_counter(common: SharedArgs) -> None:
     logging.info('Starting Download Count Calculation...')
     DownloadCounter(
         common.netkan_repo,
@@ -59,7 +59,7 @@ def download_counter(common):
     '--interval', envvar='STATUS_INTERVAL', default=300,
     help='Dump status to S3 every `interval` seconds',
 )
-def export_status_s3(status_bucket, status_key, interval):
+def export_status_s3(status_bucket: str, status_key: str, interval: bool) -> None:
     frequency = 'every {} seconds'.format(
         interval) if interval else 'once'
     logging.info('Exporting to s3://%s/%s %s',
@@ -73,13 +73,13 @@ def export_status_s3(status_bucket, status_key, interval):
 
 
 @click.command()
-def dump_status():
+def dump_status() -> None:
     click.echo(json.dumps(ModStatus.export_all_mods()))
 
 
 @click.command()
 @click.argument('filename')
-def restore_status(filename):
+def restore_status(filename: str) -> None:
     click.echo(
         'To keep within free tier rate limits, this could take some time'
     )
@@ -90,7 +90,7 @@ def restore_status(filename):
 @click.command()
 @common_options
 @pass_state
-def recover_status_timestamps(common):
+def recover_status_timestamps(common: SharedArgs) -> None:
     ModStatus.recover_timestamps(common.ckanmeta_repo)
 
 
@@ -101,7 +101,7 @@ def recover_status_timestamps(common):
 @click.option(
     '--service-name', help='Name of ECS Service to restart',
 )
-def redeploy_service(cluster, service_name):
+def redeploy_service(cluster: str, service_name: str) -> None:
     click.secho(
         'Forcing redeployment of {}:{}'.format(cluster, service_name),
         fg='green'
@@ -140,7 +140,7 @@ def redeploy_service(cluster, service_name):
 )
 @common_options
 @pass_state
-def ticket_closer(common, days_limit):
+def ticket_closer(common: SharedArgs, days_limit: int) -> None:
     TicketCloser(common.token).close_tickets(days_limit)
 
 
@@ -153,7 +153,7 @@ def ticket_closer(common, days_limit):
     type=click.Path(exists=True, writable=True),
     help='Absolute path to the mod download cache'
 )
-def clean_cache(days, cache):
+def clean_cache(days: int, cache: str) -> None:
     older_than = (
         datetime.datetime.now() - datetime.timedelta(days=int(days))
     ).timestamp()
@@ -174,7 +174,7 @@ def clean_cache(days, cache):
 )
 @common_options
 @pass_state
-def mirror_purge_epochs(common, dry_run):
+def mirror_purge_epochs(common: SharedArgs, dry_run: bool) -> None:
     Mirrorer(
         common.ckanmeta_repo, common.ia_access,
         common.ia_secret, common.ia_collection

--- a/netkan/netkan/common.py
+++ b/netkan/netkan/common.py
@@ -1,15 +1,16 @@
 from git import Repo
+from typing import List, Iterable, Dict
 
 from .metadata import Netkan
 from .repos import NetkanRepo
 
 
-def netkans(path, ids):
+def netkans(path: str, ids: Iterable[str]) -> Iterable[Netkan]:
     repo = NetkanRepo(Repo(path))
     return (Netkan(p) for p in repo.nk_paths(ids))
 
 
-def sqs_batch_entries(messages, batch_size=10):
+def sqs_batch_entries(messages: Iterable[Dict[str, str]], batch_size: int = 10) -> Iterable[List[Dict[str, str]]]:
     batch = []
     for msg in messages:
         batch.append(msg)
@@ -20,6 +21,6 @@ def sqs_batch_entries(messages, batch_size=10):
         yield batch
 
 
-def pull_all(repos):
+def pull_all(repos: Iterable[Repo]) -> None:
     for repo in repos:
         repo.remotes.origin.pull('master', strategy_option='theirs')

--- a/netkan/netkan/download_counter.py
+++ b/netkan/netkan/download_counter.py
@@ -4,46 +4,54 @@ import re
 from pathlib import Path
 from json.decoder import JSONDecodeError
 import requests
+import git
+from typing import Optional, Dict, Any
 
 from .metadata import Netkan
 from .utils import repo_file_add_or_changed
-from .repos import NetkanRepo
+from .repos import NetkanRepo, CkanMetaRepo
 
 
 class NetkanDownloads(Netkan):
     GITHUB_PATTERN = re.compile('^([^/]+)/([^/]+)')
     GITHUB_API = 'https://api.github.com/repos/'
 
-    def __init__(self, filename=None, github_token=None, contents=None):
+    def __init__(self, filename: Path = None, github_token: str = None, contents: str = None) -> None:
         super().__init__(filename, contents)
         self.github_headers = {'Authorization': f'token {github_token}'}
         self.github_token = github_token
 
     @property
-    def spacedock_api(self):
+    def spacedock_api(self) -> str:
         return f'https://spacedock.info/api/mod/{self.kref_id}'
 
     @property
-    def github_repo_api(self):
-        (user, repo) = self.GITHUB_PATTERN.match(self.kref_id).groups()
-        return f'{self.GITHUB_API}{user}/{repo}'
+    def github_repo_api(self) -> Optional[str]:
+        if self.kref_id:
+            match = self.GITHUB_PATTERN.match(self.kref_id)
+            if match:
+                (user, repo) = match.groups()
+                return f'{self.GITHUB_API}{user}/{repo}'
+        return None
 
     @property
-    def curse_api(self):
-        if self.kref_id.isnumeric():
+    def curse_api(self) -> str:
+        if self.kref_id and self.kref_id.isnumeric():
             return f'https://api.cfwidget.com/project/{self.kref_id}'
         return f'https://api.cfwidget.com/kerbal/ksp-mods/{self.kref_id}'
 
     @property
-    def remote_netkan(self):
+    def remote_netkan(self) -> Optional[str]:
         return self.kref_id
 
-    def count_from_spacedock(self):
+    def count_from_spacedock(self) -> int:
         return requests.get(self.spacedock_api).json()['downloads']
 
-    def count_from_github(self, url=None):
+    def count_from_github(self, url: str = None) -> int:
         if not url:
             url = self.github_repo_api
+        if not url:
+            return 0
         releases = requests.get(
             f'{url}/releases', headers=self.github_headers
         ).json()
@@ -62,16 +70,18 @@ class NetkanDownloads(Netkan):
             total += self.count_from_github(url)
         return total
 
-    def count_from_curse(self):
+    def count_from_curse(self) -> int:
         return requests.get(self.curse_api).json()['downloads']['total']
 
-    def count_from_netkan(self):
-        return NetkanDownloads(
-            github_token=self.github_token,
-            contents=requests.get(self.remote_netkan).text
-        ).get_count()
+    def count_from_netkan(self) -> int:
+        if self.remote_netkan:
+            return NetkanDownloads(
+                github_token=self.github_token,
+                contents=requests.get(self.remote_netkan).text
+            ).get_count()
+        return 0
 
-    def get_count(self):
+    def get_count(self) -> int:
         count = 0
         if self.has_kref:
             try:
@@ -96,29 +106,29 @@ class NetkanDownloads(Netkan):
 
 class DownloadCounter:
 
-    def __init__(self, nk_repo, ckm_repo, github_token):
+    def __init__(self, nk_repo: NetkanRepo, ckm_repo: CkanMetaRepo, github_token: str) -> None:
         self.nk_repo = nk_repo
         self.ckm_repo = ckm_repo
-        self.counts = {}
+        self.counts: Dict[str, Any] = {}
         self.github_token = github_token
         self.output_file = Path(
             self.ckm_repo.git_repo.working_dir, 'download_counts.json'
         )
 
-    def get_counts(self):
+    def get_counts(self) -> None:
         for netkan in self.nk_repo.all_nk_paths():
-            netkan = NetkanDownloads(netkan, self.github_token)
-            count = netkan.get_count()
+            netkanDl = NetkanDownloads(netkan, self.github_token)
+            count = netkanDl.get_count()
             if count > 0:
-                logging.info('Count for %s is %s', netkan.identifier, count)
-                self.counts[netkan.identifier] = count
+                logging.info('Count for %s is %s', netkanDl.identifier, count)
+                self.counts[netkanDl.identifier] = count
 
-    def write_json(self):
+    def write_json(self) -> None:
         self.output_file.write_text(
             json.dumps(self.counts, sort_keys=True, indent=4)
         )
 
-    def commit_counts(self):
+    def commit_counts(self) -> None:
         index = self.ckm_repo.git_repo.index
         index.add([self.output_file.as_posix()])
         index.commit(
@@ -127,7 +137,7 @@ class DownloadCounter:
         logging.info('Download counts changed and commited')
         self.ckm_repo.git_repo.remotes.origin.push('master')
 
-    def update_counts(self):
+    def update_counts(self) -> None:
         self.get_counts()
         self.ckm_repo.git_repo.remotes.origin.pull(
             'master', strategy_option='ours'

--- a/netkan/netkan/github_pr.py
+++ b/netkan/netkan/github_pr.py
@@ -7,12 +7,12 @@ import logging
 # and learning how it worked seemed like a waste.
 class GitHubPR:
 
-    def __init__(self, token, repo, user):
+    def __init__(self, token: str, repo: str, user: str) -> None:
         self.token = token
         self.repo = repo
         self.user = user
 
-    def create_pull_request(self, title, branch, body):
+    def create_pull_request(self, title: str, branch: str, body: str) -> None:
         headers = {
             'Authorization': 'token {}'.format(self.token),
             'Content-Type': 'application/json'

--- a/netkan/netkan/mirror_description_template.jinja2
+++ b/netkan/netkan/mirror_description_template.jinja2
@@ -1,0 +1,12 @@
+{{ mod.abstract }}<br>
+{%- if mod.resources -%}
+    {%- if mod.resources.homepage -%}
+        <br>Homepage: <a href="{{mod.resources.homepage}}">{{mod.resources.homepage}}</a>
+    {%- endif -%}
+    {%- if mod.resources.repository -%}
+        <br>Repository: <a href="{{mod.resources.repository}}">{{mod.resources.repository}}</a>
+    {%- endif -%}
+{%- endif -%}
+{%- if mod.licenses() -%}
+    <br>License(s): {{ ' '.join(mod.licenses()) }}
+{%- endif -%}

--- a/netkan/netkan/notifications.py
+++ b/netkan/netkan/notifications.py
@@ -2,38 +2,39 @@ import os
 import sys
 import logging
 import discord
+from typing import Iterable, Type
+from types import TracebackType
 
 
-def catch_all(exception_type, value, stacktrace):
+def catch_all(type_: Type[BaseException], value: BaseException, traceback: TracebackType) -> None:
     # Log an error for Discord
-    logging.error("Uncaught exception:", exc_info=(exception_type, value, stacktrace))
+    logging.error("Uncaught exception:", exc_info=(type_, value, traceback))
     # Pass to default handler (prints, exits, etc.)
-    sys.__excepthook__(exception_type, value, stacktrace)
+    sys.__excepthook__(type_, value, traceback)
 
 
 class DiscordLogHandler(logging.Handler):
 
-    def __init__(self, webhook_id, webhook_token):
+    def __init__(self, webhook_id: str, webhook_token: str) -> None:
         super().__init__()
         self.webhook = discord.Webhook.partial(webhook_id, webhook_token,
                                                adapter=discord.RequestsWebhookAdapter())
 
-    def emit(self, record):
+    def emit(self, record: logging.LogRecord) -> None:
         fmt = self.format(record)
         as_code = "\n" in fmt
         for part in self._message_parts(fmt, as_code):
             self.webhook.send(part)
 
-
     @staticmethod
-    def _message_parts(msg, as_code, max_len=2000):
+    def _message_parts(msg: str, as_code: bool, max_len: int = 2000) -> Iterable[str]:
         if as_code:
             return (f'```{msg[start:start+max_len-6]}```'
                     for start in range(0, len(msg), max_len - 6))
         return (msg[start:start+max_len] for start in range(0, len(msg), max_len))
 
 
-def setup_log_handler(debug=False):
+def setup_log_handler(debug: bool = False) -> bool:
     if not sys.argv[0].endswith('gunicorn'):
         level = logging.DEBUG if debug else logging.INFO
         logging.basicConfig(

--- a/netkan/netkan/repos.py
+++ b/netkan/netkan/repos.py
@@ -1,8 +1,9 @@
 import logging
 from pathlib import Path
 from git import Repo
+from typing import Iterable, Optional
 
-from .metadata import Netkan, Ckan, CkanGroup
+from .metadata import Netkan, Ckan
 
 
 class NetkanRepo:
@@ -16,27 +17,27 @@ class NetkanRepo:
     FROZEN_SUFFIX = 'frozen'
     NETKAN_GLOB = f'**/*.{UNFROZEN_SUFFIX}'
 
-    def __init__(self, git_repo):
+    def __init__(self, git_repo: Repo) -> None:
         self.git_repo = git_repo
         self.nk_dir = Path(self.git_repo.working_dir, self.NETKAN_DIR)
 
-    def nk_path(self, identifier):
+    def nk_path(self, identifier: str) -> Path:
         return self.nk_dir.joinpath(f'{identifier}.{self.UNFROZEN_SUFFIX}')
 
-    def frozen_path(self, identifier):
+    def frozen_path(self, identifier: str) -> Path:
         return self.nk_dir.joinpath(f'{identifier}.{self.FROZEN_SUFFIX}')
 
-    def all_nk_paths(self):
+    def all_nk_paths(self) -> Iterable[Path]:
         return sorted(self.nk_dir.glob(self.NETKAN_GLOB),
                       key=self._nk_sort)
 
-    def nk_paths(self, identifiers):
+    def nk_paths(self, identifiers: Iterable[str]) -> Iterable[Path]:
         return (self.nk_path(identifier) for identifier in identifiers)
 
-    def netkans(self):
+    def netkans(self) -> Iterable[Netkan]:
         return (Netkan(f) for f in self.all_nk_paths())
 
-    def _nk_sort(self, p):
+    def _nk_sort(self, p: Path) -> str:
         return p.stem.casefold()
 
 
@@ -48,15 +49,16 @@ class CkanMetaRepo:
 
     CKANMETA_GLOB = '**/*.ckan'
 
-    def __init__(self, git_repo):
+    def __init__(self, git_repo: Repo) -> None:
         self.git_repo = git_repo
         self.ckm_dir = Path(self.git_repo.working_dir)
 
-    def mod_path(self, identifier):
+    def mod_path(self, identifier: str) -> Path:
         return self.ckm_dir.joinpath(identifier)
 
-    def ckans(self, identifier):
+    def ckans(self, identifier: str) -> Iterable[Ckan]:
         return (Ckan(p) for p in self.mod_path(identifier).glob(self.CKANMETA_GLOB))
 
-    def group(self, identifier):
-        return CkanGroup(self, identifier)
+    def highest_version(self, identifier: str) -> Optional[Ckan.Version]:
+        highest = max(self.ckans(identifier), default=None, key=lambda ck: ck.version)
+        return highest.version if highest else None

--- a/netkan/netkan/ticket_closer.py
+++ b/netkan/netkan/ticket_closer.py
@@ -5,10 +5,10 @@ import github
 
 class TicketCloser:
 
-    def __init__(self, token):
+    def __init__(self, token: str) -> None:
         self._gh = github.Github(token)
 
-    def close_tickets(self, days_limit=7):
+    def close_tickets(self, days_limit: int = 7) -> None:
         date_cutoff = datetime.datetime.now() - datetime.timedelta(days=days_limit)
 
         for repo_name in ['CKAN', 'NetKAN']:

--- a/netkan/netkan/utils.py
+++ b/netkan/netkan/utils.py
@@ -2,9 +2,10 @@ import logging
 import subprocess
 from pathlib import Path
 from git import Repo
+from typing import Union
 
 
-def init_repo(metadata, path, deep_clone):
+def init_repo(metadata: str, path: str, deep_clone: bool) -> Repo:
     if not metadata:
         return None
     clone_path = Path(path)
@@ -19,7 +20,7 @@ def init_repo(metadata, path, deep_clone):
     return repo
 
 
-def init_ssh(key, key_path: Path):
+def init_ssh(key: str, key_path: Path) -> None:
     if not key:
         logging.warning('Private Key required for SSH Git')
         return
@@ -35,7 +36,7 @@ def init_ssh(key, key_path: Path):
         Path(key_path, 'known_hosts').write_text(scan.stdout.decode('utf-8'))
 
 
-def repo_file_add_or_changed(repo, filename):
+def repo_file_add_or_changed(repo: Repo, filename: Union[str, Path]) -> bool:
     relative_file = Path(filename).relative_to(repo.working_dir).as_posix()
     if relative_file in repo.untracked_files:
         return True

--- a/netkan/netkan/webhooks/__init__.py
+++ b/netkan/netkan/webhooks/__init__.py
@@ -15,21 +15,21 @@ from .github_inflate import github_inflate
 from .github_mirror import github_mirror
 
 
-def create_app():
+def create_app() -> Flask:
     # Set up Discord logger so we can see errors
     if setup_log_handler():
         sys.excepthook = catch_all
 
     app = Flask(__name__)
 
-    init_ssh(os.environ.get('SSH_KEY'), Path(Path.home(), '.ssh'))
+    init_ssh(os.environ.get('SSH_KEY', ''), Path(Path.home(), '.ssh'))
 
     # Set up config
     app.config['secret'] = os.environ.get('XKAN_GHSECRET')
     app.config['nk_repo'] = NetkanRepo(
-        init_repo(os.environ.get('NETKAN_REMOTE'), '/tmp/NetKAN', False))
+        init_repo(os.environ.get('NETKAN_REMOTE', ''), '/tmp/NetKAN', False))
     app.config['ckm_repo'] = CkanMetaRepo(
-        init_repo(os.environ.get('CKANMETA_REMOTE'), '/tmp/CKAN-meta', False))
+        init_repo(os.environ.get('CKANMETA_REMOTE', ''), '/tmp/CKAN-meta', False))
     app.config['repos'] = [app.config['nk_repo'].git_repo, app.config['ckm_repo'].git_repo]
     app.config['client'] = boto3.client('sqs')
     sqs = boto3.resource('sqs')

--- a/netkan/netkan/webhooks/errors.py
+++ b/netkan/netkan/webhooks/errors.py
@@ -1,10 +1,11 @@
 from flask import Blueprint, current_app
+from typing import Tuple
 
 
 errors = Blueprint('errors', __name__)  # pylint: disable=invalid-name
 
 
 @errors.app_errorhandler(Exception)
-def handle_error(exc):
+def handle_error(exc: Exception) -> Tuple[str, int]:
     current_app.logger.error("Uncaught exception:", exc_info=exc)
     return '', 500

--- a/netkan/netkan/webhooks/github_utils.py
+++ b/netkan/netkan/webhooks/github_utils.py
@@ -2,11 +2,12 @@ from functools import wraps
 import hashlib
 import hmac
 from flask import current_app, request
+from typing import Callable, Tuple, Any, Dict, Optional
 
 
-def signature_required(func):
+def signature_required(func: Callable[..., Any]) -> Callable[..., Any]:
     @wraps(func)
-    def decorated_function(*args, **kwargs):
+    def decorated_function(*args: Any, **kwargs: Any) -> Tuple[str, int]:
         # Make sure it's from GitHub
         if not sig_match(request.headers.get('X-Hub-Signature'), request.data):
             current_app.logger.warning('X-Hub-Signature did not match the request data')
@@ -15,7 +16,7 @@ def signature_required(func):
     return decorated_function
 
 
-def sig_match(req_sig, body):
+def sig_match(req_sig: Optional[str], body: bytes) -> bool:
     # Make sure a secret is defined in our config
     hook_secret = current_app.config['secret']
     if not hook_secret:

--- a/netkan/netkan/webhooks/inflate.py
+++ b/netkan/netkan/webhooks/inflate.py
@@ -1,4 +1,5 @@
 from flask import Blueprint, current_app, request
+from typing import Tuple
 
 from ..common import netkans, sqs_batch_entries, pull_all
 
@@ -10,7 +11,7 @@ inflate = Blueprint('inflate', __name__)  # pylint: disable=invalid-name
 # Handles: https://netkan.ksp-ckan.space/inflate
 # Payload: { "identifiers": [ "Id1", "Id2", ... ] }
 @inflate.route('/inflate', methods=['POST'])
-def inflate_hook():
+def inflate_hook() -> Tuple[str, int]:
     # SpaceDock doesn't set the `Content-Type: application/json` header
     ids = request.get_json(force=True).get('identifiers')
     if not ids:

--- a/netkan/netkan/webhooks/spacedock_add.py
+++ b/netkan/netkan/webhooks/spacedock_add.py
@@ -1,6 +1,7 @@
 from hashlib import md5
 import json
 from flask import Blueprint, current_app, request
+from typing import Tuple, Dict, Any
 
 from ..common import sqs_batch_entries
 
@@ -23,7 +24,7 @@ spacedock_add = Blueprint('spacedock_add', __name__)  # pylint: disable=invalid-
 #     mod_url:           https://spacedock.info/mod/12345
 #     site_name:         SpaceDock
 @spacedock_add.route('/add', methods=['POST'])
-def add_hook():
+def add_hook() -> Tuple[str, int]:
     # Submit add requests to queue in batches of <=10
     messages = [batch_message(request.form)]
     for batch in sqs_batch_entries(messages):
@@ -35,7 +36,7 @@ def add_hook():
     return '', 204
 
 
-def batch_message(raw):
+def batch_message(raw: Dict[str, Any]) -> Dict[str, Any]:
     body = json.dumps(raw)
     return {
         'Id':                     '1',

--- a/netkan/netkan/webhooks/spacedock_inflate.py
+++ b/netkan/netkan/webhooks/spacedock_inflate.py
@@ -1,7 +1,9 @@
 from pathlib import Path
 from flask import Blueprint, current_app, request
+from typing import Tuple, Iterable
 
 from ..common import sqs_batch_entries, pull_all
+from ..metadata import Netkan
 
 
 spacedock_inflate = Blueprint('spacedock_inflate', __name__)  # pylint: disable=invalid-name
@@ -15,11 +17,11 @@ spacedock_inflate = Blueprint('spacedock_inflate', __name__)  # pylint: disable=
 #                 version-update - Default version changed
 #                 delete         - Mod was deleted from SpaceDock
 @spacedock_inflate.route('/inflate', methods=['POST'])
-def inflate_hook():
+def inflate_hook() -> Tuple[str, int]:
     # Make sure our NetKAN and CKAN-meta repos are up to date
     pull_all(current_app.config['repos'])
     # Get the relevant netkans
-    nks = find_netkans(request.form.get('mod_id'))
+    nks = find_netkans(request.form.get('mod_id', ''))
     if nks:
         if request.form.get('event_type') == 'delete':
             # Just let the team know on Discord
@@ -40,6 +42,6 @@ def inflate_hook():
     return 'No such module', 404
 
 
-def find_netkans(sd_id):
+def find_netkans(sd_id: str) -> Iterable[Netkan]:
     all_nk = current_app.config['nk_repo'].netkans()
     return (nk for nk in all_nk if nk.kref_src == 'spacedock' and nk.kref_id == sd_id)

--- a/netkan/setup.py
+++ b/netkan/setup.py
@@ -10,7 +10,7 @@ setup(
     author_email='techman83@gmail.com',
     packages=find_packages(),
     package_data={
-        "": [ "*.txt" ],
+        "": ["*.txt", "*.jinja2"],
     },
     install_requires=[
         'boto3',
@@ -21,10 +21,12 @@ setup(
         'python-dateutil>=2.1,<2.8.1',
         'requests',
         'flask',
+        'jinja2',
         'internetarchive',
         'gunicorn>=19.9,!=20.0.0',
         'discord',
         'PyGithub',
+        'mypy',
     ],
     entry_points={
         'console_scripts': [

--- a/netkan/setup.py
+++ b/netkan/setup.py
@@ -26,7 +26,6 @@ setup(
         'gunicorn>=19.9,!=20.0.0',
         'discord',
         'PyGithub',
-        'mypy',
     ],
     entry_points={
         'console_scripts': [
@@ -39,6 +38,9 @@ setup(
             'pylint',
             'autopep8',
             'troposphere',
+        ],
+        'test': [
+            'mypy',
         ]
     },
 )

--- a/netkan/tests/metadata.py
+++ b/netkan/tests/metadata.py
@@ -313,20 +313,3 @@ class TestVersionComparison(unittest.TestCase):
         v2 = Ckan.Version('2.0')
 
         self.assertTrue(v1 < v2)
-
-
-class TestCkanGroup(unittest.TestCase):
-
-    TEST_PATH = Path(PurePath(__file__).parent, 'testdata/CKAN-meta')
-
-    def test_highest_version_epoch(self):
-        ckg = CkanMetaRepo(Repo.init(self.TEST_PATH)).group('AdequateMod')
-        self.assertEqual(ckg.highest_version().string, '1:0.2')
-
-    def test_highest_version_v(self):
-        ckg = CkanMetaRepo(Repo.init(self.TEST_PATH)).group('AmazingMod')
-        self.assertEqual(ckg.highest_version().string, 'v1.1')
-
-    def test_highest_version_numeric(self):
-        ckg = CkanMetaRepo(Repo.init(self.TEST_PATH)).group('AwesomeMod')
-        self.assertEqual(ckg.highest_version().string, '0.11')

--- a/netkan/tests/mirrorer.py
+++ b/netkan/tests/mirrorer.py
@@ -68,6 +68,7 @@ class TestCkanMirrorRedistributable(unittest.TestCase):
                              'x-amz-auto-make-bucket': "1",
                          })
 
+
 class TestCkanMirrorRestricted(unittest.TestCase):
 
     def setUp(self):
@@ -85,6 +86,7 @@ class TestCkanMirrorRestricted(unittest.TestCase):
         self.assertFalse(self.ckan_mirror.redistributable)
         self.assertFalse(self.ckan_mirror.can_mirror)
 
+
 class TestCkanMirrorGitHub(unittest.TestCase):
 
     def setUp(self):
@@ -96,8 +98,13 @@ class TestCkanMirrorGitHub(unittest.TestCase):
         }""")
 
     def test_source_download(self):
-        self.assertEqual(self.ckan_mirror.source_download,
+        self.assertEqual(self.ckan_mirror.source_download(),
                          "https://github.com/HebaruSan/Astrogator/archive/master.zip")
+
+    def test_source_download_alt_branch(self):
+        self.assertEqual(self.ckan_mirror.source_download('primary'),
+                         "https://github.com/HebaruSan/Astrogator/archive/primary.zip")
+
 
 class TestCkanMirrorGitLab(unittest.TestCase):
 
@@ -110,8 +117,9 @@ class TestCkanMirrorGitLab(unittest.TestCase):
         }""")
 
     def test_source_download(self):
-        self.assertEqual(self.ckan_mirror.source_download,
+        self.assertEqual(self.ckan_mirror.source_download(),
                          "https://gitlab.com/N70/Kerbalism/-/archive/master/Kerbalism-master.zip")
+
 
 class TestCkanMirrorButBucket(unittest.TestCase):
 
@@ -124,5 +132,5 @@ class TestCkanMirrorButBucket(unittest.TestCase):
         }""")
 
     def test_source_download(self):
-        self.assertEqual(self.ckan_mirror.source_download,
+        self.assertEqual(self.ckan_mirror.source_download(),
                          "https://bitbucket.org/blowfishpro/b9-aerospace/get/master.zip")

--- a/netkan/tests/scheduler.py
+++ b/netkan/tests/scheduler.py
@@ -13,9 +13,9 @@ class TestScheduler(unittest.TestCase):
 
     def setUp(self):
         self.nk_repo = NetkanRepo(Repo.init(self.test_data))
-        self.ckm_repo = CkanMetaRepo(Repo(self.ckm_root))
+        self.ckm_repo = CkanMetaRepo(Repo.init(self.ckm_root))
         self.scheduler = NetkanScheduler(self.nk_repo, self.ckm_repo, 'TestyMcTestFace')
-        self.messages = (nk.sqs_message(self.ckm_repo.group(nk.identifier))
+        self.messages = (nk.sqs_message(self.ckm_repo.highest_version(nk.identifier))
                          for nk in self.scheduler.nk_repo.netkans())
 
     def test_netkans(self):
@@ -40,7 +40,7 @@ class TestScheduler(unittest.TestCase):
         test_data = Path(PurePath(__file__).parent, 'testdata/NetTEN')
         scheduler = NetkanScheduler(
             NetkanRepo(Repo.init(test_data)), self.ckm_repo, 'TestyMcTestFace')
-        messages = (nk.sqs_message(self.ckm_repo.group(nk.identifier))
+        messages = (nk.sqs_message(self.ckm_repo.highest_version(nk.identifier))
                     for nk in scheduler.nk_repo.netkans())
 
         batches = []

--- a/prod-stack.py
+++ b/prod-stack.py
@@ -784,7 +784,7 @@ services = [
         'name': 'Mirrorer',
         'command': 'mirrorer',
         'secrets': [
-            'IA_access', 'IA_secret', 'SSH_KEY'
+            'IA_access', 'IA_secret', 'SSH_KEY', 'GH_Token'
         ],
         'env': [
             ('CKANMETA_REMOTE', CKANMETA_REMOTE),


### PR DESCRIPTION
## Motivation

Python supports optional type hints, similar to declaring types in a compiled language. The type checker `mypy` uses these type hints to find issues in code, similar to a compiler.

- https://www.python.org/dev/peps/pep-0484/
- http://mypy-lang.org/

## Changes

- `mypy` installed by `setup.py`
- Run `mypy` when Docker builds the container
- Ignore the cache for git
- Add type hints for everything
- Manual concatenation of HTML strings for description sent to archive.org is replaced by a small Jinja2 template
- The Mirrorer now gets the actual default branch for GitHub repos instead of assuming `master`, using the API and token
- `CkanGroup` is now merged into `CkanMetaRepo` to avoid a circular import
- GitHub notifications about `.frozen` files in the NetKAN repo will now set `ModStatus.frozen = True` (previously we had to wait for the AutoFreezer to run)