### PR TITLE
Limit cache search to ZIP files

### DIFF
--- a/netkan/netkan/metadata.py
+++ b/netkan/netkan/metadata.py
@@ -283,7 +283,7 @@ class Ckan:
 
     @property
     def cache_find_file(self) -> Optional[Path]:
-        found = list(self.CACHE_PATH.glob(f'**/{self.cache_prefix}*'))
+        found = list(self.CACHE_PATH.glob(f'**/{self.cache_prefix}*.zip'))
         if found:
             return found[0]
         return None


### PR DESCRIPTION
## Problem

After #190, we now get these every 5 minutes:

![image](https://user-images.githubusercontent.com/1559108/85209817-8884d500-b300-11ea-8a56-a91b5c18c2d9.png)

## Cause

The function that finds a mod's download in the cache is getting confused by the hash files from KSP-CKAN/CKAN#3080! It sometimes returns them instead of the actual download file.

## Changes

Now `Ckan.cache_find_file` only returns ZIP files.