### PR TITLE
Omit step IDs

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -20,7 +20,6 @@ jobs:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
       - name: Run tests before deploying
-        id: docker_build
         uses: docker/build-push-action@v2
         with:
           context: ./netkan
@@ -28,7 +27,6 @@ jobs:
           push: false
           target: test
       - name: Build and push NetKAN-infra
-        id: docker_build
         uses: docker/build-push-action@v2
         with:
           context: ./netkan


### PR DESCRIPTION
Deployment build failed with the following:
```
The workflow is not valid. .github/workflows/deploy.yml (Line: 31, Col: 13): The identifier 'docker_build' may not be used more than once within the same scope.
```
We don't use the outputs from these steps, so we don't require them.