### PR TITLE
Refactor GraphQL Batching

### DIFF
--- a/netkan/netkan/common.py
+++ b/netkan/netkan/common.py
@@ -1,5 +1,6 @@
-from git import Repo
 from typing import List, Iterable, Dict
+
+from git import Repo
 
 from .metadata import Netkan
 from .repos import NetkanRepo
@@ -10,7 +11,8 @@ def netkans(path: str, ids: Iterable[str]) -> Iterable[Netkan]:
     return (Netkan(p) for p in repo.nk_paths(ids))
 
 
-def sqs_batch_entries(messages: Iterable[Dict[str, str]], batch_size: int = 10) -> Iterable[List[Dict[str, str]]]:
+def sqs_batch_entries(messages: Iterable[Dict[str, str]],
+                      batch_size: int = 10) -> Iterable[List[Dict[str, str]]]:
     batch = []
     for msg in messages:
         batch.append(msg)


### PR DESCRIPTION
The batching logic sitting outside of the left a lot of the responsibility for getting it right outside of the function responsible for generating the results.

This brings that all back into the GraphQLQuery class, which returns the complete result set whilst still querying github in batches no bigger than specified in `MODULES_PER_GRAPHQL`.

Cleans up a bunch of minor linting warnings as well.