### PR TITLE
Print more info about mismatched hashes

### DIFF
--- a/netkan/netkan/mirrorer.py
+++ b/netkan/netkan/mirrorer.py
@@ -313,9 +313,19 @@ class Mirrorer:
             file_hash = self.large_file_sha256(download_file)
             if ckan.download_hash.get('sha256') != file_hash:
                 # Bad download, try again later
-                logging.error('Hash mismatch, %s != %s',
-                              ckan.download_hash.get('sha256'),
-                              file_hash)
+                cache_file_path = ckan.cache_find_file
+                if cache_file_path:
+                    logging.error('Hash mismatch for %s (%s, size=%s), %s != %s',
+                                  ckan.mirror_item(),
+                                  cache_file_path,
+                                  cache_file_path.stat().st_size,
+                                  ckan.download_hash.get('sha256'),
+                                  file_hash)
+                else:
+                    logging.error('Hash mismatch for %s, %s != %s',
+                                  ckan.mirror_item(),
+                                  ckan.download_hash.get('sha256'),
+                                  file_hash)
                 return False
             logging.info('Uploading %s', ckan.mirror_item())
             item = internetarchive.Item(self.ia_session, ckan.mirror_item())


### PR DESCRIPTION
## Problem

After #189 we now get these every 5 minutes:

![image](https://user-images.githubusercontent.com/1559108/85209469-e9f77480-b2fd-11ea-8f55-3315d5c16123.png)

So now we know why it was failing before; the hashes don't match. There could be multiple reasons for that, maybe it's getting the wrong file out of the cache, or maybe a download actually failed. It will probably make sense to just delete the cached file and try again later, but I want to get more info about what's happening to make sure before we add that.

## Changes

Now in addition to the hashes, we will print which mod it is (already known but easier to keep track this way), and the path and size of the cached file. This will help us to determine why the hashes aren't matching.