### PR TITLE
Add More git interaction tests

### DIFF
--- a/netkan/netkan/indexer.py
+++ b/netkan/netkan/indexer.py
@@ -120,7 +120,8 @@ class CkanMessage:
             if not self.Success and getattr(status, 'last_error', None) != self.ErrorMessage:
                 logging.error('New inflation error for %s: %s',
                               self.ModIdentifier, self.ErrorMessage)
-            elif getattr(status, 'last_warnings', None) != self.WarningMessages and self.WarningMessages is not None:
+            elif (getattr(status, 'last_warnings', None) != self.WarningMessages and
+                  self.WarningMessages is not None):
                 logging.error('New inflation warnings for %s: %s',
                               self.ModIdentifier, self.WarningMessages)
             actions = [

--- a/netkan/netkan/repos.py
+++ b/netkan/netkan/repos.py
@@ -26,8 +26,9 @@ class XkanRepo:
     def is_active_branch(self, branch_name: str) -> bool:
         return branch_name == self.active_branch
 
-    def checkout_branch(self, branch_name: str) -> None:
-        getattr(self.git_repo.heads, branch_name).checkout()
+    def checkout_existing_branch(self, branch_name: str) -> None:
+        branch = getattr(self.git_repo.heads, branch_name)
+        branch.checkout()
 
     def pull_remote_branch(self, branch_name: str, strategy_option: str = 'ours') -> None:
         self.git_repo.remotes.origin.pull(branch_name, strategy_option=strategy_option)

--- a/netkan/netkan/repos.py
+++ b/netkan/netkan/repos.py
@@ -1,6 +1,6 @@
 from contextlib import contextmanager
 from pathlib import Path
-from typing import Iterable, List, Optional, Generator
+from typing import Iterable, List, Optional, Generator, Union
 
 from git import Repo, Commit, GitCommandError
 from .metadata import Netkan, Ckan
@@ -14,9 +14,9 @@ class XkanRepo:
     def __init__(self, git_repo: Repo) -> None:
         self.git_repo = git_repo
 
-    def commit(self, files: List[str], commit_message: str) -> Commit:
+    def commit(self, files: List[Union[str, Path]], commit_message: str) -> Commit:
         index = self.git_repo.index
-        index.add(files)
+        index.add([x.as_posix() if isinstance(x, Path) else x for x in files])
         return index.commit(commit_message)
 
     @property

--- a/netkan/netkan/repos.py
+++ b/netkan/netkan/repos.py
@@ -26,7 +26,15 @@ class XkanRepo:
     def is_active_branch(self, branch_name: str) -> bool:
         return branch_name == self.active_branch
 
-    def checkout_existing_branch(self, branch_name: str) -> None:
+    def checkout_branch(self, branch_name: str) -> None:
+        """Checkout Existing Branch
+
+        We utilise this function to checkout a existing branches, though
+        it doesn't quite mirror what Git will do directly. If the branch
+        doesn't exist an 'AttributeError' will be thown.
+
+        repo.checkout_branch('master')
+        """
         branch = getattr(self.git_repo.heads, branch_name)
         branch.checkout()
 

--- a/netkan/tests/repos.py
+++ b/netkan/tests/repos.py
@@ -4,6 +4,7 @@ import unittest
 from pathlib import Path, PurePath
 
 from git import Repo
+from gitdb.exc import BadName
 from netkan.repos import NetkanRepo, CkanMetaRepo
 
 
@@ -14,29 +15,61 @@ class TestRepo(unittest.TestCase):
         super(TestRepo, cls).setUpClass()
         cls.tmpdir = tempfile.TemporaryDirectory()
         cls.working = Path(cls.tmpdir.name, 'working')
+        upstream = Path(cls.tmpdir.name, 'upstream')
+        upstream.mkdir()
+        Repo.init(upstream, bare=True)
         shutil.copytree(cls.test_data, cls.working)
+        cls.repo = Repo.init(cls.working)
+        cls.repo.index.add(cls.repo.untracked_files)
+        cls.repo.index.commit('Test Data')
+        cls.repo.create_remote('origin', upstream.as_posix())
+        cls.repo.remotes.origin.push('master:master')
 
     @classmethod
     def tearDownClass(cls):
         super(TestRepo, cls).tearDownClass()
         cls.tmpdir.cleanup()
 
+    def tearDown(self):
+        meta = self.repo
+        meta.git.clean('-df')
+        meta.heads.master.checkout()
+        try:
+            cleanup = meta.create_head('cleanup', 'HEAD~1')
+            meta.head.reference = cleanup
+            meta.head.reset(index=True, working_tree=True)
+        except BadName:
+            pass
+
 
 class TestNetkanRepo(TestRepo):
     test_data = Path(PurePath(__file__).parent, 'testdata/NetKAN')
 
     def setUp(self):
-        self.nk_repo = NetkanRepo(Repo.init(self.working))
+        self.nk_repo = NetkanRepo(self.repo)
 
     def test_nk_path(self):
         self.assertTrue(self.nk_repo.nk_path('DogeCoinFlag').exists())
+
+    def test_active_branch(self):
+        self.assertEqual(self.nk_repo.active_branch, 'master')
+
+    def test_is_active_branch(self):
+        self.assertTrue(self.nk_repo.is_active_branch('master'))
+        self.assertFalse(self.nk_repo.is_active_branch('some/other/branch'))
+
+    def test_checkout_branch(self):
+        self.assertTrue(self.nk_repo.is_active_branch('master'))
+        self.nk_repo.checkout_branch('a/branch')
+        self.assertTrue(self.nk_repo.is_active_branch('a/branch'))
+
 
 
 class TestCkanMetaRepo(TestRepo):
     test_data = Path(PurePath(__file__).parent, 'testdata/CKAN-meta')
 
     def setUp(self):
-        self.ckm_repo = CkanMetaRepo(Repo.init(self.working))
+        self.ckm_repo = CkanMetaRepo(self.repo)
 
     def test_mod_path(self):
         self.assertTrue(self.ckm_repo.mod_path('AwesomeMod').exists())

--- a/netkan/tests/repos.py
+++ b/netkan/tests/repos.py
@@ -15,14 +15,14 @@ class TestRepo(unittest.TestCase):
         super(TestRepo, cls).setUpClass()
         cls.tmpdir = tempfile.TemporaryDirectory()
         cls.working = Path(cls.tmpdir.name, 'working')
-        upstream = Path(cls.tmpdir.name, 'upstream')
-        upstream.mkdir()
-        Repo.init(upstream, bare=True)
+        cls.upstream = Path(cls.tmpdir.name, 'upstream')
+        cls.upstream.mkdir()
+        Repo.init(cls.upstream, bare=True)
         shutil.copytree(cls.test_data, cls.working)
         cls.repo = Repo.init(cls.working)
         cls.repo.index.add(cls.repo.untracked_files)
         cls.repo.index.commit('Test Data')
-        cls.repo.create_remote('origin', upstream.as_posix())
+        cls.repo.create_remote('origin', cls.upstream.as_posix())
         cls.repo.remotes.origin.push('master:master')
 
     @classmethod
@@ -59,10 +59,34 @@ class TestNetkanRepo(TestRepo):
         self.assertFalse(self.nk_repo.is_active_branch('some/other/branch'))
 
     def test_checkout_branch(self):
+        with self.nk_repo.change_branch('a/branch'):
+            pass
         self.assertTrue(self.nk_repo.is_active_branch('master'))
         self.nk_repo.checkout_branch('a/branch')
         self.assertTrue(self.nk_repo.is_active_branch('a/branch'))
 
+    def test_push_pull(self):
+        new_clone = Repo.init(Path(self.tmpdir.name, 'push_pull'))
+        new_clone.create_remote('origin', self.upstream.as_posix())
+        new_repo = NetkanRepo(new_clone)
+        new_repo.pull_remote_branch('master')
+        Path(new_repo.nk_dir, 'test_pushpull_file').write_text('I can haz cheezburger')
+        new_repo.commit(new_repo.git_repo.untracked_files, 'Pls')
+        new_repo.push_remote_branch('master')
+        self.assertFalse(Path(self.nk_repo.nk_dir, 'test_pushpull_file').exists())
+        self.nk_repo.pull_remote_branch('master')
+        self.assertTrue(Path(self.nk_repo.nk_dir, 'test_pushpull_file').exists())
+
+    def test_change_branch(self):
+        self.assertTrue(self.nk_repo.is_active_branch('master'))
+        staged = Path(self.nk_repo.nk_dir, 'StagedMod.netkan')
+        self.assertFalse(staged.exists())
+        with self.nk_repo.change_branch('some/other/branch'):
+            self.assertTrue(self.nk_repo.is_active_branch('some/other/branch'))
+            staged.write_text('{"name": "Stagey McStage"}')
+            self.assertTrue(staged.exists())
+            self.nk_repo.commit(self.nk_repo.nk_paths(['StagedMod']), 'Test Stage')
+        self.assertFalse(staged.exists())
 
 
 class TestCkanMetaRepo(TestRepo):


### PR DESCRIPTION
This adds some more git interaction tests. It also allows our commit function to take a `Path` object or a `str` when committing files. Along with a minor doc improvement for `checkout_branch`