### PR TITLE
Check release date in AutoFreezer

### DIFF
--- a/netkan/netkan/auto_freezer.py
+++ b/netkan/netkan/auto_freezer.py
@@ -59,13 +59,15 @@ class AutoFreezer:
 
     def _too_old(self, ident: str, update_cutoff: datetime) -> bool:
         status = ModStatus.get(ident)
+        release_date = getattr(status, 'release_date', None)
+        if release_date:
+            return release_date < update_cutoff
         last_indexed = getattr(status, 'last_indexed', None)
-        if not last_indexed:
-            # Never indexed since the start of status tracking = 4+ years old
-            # ... except for mods that were updated by the old webhooks :(
-            return False
-        else:
+        if last_indexed:
             return last_indexed < update_cutoff
+        # Never indexed since the start of status tracking = 4+ years old
+        # ... except for mods that were updated by the old webhooks :(
+        return False
 
     def _add_freezee(self, ident: str) -> None:
         self.nk_repo.git_repo.index.move([

--- a/netkan/netkan/indexer.py
+++ b/netkan/netkan/indexer.py
@@ -108,6 +108,9 @@ class CkanMessage:
             attrs['ModIdentifier'] = self.ModIdentifier
         if self.indexed:
             attrs['last_indexed'] = datetime.now(timezone.utc)
+        release_date = getattr(self.ckan, 'release_date', None)
+        if release_date:
+            attrs['release_date'] = release_date
         return attrs
 
     def _process_ckan(self) -> None:

--- a/netkan/netkan/status.py
+++ b/netkan/netkan/status.py
@@ -40,6 +40,7 @@ class ModStatus(Model):
     last_checked = UTCDateTimeAttribute(null=True)
     last_indexed = UTCDateTimeAttribute(null=True)
     last_inflated = UTCDateTimeAttribute(null=True)
+    release_date = UTCDateTimeAttribute(null=True)
     success = BooleanAttribute()
     frozen = BooleanAttribute(default=False)
     resources: 'MapAttribute[str, Any]' = MapAttribute(default={})


### PR DESCRIPTION
## Problems

The AutoFreezer from #96 has itself been in cryofreeze due to mass-update changes:

- KSP-CKAN/CKAN#2760
- KSP-CKAN/CKAN#2922
- KSP-CKAN/CKAN#2942
- KSP-CKAN/CKAN#3061
- KSP-CKAN/NetKAN#7542 through KSP-CKAN/NetKAN#7598

It uses `ModStatus.last_indexed` to detect idle mods, so anytime we re-index a mod due to a change in how we generate metadata, we effectively fool the AutoFreezer into thinking that the mod was just updated. In reality we should be checking when the most recent release came out.

## Background

After KSP-CKAN/CKAN#3059, we will be capturing mods' release dates in metadata. They will pass through the Indexer on their way to CKAN-meta.

## Changes

- Now `Ckan` parses `release_date` into a `datetime` object
- Now `ModStatus` has a `release_date` property
- Now the Indexer copies `Ckan.release_date` into `ModStatus.release_date`
- Now the AutoFreezer's `_too_old` check looks at `release_date` if it's defined and falls back to `last_indexed` otherwise

This way we will be able to detect idle mods again.