### PR TITLE
Set up SSH key before cloning repos in webhooks

### DIFF
--- a/netkan/netkan/webhooks/__init__.py
+++ b/netkan/netkan/webhooks/__init__.py
@@ -4,7 +4,6 @@ import boto3
 from flask import Flask
 from pathlib import Path
 
-from ..utils import init_ssh
 from ..notifications import setup_log_handler, catch_all
 from .config import current_config
 from .errors import errors
@@ -17,14 +16,12 @@ from .github_mirror import github_mirror
 
 class NetkanWebhooks(Flask):
 
-    def __init__(self, ssh_key: str) -> None:
+    def __init__(self) -> None:
         super().__init__(__name__)
 
         # Set up Discord logger so we can see errors
         if setup_log_handler():
             sys.excepthook = catch_all
-
-        init_ssh(ssh_key, Path(Path.home(), '.ssh'))
 
         # Add the hook handlers
         self.register_blueprint(errors)
@@ -38,6 +35,7 @@ class NetkanWebhooks(Flask):
 def create_app() -> NetkanWebhooks:
     # Set config values for other modules to retrieve
     current_config.setup(
+        os.environ.get('SSH_KEY', ''),
         os.environ.get('XKAN_GHSECRET', ''),
         os.environ.get('NETKAN_REMOTE', ''), '/tmp/NetKAN',
         os.environ.get('CKANMETA_REMOTE', ''), '/tmp/CKAN-meta',
@@ -45,4 +43,4 @@ def create_app() -> NetkanWebhooks:
         os.environ.get('ADD_SQS_QUEUE', ''),
         os.environ.get('MIRROR_SQS_QUEUE', '')
     )
-    return NetkanWebhooks(os.environ.get('SSH_KEY', ''))
+    return NetkanWebhooks()

--- a/netkan/netkan/webhooks/config.py
+++ b/netkan/netkan/webhooks/config.py
@@ -1,7 +1,8 @@
 import boto3
+from pathlib import Path
 
 from ..repos import NetkanRepo, CkanMetaRepo
-from ..utils import init_repo
+from ..utils import init_repo, init_ssh
 
 
 class WebhooksConfig:
@@ -9,15 +10,19 @@ class WebhooksConfig:
     # Ideally this would be __init__, but we want other modules to
     # import a reference to our global config object before we set
     # its properties, and that requires a temporary 'empty' state.
-    def setup(self, secret: str,
+    def setup(self, ssh_key: str, secret: str,
               netkan_remote: str, netkan_path: str,
               ckanmeta_remote: str, ckanmeta_path: str,
               inf_queue_name: str, add_queue_name: str, mir_queue_name: str) -> None:
 
         self.secret = secret
+        # Cloning the repos requires an SSH key set up in our home dir
+        init_ssh(ssh_key, Path(Path.home(), '.ssh'))
+
         self.nk_repo = NetkanRepo(init_repo(netkan_remote, netkan_path, False))
         self.ckm_repo = CkanMetaRepo(init_repo(ckanmeta_remote, ckanmeta_path, False))
         self.repos = [self.nk_repo.git_repo, self.ckm_repo.git_repo]
+
         self.client = boto3.client('sqs')
         sqs = boto3.resource('sqs')
         self.inflation_queue = sqs.get_queue_by_name(QueueName=inf_queue_name)


### PR DESCRIPTION
The webhooks aren't starting.

```
git.exc.GitCommandError: Cmd('git') failed due to: exit code(128)
  cmdline: git clone --depth=1 -v git@github.com:KSP-CKAN/NetKAN.git /tmp/NetKAN
  stderr: 'Cloning into '/tmp/NetKAN'...
Host key verification failed.
fatal: Could not read from remote repository.

Please make sure you have the correct access rights
and the repository exists.
```

#182 refactored the webhooks' config info, but it moved the `init_ssh` call till after the repo clones. I could not remember what `init_ssh` was for or why we needed it, so I put it in `NetkanWebhooks.__init__` so it would be available during runtime. But we need it before that.

Now the ssh key is passed to `NetkanWebhooks.setup()`, so it can be stored before we clone.