### PR TITLE
Fix NetKAN hook freezer

### DIFF
--- a/netkan/netkan/webhooks/github_inflate.py
+++ b/netkan/netkan/webhooks/github_inflate.py
@@ -88,8 +88,8 @@ def freeze(ids: List[str]) -> None:
                 status = ModStatus.get(ident)
                 if not status.frozen:
                     logging.info('Marking frozen: %s', ident)
-                    status.frozen = True
-                    status.save()
+                    # https://readthedocs.org/projects/pynamodb/downloads/pdf/stable/
+                    status.update(actions=[ModStatus.frozen.set(True)])
             except ModStatus.DoesNotExist:
                 # No status, don't need to freeze
                 pass


### PR DESCRIPTION
The freezing feature from #173 was too slow and had to be disabled in #180.

Now instead of scanning all status records it just pull out the ones it needs. Should be way faster.

Fixes #179.