### PR TITLE
Stop abusing current_app.config in webhooks

### DIFF
--- a/netkan/netkan/webhooks/config.py
+++ b/netkan/netkan/webhooks/config.py
@@ -1,0 +1,29 @@
+import boto3
+
+from ..repos import NetkanRepo, CkanMetaRepo
+from ..utils import init_repo
+
+
+class WebhooksConfig:
+
+    # Ideally this would be __init__, but we want other modules to
+    # import a reference to our global config object before we set
+    # its properties, and that requires a temporary 'empty' state.
+    def setup(self, secret: str,
+              netkan_remote: str, netkan_path: str,
+              ckanmeta_remote: str, ckanmeta_path: str,
+              inf_queue_name: str, add_queue_name: str, mir_queue_name: str) -> None:
+
+        self.secret = secret
+        self.nk_repo = NetkanRepo(init_repo(netkan_remote, netkan_path, False))
+        self.ckm_repo = CkanMetaRepo(init_repo(ckanmeta_remote, ckanmeta_path, False))
+        self.repos = [self.nk_repo.git_repo, self.ckm_repo.git_repo]
+        self.client = boto3.client('sqs')
+        sqs = boto3.resource('sqs')
+        self.inflation_queue = sqs.get_queue_by_name(QueueName=inf_queue_name)
+        self.add_queue = sqs.get_queue_by_name(QueueName=add_queue_name)
+        self.mirror_queue = sqs.get_queue_by_name(QueueName=mir_queue_name)
+
+
+# Provide the active config to other modules
+current_config = WebhooksConfig()

--- a/netkan/netkan/webhooks/github_utils.py
+++ b/netkan/netkan/webhooks/github_utils.py
@@ -4,6 +4,8 @@ import hmac
 from flask import current_app, request
 from typing import Callable, Tuple, Any, Dict, Optional
 
+from .config import current_config
+
 
 def signature_required(func: Callable[..., Any]) -> Callable[..., Any]:
     @wraps(func)
@@ -18,7 +20,7 @@ def signature_required(func: Callable[..., Any]) -> Callable[..., Any]:
 
 def sig_match(req_sig: Optional[str], body: bytes) -> bool:
     # Make sure a secret is defined in our config
-    hook_secret = current_app.config['secret']
+    hook_secret = current_config.secret
     if not hook_secret:
         current_app.logger.warning('No secret is configured')
         return False

--- a/netkan/netkan/webhooks/inflate.py
+++ b/netkan/netkan/webhooks/inflate.py
@@ -2,6 +2,7 @@ from flask import Blueprint, current_app, request
 from typing import Tuple
 
 from ..common import netkans, sqs_batch_entries, pull_all
+from .config import current_config
 
 
 inflate = Blueprint('inflate', __name__)  # pylint: disable=invalid-name
@@ -18,13 +19,13 @@ def inflate_hook() -> Tuple[str, int]:
         current_app.logger.info('No identifiers received')
         return 'An array of identifiers is required', 400
     # Make sure our NetKAN and CKAN-meta repos are up to date
-    pull_all(current_app.config['repos'])
-    messages = (nk.sqs_message(current_app.config['ckm_repo'].highest_version(nk.identifier))
-                for nk in netkans(current_app.config['nk_repo'].git_repo.working_dir, ids))
+    pull_all(current_config.repos)
+    messages = (nk.sqs_message(current_config.ckm_repo.highest_version(nk.identifier))
+                for nk in netkans(current_config.nk_repo.git_repo.working_dir, ids))
     for batch in sqs_batch_entries(messages):
         current_app.logger.info(f'Queueing inflation request batch: {batch}')
-        current_app.config['client'].send_message_batch(
-            QueueUrl=current_app.config['inflation_queue'].url,
+        current_config.client.send_message_batch(
+            QueueUrl=current_config.inflation_queue.url,
             Entries=batch
         )
     return '', 204

--- a/netkan/netkan/webhooks/spacedock_add.py
+++ b/netkan/netkan/webhooks/spacedock_add.py
@@ -4,7 +4,7 @@ from flask import Blueprint, current_app, request
 from typing import Tuple, Dict, Any
 
 from ..common import sqs_batch_entries
-
+from .config import current_config
 
 spacedock_add = Blueprint('spacedock_add', __name__)  # pylint: disable=invalid-name
 
@@ -29,8 +29,8 @@ def add_hook() -> Tuple[str, int]:
     messages = [batch_message(request.form)]
     for batch in sqs_batch_entries(messages):
         current_app.logger.info(f'Queueing add request batch: {batch}')
-        current_app.config['client'].send_message_batch(
-            QueueUrl=current_app.config['add_queue'].url,
+        current_config.client.send_message_batch(
+            QueueUrl=current_config.add_queue.url,
             Entries=batch
         )
     return '', 204


### PR DESCRIPTION
## Problem

#173 refactored `CkanMetaRepo.group` out of existence, but it was still being called in a few places:

![image](https://user-images.githubusercontent.com/1559108/83495904-ef3f6d00-a47d-11ea-832b-0d24eefad32b.png)

(That exception was fixed in https://github.com/KSP-CKAN/NetKAN-Infra/commit/9dcb72e139830dd2391b1e909af1b8482ec0a959)

## Cause

Several shared objects that the webhooks need, including `ckm_repo`, are stuffed into the `current_app.config` dict, so they don't benefit from type checking.

## Changes

Now a new `WebhooksConfig` object, imported as `current_config` where needed, holds references to all these objects in properties that can be type checked. If the above bug is restored, `mypy` catches it thusly:

![image](https://user-images.githubusercontent.com/1559108/83495916-f36b8a80-a47d-11ea-96af-2137cbb0964b.png)