### PR TITLE
Fix cache hashes again

### DIFF
--- a/netkan/netkan/csharp_compat.py
+++ b/netkan/netkan/csharp_compat.py
@@ -1,0 +1,18 @@
+
+def csharp_uri_tostring(uri: str) -> str:
+    """
+    Equivalent to C#: return new System.Uri(uri).ToString();
+
+    https://docs.microsoft.com/en-us/dotnet/api/system.uri.tostring?view=netframework-4.7.2
+
+    That documentation is either wrong or misleading:
+    It DOES NOT escape # or ?, but it does UNescape some, but not all, special characters.
+
+    There are many other characters that it neither encodes nor decodes but rather leaves
+    in their original form, encoded or decoded, so we can't use urllib.parse here.
+    """
+    return uri.replace('%20', ' ') \
+              .replace('%3A', ':') \
+              .replace('%27', "'") \
+              .replace('%28', '(') \
+              .replace('%29', ')')

--- a/netkan/netkan/metadata.py
+++ b/netkan/netkan/metadata.py
@@ -8,6 +8,7 @@ import urllib.parse
 from typing import Optional, List, Tuple, Union, Any, Dict
 import dateutil.parser
 
+from .csharp_compat import csharp_uri_tostring
 
 class Netkan:
 
@@ -292,7 +293,7 @@ class Ckan:
     def cache_prefix(self) -> Optional[str]:
         if 'download' not in self._raw:
             return None
-        return sha1(urllib.parse.unquote(self.download).encode()).hexdigest().upper()[0:8]
+        return sha1(csharp_uri_tostring(self.download).encode()).hexdigest()[0:8].upper()
 
     @property
     def cache_find_file(self) -> Optional[Path]:

--- a/netkan/tests/__init__.py
+++ b/netkan/tests/__init__.py
@@ -6,3 +6,4 @@ from .mirrorer import *
 from .repos import *
 from .scheduler import *
 from .utils import *
+from .csharp_compat import *

--- a/netkan/tests/csharp_compat.py
+++ b/netkan/tests/csharp_compat.py
@@ -1,0 +1,23 @@
+import unittest
+
+from netkan.csharp_compat import csharp_uri_tostring
+
+class TestCsharpCompat(unittest.TestCase):
+
+    def test_csharp_uri_tostring(self) -> None:
+        """
+        https://docs.microsoft.com/en-us/dotnet/api/system.uri.tostring?view=netframework-4.7.2
+
+        That documentation is incomplete or wrong; these tests determined empirically in Mono.
+        """
+
+        # Stuff that should be changed
+        self.assertEqual(csharp_uri_tostring('%20'), ' ')
+        self.assertEqual(csharp_uri_tostring('%3A'), ':')
+        self.assertEqual(csharp_uri_tostring('%27'), "'")
+        self.assertEqual(csharp_uri_tostring('%28'), '(')
+        self.assertEqual(csharp_uri_tostring('%29'), ')')
+
+        # Stuff that shouldn't be changed
+        stay_same = " :'()&%26/%2F+%2B?%3F#%23,%2C"
+        self.assertEqual(csharp_uri_tostring(stay_same), stay_same)


### PR DESCRIPTION
## Problem

The Last Downloaded column on the status page has "N/A" for a lot of entries, with no inflation errors:

![image](https://user-images.githubusercontent.com/1559108/105766920-f68d1c80-5f1f-11eb-9de7-16ff72f4255b.png)

## Cause

`Ckan.cache_find_file` isn't finding those cached files.

#141 was an over-correction; we need the Python URL hashing code to emulate this C# code:

```csharp
    return new System.Uri(uri).ToString();
```

... but that code _doesn't_ de-code **all** of the `%XX` sequences in the input, just **some** of them. `urllib.parse.unquote` decodes **all** of them, so mismatched hashes were being generated for these URLs:

```
- https://spacedock.info/mod/130/Contracts%20Window%20%2B/download/9.4
- https://spacedock.info/mod/47/Craft%20Import%20%26%20Upload/download/0.9.0
- https://spacedock.info/mod/1641/Retracting/vectoring%20engines%2C%20Critter%20Crawler/download/1.3.6
- https://spacedock.info/mod/1797/Elon%27s%20Roadster%20%26%20Starman/download/2.1.1
- https://spacedock.info/mod/991/EVA%20Parachutes%20%26%20Ejection%20Seats/download/0.2.0.2
- https://spacedock.info/mod/2311/Kerbal%20Research%20%26%20Development/download/1.16.0.8
- https://spacedock.info/mod/866/KSP%20Craft%20Organizer%20%28VAB/SPH%20tags%20%2B%20craft%20searching%29/download/1.6.0
- https://spacedock.info/mod/1503/Streamline%20-%20Engines%2C%20RCSs%20and%20fueltanks/download/1.2
- https://spacedock.info/mod/842/Tanks%2C%20But%20No%20Tanks/download/0.2
- https://github.com/Starstrider42/TestFlight-Configs/releases/download/0.2.0/Stock%2B-TF-Configs-0.2.0.zip
- https://spacedock.info/mod/2424/TweakScale%20Companion%20for%20ReStock%2B/download/1.1.0.0
- https://spacedock.info/mod/1027/Wheels%20Collection%20%28formerly%20rollkage%20%26%20better%20wheels%29%20/download/1.3
- https://spacedock.info/mod/825/Who%20Am%20I%3F/download/1.2.0
```

Specifically:

- %2B was being decoded to `+` but C# keeps it as-is
- %26 was being decoded to `&` but C# keeps it as-is
- %3F was being decoded to `?` but C# keeps it as-is
- %2C was being decoded to `,` but C# keeps it as-is

## Changes

Now we no longer use `urllib.parse.unquote`, and instead just perform the exact same substitutions that C# does, in a new `netkan.csharp_compat.csharp_uri_tostring` function.

Tests are added to make this explicit and less likely to break.

For an infinitesimal performance improvement, we now don't waste time capitalizing 32 hash characters that we're going to truncate anyway.