### PR TITLE
Refactor/repo interactions

### DIFF
--- a/netkan/netkan/download_counter.py
+++ b/netkan/netkan/download_counter.py
@@ -129,9 +129,8 @@ class DownloadCounter:
         )
 
     def commit_counts(self) -> None:
-        index = self.ckm_repo.git_repo.index
-        index.add([self.output_file.as_posix()])
-        index.commit(
+        self.ckm_repo.commit(
+            [self.output_file.as_posix()],
             'NetKAN Updating Download Counts'
         )
         logging.info('Download counts changed and commited')

--- a/netkan/netkan/indexer.py
+++ b/netkan/netkan/indexer.py
@@ -5,11 +5,10 @@ from collections import deque
 from datetime import datetime, timezone
 from contextlib import contextmanager
 from dateutil.parser import parse
-from git import GitCommandError, Repo, Commit
-import boto3
 from typing import Generator, List, Optional, Type, Dict, Any, Deque
 from types import TracebackType
 
+from git import GitCommandError, Commit
 from .metadata import Ckan
 from .repos import CkanMetaRepo
 from .status import ModStatus
@@ -75,10 +74,9 @@ class CkanMessage:
             file.write(self.body)
 
     def commit_metadata(self) -> Commit:
-        index = self.ckm_repo.git_repo.index
-        index.add([self.mod_file.as_posix()])
-        commit = index.commit(
-            'NetKAN generated mods - {}'.format(self.mod_version)
+        commit = self.ckm_repo.commit(
+            [self.mod_file.as_posix()],
+            f'NetKAN generated mods - {self.mod_version}'
         )
         logging.info('Committing %s', self.mod_version)
         self.indexed = True

--- a/netkan/netkan/indexer.py
+++ b/netkan/netkan/indexer.py
@@ -3,12 +3,13 @@ import logging
 from pathlib import Path, PurePath
 from collections import deque
 from datetime import datetime, timezone
-from contextlib import contextmanager
-from dateutil.parser import parse
-from typing import Generator, List, Optional, Type, Dict, Any, Deque
+from typing import List, Optional, Type, Dict, Any, Deque
 from types import TracebackType
 
-from git import GitCommandError, Commit
+import boto3  # pylint: disable=unused-import
+from dateutil.parser import parse
+from git import Commit
+
 from .metadata import Ckan
 from .repos import CkanMetaRepo
 from .status import ModStatus
@@ -17,9 +18,11 @@ from .github_pr import GitHubPR
 
 class CkanMessage:
 
-    def __init__(self, msg: 'boto3.resources.factory.sqs.Message', ckm_repo: CkanMetaRepo, github_pr: GitHubPR = None) -> None:
+    def __init__(self, msg: 'boto3.resources.factory.sqs.Message',
+                 ckm_repo: CkanMetaRepo, github_pr: GitHubPR = None) -> None:
         self.body = msg.body
         self.ckan = Ckan(contents=self.body)
+        # pylint: disable=invalid-name
         self.ModIdentifier: str
         self.CheckTime: str
         self.FileName: str
@@ -27,6 +30,7 @@ class CkanMessage:
         self.Staged: bool
         self.ErrorMessage = None
         self.WarningMessages: Optional[str] = None
+        # pylint: enable=invalid-name
         self.indexed = False
         for item in msg.message_attributes.items():
             attr_type = '{}Value'.format(item[1]['DataType'])
@@ -82,47 +86,6 @@ class CkanMessage:
         self.indexed = True
         return commit
 
-    @contextmanager
-    def change_branch(self) -> Generator[None, None, None]:
-        try:
-            self.ckm_repo.git_repo.remotes.origin.fetch(self.mod_version)
-            if self.mod_version not in self.ckm_repo.git_repo.heads:
-                self.ckm_repo.git_repo.create_head(
-                    self.mod_version,
-                    getattr(
-                        self.ckm_repo.git_repo.remotes.origin.refs,
-                        self.mod_version
-                    )
-                )
-            branch = getattr(
-                self.ckm_repo.git_repo.heads, self.mod_version
-            )
-            branch.checkout()
-        except GitCommandError:
-            if self.mod_version not in self.ckm_repo.git_repo.heads:
-                branch = self.ckm_repo.git_repo.create_head(self.mod_version)
-            else:
-                branch = getattr(
-                    self.ckm_repo.git_repo.heads, self.mod_version
-                )
-            branch.checkout()
-        try:
-            yield
-        finally:
-            if self.indexed:
-                # It's unlikely will hit a scenario where the metadata has
-                # changed upstream of us, but the bot should win if it does.
-                try:
-                    self.ckm_repo.git_repo.remotes.origin.pull(
-                        self.mod_version, strategy_option='ours'
-                    )
-                except GitCommandError:
-                    pass
-                self.ckm_repo.git_repo.remotes.origin.push(
-                    '{mod}:{mod}'.format(mod=self.mod_version)
-                )
-            self.ckm_repo.git_repo.heads.master.checkout()
-
     def status_attrs(self, new: bool = False) -> Dict[str, Any]:
         inflation_time = parse(self.CheckTime)
         attrs: Dict[str, Any] = {
@@ -170,27 +133,20 @@ class CkanMessage:
             ModStatus(**self.status_attrs(True)).save()
 
     def process_ckan(self) -> None:
-        # Process regular CKAN
-        if not self.Staged:
-            self._process_ckan()
+        # Staged CKANs that were inflated successfully and have been changed
+        if self.Staged and self.Success and self.metadata_changed():
+            with self.ckm_repo.change_branch(self.mod_version):
+                self._process_ckan()
+            if self.indexed and self.github_pr:
+                self.github_pr.create_pull_request(
+                    title=f'NetKAN inflated: {self.ModIdentifier}',
+                    branch=self.mod_version,
+                    body=getattr(self, 'StagingReason',
+                                 f'{self.ModIdentifier} has been staged, please test and merge')
+                )
             return
 
-        # TODO: This is a bit of hack to get this across the line, no mod
-        #       version, no valid name to stage the branch
-        if not self.Success:
-            self._process_ckan()
-            return
-
-        # Staging operations
-        with self.change_branch():
-            self._process_ckan()
-        if self.indexed and self.github_pr:
-            self.github_pr.create_pull_request(
-                title=f'NetKAN inflated: {self.ModIdentifier}',
-                branch=self.mod_version,
-                body=getattr(self, 'StagingReason',
-                             f'{self.ModIdentifier} has been staged, please test and merge')
-            )
+        self._process_ckan()
 
     @property
     def delete_attrs(self) -> Dict[str, Any]:
@@ -219,13 +175,14 @@ class MessageHandler:
     # we can ensure we call close on it and run our handler inside
     # a context manager
     def __enter__(self) -> 'MessageHandler':
-        if str(self.ckm_repo.git_repo.active_branch) != 'master':
-            self.ckm_repo.git_repo.heads.master.checkout()
-        self.ckm_repo.git_repo.remotes.origin.pull('master', strategy_option='ours')
+        if not self.ckm_repo.is_active_branch('master'):
+            self.ckm_repo.checkout_branch('master')
+        self.ckm_repo.pull_remote_branch('master')
         return self
 
-    def __exit__(self, exc_type: Type[BaseException], exc_value: BaseException, traceback: TracebackType) -> None:
-        self.ckm_repo.git_repo.close()
+    def __exit__(self, exc_type: Type[BaseException],
+                 exc_value: BaseException, traceback: TracebackType) -> None:
+        self.ckm_repo.close_repo()
 
     def append(self, message: 'boto3.resources.factory.sqs.Message') -> None:
         ckan = CkanMessage(
@@ -253,6 +210,6 @@ class MessageHandler:
     def process_ckans(self) -> None:
         self._process_queue(self.master)
         if any(ckan.indexed for ckan in self.processed):
-            self.ckm_repo.git_repo.remotes.origin.pull('master', strategy_option='ours')
-            self.ckm_repo.git_repo.remotes.origin.push('master')
+            self.ckm_repo.pull_remote_branch('master')
+            self.ckm_repo.push_remote_branch('master')
         self._process_queue(self.staged)

--- a/netkan/netkan/repos.py
+++ b/netkan/netkan/repos.py
@@ -71,7 +71,7 @@ class CkanMetaRepo(XkanRepo):
         return self.ckm_dir.joinpath(identifier)
 
     def ckans(self, identifier: str) -> Iterable[Ckan]:
-        return (Ckan(p) for p in self.mod_path(identifier).glob(self.CKANMETA_GLOB))
+        return (Ckan(f) for f in self.mod_path(identifier).glob(self.CKANMETA_GLOB))
 
     def highest_version(self, identifier: str) -> Optional[Ckan.Version]:
         highest = max(self.ckans(identifier), default=None, key=lambda ck: ck.version)

--- a/netkan/tests/__init__.py
+++ b/netkan/tests/__init__.py
@@ -3,5 +3,6 @@ from .download_counter import *
 from .indexer import *
 from .metadata import *
 from .mirrorer import *
+from .repos import *
 from .scheduler import *
 from .utils import *

--- a/netkan/tests/indexer.py
+++ b/netkan/tests/indexer.py
@@ -154,11 +154,11 @@ class TestStagedCkan(TestUpdateCkan):
         self.message = CkanMessage(self.msg, self.ckm_repo)
 
     def test_ckan_message_changed(self):
-        with self.message.change_branch():
+        with self.message.ckm_repo.change_branch(self.message.mod_version):
             self.assertTrue(self.message.metadata_changed())
 
     def test_ckan_message_commit(self):
-        with self.message.change_branch():
+        with self.message.ckm_repo.change_branch(self.message.mod_version):
             self.message.write_metadata()
             c = self.message.commit_metadata()
             self.assertEqual(0, len(self.ckan_meta.untracked_files))
@@ -175,7 +175,7 @@ class TestStagedCkan(TestUpdateCkan):
 
     def test_ckan_message_change_branch(self):
         self.assertEqual(str(self.ckan_meta.active_branch), 'master')
-        with self.message.change_branch():
+        with self.message.ckm_repo.change_branch(self.message.mod_version):
             self.assertEqual(
                 str(self.ckan_meta.active_branch), 'DogeCoinFlag-v1.02'
             )

--- a/netkan/tests/repos.py
+++ b/netkan/tests/repos.py
@@ -1,3 +1,5 @@
+import shutil
+import tempfile
 import unittest
 from pathlib import Path, PurePath
 
@@ -5,15 +7,36 @@ from git import Repo
 from netkan.repos import NetkanRepo, CkanMetaRepo
 
 
-class TestNetkanRepo(unittest.TestCase):
-    nk_repo = NetkanRepo(Repo(Path(PurePath(__file__).parent, 'testdata/NetKAN')))
+class TestRepo(unittest.TestCase):
+
+    @classmethod
+    def setUpClass(cls):
+        super(TestRepo, cls).setUpClass()
+        cls.tmpdir = tempfile.TemporaryDirectory()
+        cls.working = Path(cls.tmpdir.name, 'working')
+        shutil.copytree(cls.test_data, cls.working)
+
+    @classmethod
+    def tearDownClass(cls):
+        super(TestRepo, cls).tearDownClass()
+        cls.tmpdir.cleanup()
+
+
+class TestNetkanRepo(TestRepo):
+    test_data = Path(PurePath(__file__).parent, 'testdata/NetKAN')
+
+    def setUp(self):
+        self.nk_repo = NetkanRepo(Repo.init(self.working))
 
     def test_nk_path(self):
         self.assertTrue(self.nk_repo.nk_path('DogeCoinFlag').exists())
 
 
-class TestCkanMetaRepo(unittest.TestCase):
-    ckm_repo = CkanMetaRepo(Repo(Path(PurePath(__file__).parent, 'testdata/CKAN-meta')))
+class TestCkanMetaRepo(TestRepo):
+    test_data = Path(PurePath(__file__).parent, 'testdata/CKAN-meta')
+
+    def setUp(self):
+        self.ckm_repo = CkanMetaRepo(Repo.init(self.working))
 
     def test_mod_path(self):
         self.assertTrue(self.ckm_repo.mod_path('AwesomeMod').exists())

--- a/netkan/tests/repos.py
+++ b/netkan/tests/repos.py
@@ -1,0 +1,19 @@
+import unittest
+from pathlib import Path, PurePath
+
+from git import Repo
+from netkan.repos import NetkanRepo, CkanMetaRepo
+
+
+class TestNetkanRepo(unittest.TestCase):
+    nk_repo = NetkanRepo(Repo(Path(PurePath(__file__).parent, 'testdata/NetKAN')))
+
+    def test_nk_path(self):
+        self.assertTrue(self.nk_repo.nk_path('DogeCoinFlag').exists())
+
+
+class TestCkanMetaRepo(unittest.TestCase):
+    ckm_repo = CkanMetaRepo(Repo(Path(PurePath(__file__).parent, 'testdata/CKAN-meta')))
+
+    def test_mod_path(self):
+        self.assertTrue(self.ckm_repo.mod_path('AwesomeMod').exists())


### PR DESCRIPTION
# Problem
We use the Repo class directly absolutely everywhere, along with lots of common operations. This makes considering switching git abstractions daunting.

This was a consequence of the organic development of an initial indexer replacement, to a massive improvement and increase in the number of things our automated indexing service is able to do. 

One of the big problems we currently have is our git interactions are IO heavy, it's hard to say if those are an issue with GitPython or how we're using it. Either way it's quite difficult to assess with the logic sprayed all over the place.

# Proposed Solution
This is very much an early iteration of what we can potentially do to work towards improving our interactions with git.

We have numerous common operations (list not exhaustive) that are common to how we use the repos:
* Commits
* Branching
* Push
* Pull

With the typing improvements, I notice we're returning objects only used in tests. Which in and of itself isn't a big deal, but something we ought to consider.

# Summary
This is a full refactor of the indexer git interactions, major changes as follows

* Indexer no longer accesses `Repo` directly
* `change_branch` context manager a function of `XkanRepo` with some documentation as it wasn't super clear about what it does
* Staged CKANs only branch when the inflation was successful and it involved a metadata change, this is a subtle but relatively major change in operation. Branch changing is a relatively expensive operation IO wise, so it really doesn't make sense to change branches when there is no change to the metadata. As an added bonus this cleans up `process_ckan`
* `download_counter` uses the commit function of CkanMetaRepo
* Some initial tests to ensure using a `nk_dir` / `ckm_dir` weren't broken in the change to a property
* Cleaned up some more of the linter warnings in the Indexer