### PR TITLE
Send Discord notification when SD mods get (un)locked

### DIFF
--- a/netkan/netkan/webhooks/spacedock_inflate.py
+++ b/netkan/netkan/webhooks/spacedock_inflate.py
@@ -28,6 +28,18 @@ def inflate_hook():
             current_app.logger.error(
                 f'A SpaceDock mod has been deleted, affected netkans: {nk_msg}')
             return '', 204
+        elif request.form.get('event_type') == 'locked':
+            # Just let the team know on Discord
+            nk_msg = ', '.join(nk.identifier for nk in nks)
+            current_app.logger.error(
+                f'A SpaceDock mod has been locked, affected netkans: {nk_msg}')
+            return '', 204
+        elif request.form.get('event_type') == 'unlocked':
+            # Just let the team know on Discord
+            nk_msg = ', '.join(nk.identifier for nk in nks)
+            current_app.logger.error(
+                f'A SpaceDock mod has been unlocked again, affected netkans: {nk_msg}')
+            return '', 204
         else:
             # Submit them to the queue
             messages = (nk.sqs_message(CkanGroup(current_app.config['ckanmeta_repo'].working_dir, nk.identifier))


### PR DESCRIPTION
## Background
When https://github.com/KSP-SpaceDock/SpaceDock/pull/260 gets merged into master, SpaceDock admins have the ability to lock mods.
More information can be found in the linked PR, but in short, it unpublishes mods again, so they won't be accessible by the public (and our bot) anymore.

Depending on the reason of the lock, we might want to freeze the mod, or wait until the problem is resolved and the mod is published again.

After (un)locking a mod, SpaceDock will call the /inflate webhook with `"event_type": "locked"` or `"event_type": "unlocked"`.

## Changes
The webhook receives this and leaves a message in our `#netkan-bot` Discord channels just like we do for deleted mods.