### PR TITLE
Fun with GraphQL (download counts)

### DIFF
--- a/netkan/netkan/downloads_query.graphql
+++ b/netkan/netkan/downloads_query.graphql
@@ -1,0 +1,23 @@
+query {
+$module_queries
+}
+fragment getDownloads on Repository {
+    # Check 3 parent repos, GraphQL purposely discourages unbounded recursion
+    parent {
+        parent {
+            parent {
+                ...downloadsFromRelease
+            }
+            ...downloadsFromRelease
+        }
+        ...downloadsFromRelease
+    }
+    ...downloadsFromRelease
+}
+fragment downloadsFromRelease on Repository {
+    releases(last: 100) { nodes {
+        releaseAssets(first: 10) { nodes {
+            downloadCount
+        } }
+    } }
+}

--- a/netkan/setup.py
+++ b/netkan/setup.py
@@ -10,7 +10,7 @@ setup(
     author_email='techman83@gmail.com',
     packages=find_packages(),
     package_data={
-        "": ["*.txt", "*.jinja2"],
+        "": ["*.txt", "*.jinja2", "*.graphql"],
     },
     install_requires=[
         'boto3',


### PR DESCRIPTION
## Motivation

```
$ curl -H "Authorization: token $GH_Token" https://api.github.com/rate_limit
{
  "resources": {
    "core": {
      "limit": 5000,
      "remaining": 3126,
      "reset": 1591429935
    },
    "search": {
      "limit": 30,
      "remaining": 30,
      "reset": 1591428892
    },
    "graphql": {
      "limit": 5000,
      "remaining": 5000,
      "reset": 1591432432
    },
    "integration_manifest": {
      "limit": 5000,
      "remaining": 5000,
      "reset": 1591432432
    },
    "source_import": {
      "limit": 100,
      "remaining": 100,
      "reset": 1591428892
    }
  },
  "rate": {
    "limit": 5000,
    "remaining": 3126,
    "reset": 1591429935
  }
}
```

This part represents API credits that we're "leaving on the table" since we currently don't use GraphQL at all:

```json
    "graphql": {
      "limit": 5000,
      "remaining": 5000,
      "reset": 1591432432
    },
```

Also GraphQL is neat and allows us to query more database objects in fewer calls, leaving out data we don't need.

![image](https://user-images.githubusercontent.com/1559108/83956734-bfe68280-a826-11ea-8671-2d0e11e23af5.png)

## Changes

Now the download counts for GitHub are done via GraphQL. Mods hosted on GitHub are grouped into batches of 50 and then queried all at once. (I tried doing all of them in one gigantic request, but it timed out with an error, so we have to do smaller groups.)

- Fewer requests
- Much less total network traffic as only the download count data will be returned, without the unneeded info about repo names, owners, release tags, etc., etc.
- Parent, grandparent, etc. repos are retrieved without additional requests
- The separate `graphql` rate limiting pool is depleted instead of the main one for the API

Note that the old GitHub code is still needed to handle metanetkans that contain GitHub krefs. The batching only applies to netkans that go directly to GitHub without a metanetkan.