### PR TITLE
Drop mods from auto-freeze list after 3 weeks

### DIFF
--- a/netkan/netkan/cli/utilities.py
+++ b/netkan/netkan/cli/utilities.py
@@ -22,14 +22,18 @@ from ..mirrorer import Mirrorer
     '--days-limit', default=1000,
     help='Number of days to wait before freezing a mod as idle',
 )
+@click.option(
+    '--days-till-ignore', default=21,
+    help='Mods idle this many days will be ignored',
+)
 @common_options
 @pass_state
-def auto_freezer(common: SharedArgs, days_limit: int) -> None:
+def auto_freezer(common: SharedArgs, days_limit: int, days_till_ignore: int) -> None:
     afr = AutoFreezer(
         common.netkan_repo,
         common.github_pr,
     )
-    afr.freeze_idle_mods(days_limit)
+    afr.freeze_idle_mods(days_limit, days_till_ignore)
     afr.mark_frozen_mods()
 
 

--- a/netkan/netkan/repos.py
+++ b/netkan/netkan/repos.py
@@ -153,5 +153,5 @@ class CkanMetaRepo(XkanRepo):
         return (Ckan(f) for f in self.mod_path(identifier).glob(self.CKANMETA_GLOB))
 
     def highest_version(self, identifier: str) -> Optional[Ckan.Version]:
-        highest = max(self.ckans(identifier), default=None, key=lambda ck: ck.version)
+        highest = max(self.ckans(identifier), default=None, key=lambda ck: ck.version)  # type: ignore[type-var]
         return highest.version if highest else None


### PR DESCRIPTION
## Background

The AutoFreezer finds all unfrozen mods that haven't been updated in 1000+ days and submits a pull request to freeze them all, see KSP-CKAN/NetKAN#8233. We can then review the list to determine which ones should really be frozen and which ones are likely to have new releases or version file updates or otherwise remain active.

## Problem

We're accumulating a long-ish list of mods that we don't actually want to freeze. Two examples:

- SpaceLink is a SpaceDock-related mod, which has its compatibility updated every time there's a new KSP version, for a release from April 2017. If we freeze it, we miss those upates.
- PlaneMode was originally frozen in #8004, then unfrozen in https://github.com/KSP-CKAN/NetKAN/commit/bcc7016b533ea7866386f843134cbcdb914d6eea because it's still compatible

Once we decide we don't need to freeze a mod, it's not necessary to keep reviewing that decision every week.

## Changes

Now the list only includes mods that were last updated 1000-1021 days ago. This gives us a 3-week window (and 3 pull requests) to decide whether to freeze a mod, after which it drops off the list. As a result the lists in the pull requests will be shorter and more relevant.

The limit shouldn't be 1 week, because the last time I took a break from doing CKAN stuff, we had an AutoFreezer PR sit around for a few weeks, blocking others from being submitted. If that happened again, we could miss our chance to freeze any mods that expired in that time.