### PR TITLE
Tell Discord when PR creation fails

### DIFF
--- a/netkan/netkan/github_pr.py
+++ b/netkan/netkan/github_pr.py
@@ -37,7 +37,7 @@ class GitHubPR:
                 error = response.json()['errors'][0]['message']
             except KeyError:
                 pass
-            logging.info('PR for {} failed: {} - {}'.format(
+            logging.error('PR for {} failed: {} - {}'.format(
                 branch,
                 message,
                 error


### PR DESCRIPTION
## Background

Recently at least two SpaceDock indexing requests have failed to generate pull requests. We don't know why yet.

- https://spacedock.info/mod/2557/Missing%20Robotics
- https://spacedock.info/mod/2559/Xingyun-2%20Satellite

## Problem

Currently if there's a problem with auto-creation of a pull request for NetKAN (SpaceDock indexing requests) or CKAN-meta (auto-epoching and hard coded version verification), a message is printed to stdout but we don't see it in Discord.

## Cause

The message is passed to `logging.info`, which only prints to the console. `logging.error` is sent to Discord as of #68.

## Changes

Now it's an error instead, so Discord will hear about it. This will either reveal the cause of the missing pull requests, or indicate that the problem lies elsewhere.