### PR TITLE
Webhooks Memory Allocation

### DIFF
--- a/prod-stack.py
+++ b/prod-stack.py
@@ -762,6 +762,7 @@ services = [
             {
                 'name': 'webhooks',
                 'entrypoint': '.local/bin/gunicorn',
+                'memory': '128',
                 'command': [
                     '-b', '0.0.0.0:5000', '--access-logfile', '-',
                     '--preload', 'netkan.webhooks:create_app()'


### PR DESCRIPTION
Problem
=======
The webhooks service kept failing with
```
git.exc.GitCommandError: Cmd('git') failed due to: exit code(-9)
```
This is likely an OOM.

Change
======
I've bumped the memory for the service and we can monitor it. This has already been applied to the NetKAN stack.