### PR TITLE
Distinguish between adding and updating in commit messages

### DIFF
--- a/netkan/netkan/indexer.py
+++ b/netkan/netkan/indexer.py
@@ -77,10 +77,11 @@ class CkanMessage:
         with open(self.mod_file, mode='w') as file:
             file.write(self.body)
 
-    def commit_metadata(self) -> Commit:
+    def commit_metadata(self, file_created: bool) -> Commit:
+        verb = 'added' if file_created else 'updated'
         commit = self.ckm_repo.commit(
             [self.mod_file.as_posix()],
-            f'NetKAN generated mods - {self.mod_version}'
+            f'NetKAN {verb} mod - {self.mod_version}'
         )
         logging.info('Committing %s', self.mod_version)
         self.indexed = True
@@ -115,8 +116,9 @@ class CkanMessage:
 
     def _process_ckan(self) -> None:
         if self.Success and self.metadata_changed():
+            new_file = not self.mod_file.exists()
             self.write_metadata()
-            self.commit_metadata()
+            self.commit_metadata(new_file)
         try:
             status = ModStatus.get(self.ModIdentifier)
             attrs = self.status_attrs()

--- a/netkan/tests/indexer.py
+++ b/netkan/tests/indexer.py
@@ -128,10 +128,10 @@ class TestUpdateCkan(TestCkan):
 
     def test_ckan_message_commit(self):
         self.message.write_metadata()
-        c = self.message.commit_metadata()
+        c = self.message.commit_metadata(True)
         self.assertEqual(0, len(self.ckan_meta.untracked_files))
         self.assertEqual(
-            c.message, 'NetKAN generated mods - DogeCoinFlag-v1.02'
+            c.message, 'NetKAN added mod - DogeCoinFlag-v1.02'
         )
 
     def test_ckan_message_status_attrs(self):
@@ -160,10 +160,10 @@ class TestStagedCkan(TestUpdateCkan):
     def test_ckan_message_commit(self):
         with self.message.ckm_repo.change_branch(self.message.mod_version):
             self.message.write_metadata()
-            c = self.message.commit_metadata()
+            c = self.message.commit_metadata(True)
             self.assertEqual(0, len(self.ckan_meta.untracked_files))
             self.assertEqual(
-                c.message, 'NetKAN generated mods - DogeCoinFlag-v1.02'
+                c.message, 'NetKAN added mod - DogeCoinFlag-v1.02'
             )
         self.assertEqual(
             self.ckan_meta.head.commit.message,


### PR DESCRIPTION
## Motivation

The Indexer both creates and updates .ckan files in CKAN-meta, and sometimes it would be nice to know which one happened at a glance, but currently all commits say `NetKAN generated mods - <identifier>-<version>`:

![image](https://user-images.githubusercontent.com/1559108/100178345-4f492600-2e99-11eb-8554-7ae0b6b98c7e.png)

## Changes

Now the commit messages are split based on whether the file existed previously:

- `NetKAN added mod - <identifier>-<version>`
- `NetKAN updated mod - <identifier>-<version>`