### PR TITLE
Store cache timestamps to status pynamodb

### DIFF
--- a/netkan/netkan/indexer.py
+++ b/netkan/netkan/indexer.py
@@ -88,17 +88,11 @@ class CkanMessage:
         return commit
 
     def status_attrs(self, new: bool = False) -> Dict[str, Any]:
-        inflation_time = parse(self.CheckTime)
         attrs: Dict[str, Any] = {
             'success': self.Success,
             'last_error': self.ErrorMessage,
             'last_warnings': self.WarningMessages,
-            # We may wish to change the name in the inflator
-            # as the index will set 'last_checked'
-            'last_inflated': inflation_time,
-            # If we have perfomed an inflation, we certainly
-            # have checked the mod!
-            'last_checked': inflation_time,
+            'last_inflated': parse(self.CheckTime),
             # If we're inflating it, it's not frozen
             'frozen': False,
         }
@@ -107,6 +101,10 @@ class CkanMessage:
             attrs['resources'] = resources
         if new:
             attrs['ModIdentifier'] = self.ModIdentifier
+        cache_path = self.ckan.cache_find_file
+        if cache_path:
+            cache_mtime = datetime.fromtimestamp(cache_path.stat().st_mtime)
+            attrs['last_downloaded'] = cache_mtime.astimezone(timezone.utc)
         if self.indexed:
             attrs['last_indexed'] = datetime.now(timezone.utc)
         release_date = getattr(self.ckan, 'release_date', None)

--- a/netkan/netkan/status.py
+++ b/netkan/netkan/status.py
@@ -40,6 +40,7 @@ class ModStatus(Model):
     last_checked = UTCDateTimeAttribute(null=True)
     last_indexed = UTCDateTimeAttribute(null=True)
     last_inflated = UTCDateTimeAttribute(null=True)
+    last_downloaded = UTCDateTimeAttribute(null=True)
     release_date = UTCDateTimeAttribute(null=True)
     success = BooleanAttribute()
     frozen = BooleanAttribute(default=False)

--- a/netkan/tests/indexer.py
+++ b/netkan/tests/indexer.py
@@ -109,7 +109,6 @@ class TestCkan(unittest.TestCase):
         attrs = self.message.status_attrs(new=True)
         self.assertEqual(attrs['ModIdentifier'], 'DogeCoinFlag')
         self.assertTrue(attrs['success'])
-        self.assertIsInstance(attrs['last_checked'], datetime)
         self.assertIsInstance(attrs['last_inflated'], datetime)
         self.assertEqual(attrs['last_error'], None)
         with self.assertRaises(KeyError):
@@ -138,7 +137,6 @@ class TestUpdateCkan(TestCkan):
         attrs = self.message.status_attrs(new=True)
         self.assertEqual(attrs['ModIdentifier'], 'DogeCoinFlag')
         self.assertTrue(attrs['success'])
-        self.assertIsInstance(attrs['last_checked'], datetime)
         self.assertIsInstance(attrs['last_inflated'], datetime)
         self.assertIsInstance(attrs['last_indexed'], datetime)
 
@@ -185,7 +183,6 @@ class TestStagedCkan(TestUpdateCkan):
         attrs = self.message.status_attrs(new=True)
         self.assertEqual(attrs['ModIdentifier'], 'DogeCoinFlag')
         self.assertTrue(attrs['success'])
-        self.assertIsInstance(attrs['last_checked'], datetime)
         self.assertIsInstance(attrs['last_inflated'], datetime)
         with self.assertRaises(KeyError):
             attrs['last_indexed']
@@ -230,7 +227,6 @@ class TestFailedCkan(TestCkan):
         attrs = self.message.status_attrs(new=True)
         self.assertEqual(attrs['ModIdentifier'], 'DogeCoinFlag')
         self.assertFalse(attrs['success'])
-        self.assertIsInstance(attrs['last_checked'], datetime)
         self.assertIsInstance(attrs['last_inflated'], datetime)
         self.assertEqual(
             attrs['last_error'],

--- a/prod-stack.py
+++ b/prod-stack.py
@@ -654,6 +654,9 @@ services = [
             ('SQS_QUEUE', GetAtt(outbound, 'QueueName')),
             ('AWS_DEFAULT_REGION', Sub('${AWS::Region}')),
         ],
+        'volumes': [
+            ('ckan_cache', '/home/netkan/ckan_cache'),
+        ],
         'linux_parameters': LinuxParameters(InitProcessEnabled=True),
     },
     {


### PR DESCRIPTION
## Motivation

Currently the `ModStatus` objects have properties `last_checked` and `last_inflated`, which are identical, which is redundant. This is not a coincidence; the code sets them to the exact same value every time. They also appear on the status page:

- http://status.ksp-ckan.space/

![image](https://user-images.githubusercontent.com/1559108/103719356-744bb100-4f8e-11eb-8150-07d09da7c954.png)

## Problems

In https://github.com/KSP-CKAN/CKAN-meta/commit/8006736930cc1bcf595afe2cd86faea3916186cb, KerbalWeatherProject's release date was updated but its hashes were not. Subsequently attempting to install this mod resulted in hash mismatches:

```
CKAN.InvalidModuleFileKraken: KerbalWeatherProject v1.0.0: C:\Users\aequa\AppData\Local\Temp\tmp83D1.tmp has length 88819967, should be 88820268
   at CKAN.NetModuleCache.Store(CkanModule module, String path, String description, Boolean move)
   at CKAN.NetAsyncModulesDownloader.ModuleDownloadComplete(Uri url, String filename, Exception error)
```

So the author replaced the download, but the Inflator used the old download to re-index it.

## Causes

There are two ways the Inflator might have inflated the old file:

- The Inflator thought its cached download was up to date and didn't re-download (i.e., KSP-CKAN/CKAN#3246 is broken or did not fully fix the problem)
- The Inflator requested to re-download but SpaceDock sent the old file (i.e., KSP-SpaceDock/SpaceDock#313 is broken or too slow)

Right now we cannot tell which it is, because we do not know the timestamp of the file in the Inflator's cache. We need that info to continue investigating and eventually find a fix. If the timestamp is close to the re-indexing request, then we blame SpaceDock for lying, otherwise we blame the Inflator for laziness.

## Changes

Now `last_checked` is no longer set (but we won't purge the current values, just in case). `last_inflated` will still be set to their common value, so no information is lost.

Now a new `last_downloaded` property is set to the timestamp of the mod's download in the cache. To make this possible, the Indexer now mounts the cache directory, finds downloads in it, and `stat`s them to get the timestamp. We carefully convert this to UTC to ensure that we can always track exactly what happened with a mod, minute by minute.

A future PR will update the status page to show the new timestamps.