### PR TITLE
Pylint and flake8

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -18,4 +18,4 @@ jobs:
         run: pip install .[test]
       - name: Run pytest
         working-directory: netkan
-        run: pytest --mypy -v
+        run: pytest -v

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,7 +1,7 @@
 {
   "python.pythonPath": "/usr/bin/python3",
   "python.formatting.provider": "autopep8",
-  "editor.formatOnSave": false,
+  "editor.formatOnSave": true,
   "python.linting.pylintEnabled": true,
   "python.linting.enabled": true,
   "python.linting.pylintArgs": [

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -13,7 +13,6 @@
   "files.exclude": {
     "**/__pycache__": true
   },
-  "python.testing.pytestArgs": ["--verbose", "--exitfirst", "netkan/tests"],
   "python.testing.pytestEnabled": true,
   "python.testing.nosetestsEnabled": false,
   "python.testing.unittestEnabled": false,

--- a/netkan/.flake8
+++ b/netkan/.flake8
@@ -1,0 +1,8 @@
+[flake8]
+ignore =
+    # Whitespace before colons
+    E203,
+    # Whitespace after colons
+    E241,
+    # Line too long
+    E501,

--- a/netkan/.pylintrc
+++ b/netkan/.pylintrc
@@ -1,0 +1,13 @@
+[MESSAGES CONTROL]
+disable =
+    line-too-long,
+    duplicate-code,
+    missing-module-docstring,
+    missing-class-docstring,
+    missing-function-docstring,
+    too-few-public-methods,
+    too-many-instance-attributes,
+    too-many-statements,
+    too-many-return-statements,
+    too-many-branches,
+    too-many-arguments,

--- a/netkan/Dockerfile
+++ b/netkan/Dockerfile
@@ -27,7 +27,7 @@ RUN chown -R netkan:netkan /netkan
 USER netkan
 WORKDIR /netkan
 RUN pip install --user .[test]
-RUN /home/netkan/.local/bin/pytest --mypy -v
+RUN /home/netkan/.local/bin/pytest -v
 
 FROM production as dev
 USER root

--- a/netkan/netkan/auto_freezer.py
+++ b/netkan/netkan/auto_freezer.py
@@ -49,8 +49,7 @@ class AutoFreezer:
         except git.GitCommandError:
             logging.info('Unable to fetch %s', name)
 
-        (getattr(self.nk_repo.git_repo.heads, name, None)
-         or self.nk_repo.git_repo.create_head(name)).checkout()
+        (getattr(self.nk_repo.git_repo.heads, name, None) or self.nk_repo.git_repo.create_head(name)).checkout()
 
     def _ids(self) -> Iterable[str]:
         return (nk.identifier for nk in self.nk_repo.netkans())
@@ -62,17 +61,19 @@ class AutoFreezer:
         idle_mods = []
         for ident in self._ids():
             dttm = self._last_timestamp(ident)
-            if dttm and dttm < update_cutoff and dttm > too_old_cutoff:
+            if dttm and too_old_cutoff < dttm < update_cutoff:
                 idle_mods.append((ident, dttm))
         return idle_mods
 
-    def _last_timestamp(self, ident: str) -> Optional[datetime]:
+    @staticmethod
+    def _last_timestamp(ident: str) -> Optional[datetime]:
         status = ModStatus.get(ident)
         return getattr(status, 'release_date',
                        getattr(status, 'last_indexed',
                                None))
 
-    def _timestamp_before(self, dttm: Optional[datetime], update_cutoff: datetime) -> bool:
+    @staticmethod
+    def _timestamp_before(dttm: Optional[datetime], update_cutoff: datetime) -> bool:
         return dttm < update_cutoff if dttm else False
 
     def _add_freezee(self, ident: str) -> None:
@@ -101,6 +102,5 @@ class AutoFreezer:
                 title='Freeze idle mods',
                 body=(f'The attached mods have not updated in {days} or more days.'
                       ' Freeze them to save the bot some CPU cycles.'
-                      '\n\n'
-                      + self._mod_table(idle_mods)),
+                      '\n\n' + self._mod_table(idle_mods)),
             )

--- a/netkan/netkan/auto_freezer.py
+++ b/netkan/netkan/auto_freezer.py
@@ -72,10 +72,6 @@ class AutoFreezer:
                        getattr(status, 'last_indexed',
                                None))
 
-    @staticmethod
-    def _timestamp_before(dttm: Optional[datetime], update_cutoff: datetime) -> bool:
-        return dttm < update_cutoff if dttm else False
-
     def _add_freezee(self, ident: str) -> None:
         self.nk_repo.git_repo.index.move([
             self.nk_repo.nk_path(ident).as_posix(),
@@ -102,5 +98,6 @@ class AutoFreezer:
                 title='Freeze idle mods',
                 body=(f'The attached mods have not updated in {days} or more days.'
                       ' Freeze them to save the bot some CPU cycles.'
-                      '\n\n' + self._mod_table(idle_mods)),
+                      '\n\n'
+                      f'{self._mod_table(idle_mods)}'),
             )

--- a/netkan/netkan/cli/common.py
+++ b/netkan/netkan/cli/common.py
@@ -53,7 +53,7 @@ _COMMON_OPTIONS = [
 ]
 
 
-class SharedArgs(object):
+class SharedArgs():
 
     def __init__(self) -> None:
         self._environment_data = None

--- a/netkan/netkan/cli/common.py
+++ b/netkan/netkan/cli/common.py
@@ -53,7 +53,7 @@ _COMMON_OPTIONS = [
 ]
 
 
-class SharedArgs():
+class SharedArgs:
 
     def __init__(self) -> None:
         self._environment_data = None

--- a/netkan/netkan/cli/services.py
+++ b/netkan/netkan/cli/services.py
@@ -58,8 +58,8 @@ def indexer(common: SharedArgs) -> None:
 def scheduler(common: SharedArgs, max_queued: int, group: str, min_cpu: int, min_io: int) -> None:
     sched = NetkanScheduler(
         common.netkan_repo, common.ckanmeta_repo, common.queue, common.token,
-        nonhooks_group=(group == 'all' or group == 'nonhooks'),
-        webhooks_group=(group == 'all' or group == 'webhooks'),
+        nonhooks_group=(group in ('all', 'nonhooks')),
+        webhooks_group=(group in ('all', 'webhooks')),
     )
     if sched.can_schedule(max_queued, common.dev, min_cpu, min_io):
         sched.schedule_all_netkans()

--- a/netkan/netkan/cli/utilities.py
+++ b/netkan/netkan/cli/utilities.py
@@ -115,14 +115,14 @@ def redeploy_service(cluster: str, service_name: str) -> None:
                                     cluster=cluster)['serviceArns']
     try:
         service = list(filter(lambda i: service_name in i, services))[0]
-    except IndexError:
+    except IndexError as exc:
         available = '\n    - '.join(
             [f.split('/')[1].split('-')[1] for f in services]
         )
         raise click.UsageError(
             "Service '{}' not found. Available services:\n    - {}".format(
                 service_name, available)
-        )
+        ) from exc
     client.update_service(
         cluster=cluster,
         service=service,

--- a/netkan/netkan/common.py
+++ b/netkan/netkan/common.py
@@ -1,4 +1,5 @@
-from typing import List, Iterable, Dict
+from typing import List, Iterable, Dict, Any
+import boto3  # pylint: disable=unused-import
 
 import github
 from git import Repo
@@ -31,3 +32,10 @@ def pull_all(repos: Iterable[Repo]) -> None:
 
 def github_limit_remaining(token: str) -> int:
     return github.Github(token).get_rate_limit().core.remaining
+
+
+def deletion_msg(msg: 'boto3.resources.factory.sqs.Message') -> Dict[str, Any]:
+    return {
+        'Id':            msg.message_id,
+        'ReceiptHandle': msg.receipt_handle,
+    }

--- a/netkan/netkan/download_counter.py
+++ b/netkan/netkan/download_counter.py
@@ -151,7 +151,8 @@ class GraphQLQuery:
                     user=user, repo=repo)
         return None
 
-    def graphql_safe_identifier(self, nk_dl: NetkanDownloads) -> str:
+    @staticmethod
+    def graphql_safe_identifier(nk_dl: NetkanDownloads) -> str:
         """
         Identifiers can start with numbers and include hyphens.
         GraphQL doesn't like that, so we put an 'x' on the front
@@ -160,7 +161,8 @@ class GraphQLQuery:
         """
         return f'x{nk_dl.identifier.replace("-", "_")}'
 
-    def from_graphql_safe_identifier(self, fake_ident: str) -> str:
+    @staticmethod
+    def from_graphql_safe_identifier(fake_ident: str) -> str:
         """
         Inverse of the above. Strip off the first character and
         replace underscores with dashes, to get back to the original

--- a/netkan/netkan/github_pr.py
+++ b/netkan/netkan/github_pr.py
@@ -38,12 +38,8 @@ class GitHubPR:
             except KeyError:
                 pass
             logging.error('PR for %s failed: %s - %s',
-                          branch,
-                          message,
-                          error
-                          )
+                          branch, message, error)
             return
         pr_json = response.json()
         logging.info('PR for %s opened at %s',
-                     branch, pr_json['html_url']
-                     )
+                     branch, pr_json['html_url'])

--- a/netkan/netkan/github_pr.py
+++ b/netkan/netkan/github_pr.py
@@ -38,12 +38,12 @@ class GitHubPR:
             except KeyError:
                 pass
             logging.error('PR for %s failed: %s - %s',
-                branch,
-                message,
-                error
-            )
+                          branch,
+                          message,
+                          error
+                          )
             return
         pr_json = response.json()
         logging.info('PR for %s opened at %s',
-            branch, pr_json['html_url']
-        )
+                     branch, pr_json['html_url']
+                     )

--- a/netkan/netkan/indexer.py
+++ b/netkan/netkan/indexer.py
@@ -36,7 +36,7 @@ class CkanMessage:
             attr_type = '{}Value'.format(item[1]['DataType'])
             content = item[1][attr_type]
             if content.lower() in ['true', 'false']:
-                content = True if content.lower() == 'true' else False
+                content = (content.lower() == 'true')
             if item[0] == 'FileName':
                 content = PurePath(content).name
             setattr(self, item[0], content)
@@ -123,8 +123,7 @@ class CkanMessage:
             if not self.Success and getattr(status, 'last_error', None) != self.ErrorMessage:
                 logging.error('New inflation error for %s: %s',
                               self.ModIdentifier, self.ErrorMessage)
-            elif (getattr(status, 'last_warnings', None) != self.WarningMessages and
-                  self.WarningMessages is not None):
+            elif (getattr(status, 'last_warnings', None) != self.WarningMessages and self.WarningMessages is not None):
                 logging.error('New inflation warnings for %s: %s',
                               self.ModIdentifier, self.WarningMessages)
             actions = [

--- a/netkan/netkan/metadata.py
+++ b/netkan/netkan/metadata.py
@@ -10,6 +10,7 @@ import dateutil.parser
 
 from .csharp_compat import csharp_uri_tostring
 
+
 class Netkan:
 
     KREF_PATTERN = re.compile('^#/ckan/([^/]+)/(.+)$')
@@ -67,7 +68,8 @@ class Netkan:
             return False
         return self.on_spacedock
 
-    def string_attrib(self, val: str) -> Dict[str, str]:
+    @staticmethod
+    def string_attrib(val: str) -> Dict[str, str]:
         return {
             'DataType': 'String',
             'StringValue': val,
@@ -123,29 +125,29 @@ class Ckan:
         # (except __eq__) are deduced from it by @total_ordering.
         def __gt__(self, other: 'Ckan.Version') -> bool:
 
-            def _string_compare(v1: str, v2: str) -> Tuple[int, str, str]:
+            def _string_compare(ver1: str, ver2: str) -> Tuple[int, str, str]:
                 _result: int
                 _first_remainder = ''
                 _second_remainder = ''
 
                 # Our starting assumptions are, that both versions are completely strings,
                 # with no remainder. We'll then check if they're not.
-                str1 = v1
-                str2 = v2
+                str1 = ver1
+                str2 = ver2
 
                 # Start by walking along our version string until we find a number,
                 # thereby finding the starting string in both cases. If we fall off
                 # the end, then our assumptions made above hold.
-                for i in range(0, len(v1)):
-                    if v1[i].isdigit():
-                        _first_remainder = v1[i:]
-                        str1 = v1[:i]
+                for i, piece in enumerate(ver1):
+                    if piece.isdigit():
+                        _first_remainder = ver1[i:]
+                        str1 = ver1[:i]
                         break
 
-                for i in range(0, len(v2)):
-                    if v2[i].isdigit():
-                        _second_remainder = v2[i:]
-                        str2 = v2[:i]
+                for i, piece in enumerate(ver2):
+                    if piece.isdigit():
+                        _second_remainder = ver2[i:]
+                        str2 = ver2[:i]
                         break
 
                 # Then compare the two strings, and return our comparison state.
@@ -164,42 +166,42 @@ class Ckan:
                             _result = 0
                     else:
                         # Do an artificial __cmp__
-                        _result = ((str1 > str2)-(str1 < str2))
+                        _result = ((str1 > str2) - (str1 < str2))
                 else:
-                    _result = ((str1 > str2)-(str1 < str2))
+                    _result = ((str1 > str2) - (str1 < str2))
 
                 return _result, _first_remainder, _second_remainder
 
-            def _number_compare(v1: str, v2: str) -> Tuple[int, str, str]:
+            def _number_compare(ver1: str, ver2: str) -> Tuple[int, str, str]:
                 _result: int
                 _first_remainder = ''
                 _second_remainder = ''
 
                 minimum_length1 = 0
-                for i in range(0, len(v1)):
-                    if not v1[i].isdigit():
-                        _first_remainder = v1[i:]
+                for i, piece in enumerate(ver1):
+                    if not piece.isdigit():
+                        _first_remainder = ver1[i:]
                         break
                     minimum_length1 += 1
 
                 minimum_length2 = 0
-                for i in range(0, len(v2)):
-                    if not v2[i].isdigit():
-                        _second_remainder = v2[i:]
+                for i, piece in enumerate(ver2):
+                    if not piece.isdigit():
+                        _second_remainder = ver2[i:]
                         break
                     minimum_length2 += 1
 
-                if v1[:minimum_length1].isnumeric():
-                    integer1 = int(v1[:minimum_length1])
+                if ver1[:minimum_length1].isnumeric():
+                    integer1 = int(ver1[:minimum_length1])
                 else:
                     integer1 = 0
 
-                if v2[:minimum_length2].isnumeric():
-                    integer2 = int(v2[:minimum_length2])
+                if ver2[:minimum_length2].isnumeric():
+                    integer2 = int(ver2[:minimum_length2])
                 else:
                     integer2 = 0
 
-                _result = ((integer1 > integer2)-(integer1 < integer2))
+                _result = ((integer1 > integer2) - (integer1 < integer2))
                 return _result, _first_remainder, _second_remainder
 
             # Here begins the main comparison logic
@@ -249,10 +251,10 @@ class Ckan:
 
     CACHE_PATH = Path.home().joinpath('ckan_cache')
     MIME_TO_EXTENSION = {
-        'application/x-gzip':           'gz',
-        'application/x-tar':            'tar',
+        'application/x-gzip': 'gz',
+        'application/x-tar': 'tar',
         'application/x-compressed-tar': 'tar.gz',
-        'application/zip':              'zip',
+        'application/zip': 'zip',
     }
     ISODATETIME_PROPERTIES = [
         'release_date'
@@ -272,7 +274,7 @@ class Ckan:
             if k in dct:
                 try:
                     dct[k] = dateutil.parser.isoparse(dct[k])
-                except: # pylint: disable=bare-except
+                except:  # pylint: disable=bare-except  # noqa: E722
                     pass
         return dct
 
@@ -340,14 +342,8 @@ class Ckan:
 
     def authors(self) -> List[str]:
         auth = self.author
-        if isinstance(auth, list):
-            return auth
-        else:
-            return [auth]
+        return auth if isinstance(auth, list) else [auth]
 
     def licenses(self) -> List[str]:
         lic = self.license
-        if isinstance(lic, list):
-            return lic
-        else:
-            return [lic]
+        return lic if isinstance(lic, list) else [lic]

--- a/netkan/netkan/notifications.py
+++ b/netkan/netkan/notifications.py
@@ -31,7 +31,7 @@ class DiscordLogHandler(logging.Handler):
         if as_code:
             return (f'```{msg[start:start+max_len-6]}```'
                     for start in range(0, len(msg), max_len - 6))
-        return (msg[start:start+max_len] for start in range(0, len(msg), max_len))
+        return (msg[start:start + max_len] for start in range(0, len(msg), max_len))
 
 
 def setup_log_handler(debug: bool = False) -> bool:

--- a/netkan/netkan/repos.py
+++ b/netkan/netkan/repos.py
@@ -5,6 +5,7 @@ from typing import Iterable, List, Optional, Generator, Union
 from git import Repo, Commit, GitCommandError
 from .metadata import Netkan, Ckan
 
+
 class XkanRepo:
 
     """
@@ -130,7 +131,8 @@ class NetkanRepo(XkanRepo):
     def netkans(self) -> Iterable[Netkan]:
         return (Netkan(f) for f in self.all_nk_paths())
 
-    def _nk_sort(self, path: Path) -> str:
+    @staticmethod
+    def _nk_sort(path: Path) -> str:
         return path.stem.casefold()
 
 

--- a/netkan/netkan/spacedock_adder.py
+++ b/netkan/netkan/spacedock_adder.py
@@ -8,6 +8,7 @@ import git
 import boto3
 
 from .github_pr import GitHubPR
+from .common import deletion_msg
 
 from .repos import NetkanRepo
 
@@ -41,7 +42,7 @@ class SpaceDockAdder:
                 for msg in messages:
                     if self.try_add(json.loads(msg.body)):
                         # Successfully handled -> OK to delete
-                        to_delete.append(self.deletion_msg(msg))
+                        to_delete.append(deletion_msg(msg))
                 self.queue.delete_messages(Entries=to_delete)
                 # Clean up GitPython's lingering file handles between batches
                 self.nk_repo.git_repo.close()
@@ -102,13 +103,7 @@ class SpaceDockAdder:
         return True
 
     @staticmethod
-    def deletion_msg(msg: 'boto3.resources.factory.sqs.Message') -> Dict[str, Any]:
-        return {
-            'Id':            msg.message_id,
-            'ReceiptHandle': msg.receipt_handle,
-        }
-
-    def make_netkan(self, info: Dict[str, Any]) -> Dict[str, Any]:
+    def make_netkan(info: Dict[str, Any]) -> Dict[str, Any]:
         return {
             'spec_version': 'v1.4',
             'identifier': re.sub(r'\W+', '', info.get('name', '')),

--- a/netkan/netkan/status.py
+++ b/netkan/netkan/status.py
@@ -70,7 +70,7 @@ class ModStatus(Model):
 
             # Persist compability with existing status ui
             if compat:
-                failed = False if mod.success else True
+                failed = not mod.success
                 data[mod.ModIdentifier]['failed'] = failed
                 data[mod.ModIdentifier].pop('success')
 
@@ -101,7 +101,7 @@ class ModStatus(Model):
                         item.pop(update_key)
                     )
                 item['ModIdentifier'] = key
-                item['success'] = False if item['failed'] else True
+                item['success'] = not item['failed']
                 item.pop('failed')
 
                 # Every batch write consumes a credit, we want to leave spare

--- a/netkan/netkan/webhooks/__init__.py
+++ b/netkan/netkan/webhooks/__init__.py
@@ -1,7 +1,5 @@
 import os
 import sys
-from pathlib import Path
-import boto3
 from flask import Flask
 
 from ..notifications import setup_log_handler, catch_all

--- a/netkan/netkan/webhooks/config.py
+++ b/netkan/netkan/webhooks/config.py
@@ -7,6 +7,8 @@ from ..utils import init_repo, init_ssh
 
 class WebhooksConfig:
 
+    # pylint: disable=attribute-defined-outside-init
+
     # Ideally this would be __init__, but we want other modules to
     # import a reference to our global config object before we set
     # its properties, and that requires a temporary 'empty' state.

--- a/netkan/netkan/webhooks/spacedock_inflate.py
+++ b/netkan/netkan/webhooks/spacedock_inflate.py
@@ -29,28 +29,28 @@ def inflate_hook() -> Tuple[str, int]:
             current_app.logger.error(
                 f'A SpaceDock mod has been deleted, affected netkans: {nk_msg}')
             return '', 204
-        elif request.form.get('event_type') == 'locked':
+        if request.form.get('event_type') == 'locked':
             # Just let the team know on Discord
             nk_msg = ', '.join(nk.identifier for nk in nks)
             current_app.logger.error(
                 f'A SpaceDock mod has been locked, affected netkans: {nk_msg}')
             return '', 204
-        elif request.form.get('event_type') == 'unlocked':
+        if request.form.get('event_type') == 'unlocked':
             # Just let the team know on Discord
             nk_msg = ', '.join(nk.identifier for nk in nks)
             current_app.logger.error(
                 f'A SpaceDock mod has been unlocked again, affected netkans: {nk_msg}')
             return '', 204
-        else:
-            # Submit them to the queue
-            messages = (nk.sqs_message(current_config.ckm_repo.highest_version(nk.identifier))
-                        for nk in nks)
-            for batch in sqs_batch_entries(messages):
-                current_config.client.send_message_batch(
-                    QueueUrl=current_config.inflation_queue.url,
-                    Entries=batch
-                )
-            return '', 204
+
+        # Submit them to the queue
+        messages = (nk.sqs_message(current_config.ckm_repo.highest_version(nk.identifier))
+                    for nk in nks)
+        for batch in sqs_batch_entries(messages):
+            current_config.client.send_message_batch(
+                QueueUrl=current_config.inflation_queue.url,
+                Entries=batch
+            )
+        return '', 204
     return 'No such module', 404
 
 

--- a/netkan/pytest.ini
+++ b/netkan/pytest.ini
@@ -1,2 +1,3 @@
 [pytest]
 python_files = tests/__init__.py
+addopts = -p no:cacheprovider --mypy --pylint --flake8

--- a/netkan/setup.py
+++ b/netkan/setup.py
@@ -46,6 +46,8 @@ setup(
             'pytest',
             'pytest-mypy',
             'mypy',
+            'pytest-flake8',
+            'pytest-pylint',
         ]
     },
 )

--- a/netkan/setup.py
+++ b/netkan/setup.py
@@ -35,12 +35,14 @@ setup(
     extras_require={
         'development': [
             'ptvsd',
-            'pylint',
             'autopep8',
             'troposphere',
             'pytest',
             'pytest-mypy',
             'mypy',
+            'pytest-pylint',
+            'pylint',
+            'pytest-flake8',
         ],
         'test': [
             'pytest',

--- a/netkan/tests/__init__.py
+++ b/netkan/tests/__init__.py
@@ -1,3 +1,5 @@
+# flake8: noqa
+
 from .cli import *
 from .download_counter import *
 from .indexer import *

--- a/netkan/tests/__init__.py
+++ b/netkan/tests/__init__.py
@@ -9,3 +9,4 @@ from .repos import *
 from .scheduler import *
 from .utils import *
 from .csharp_compat import *
+from .auto_freezer import *

--- a/netkan/tests/auto_freezer.py
+++ b/netkan/tests/auto_freezer.py
@@ -1,0 +1,91 @@
+# pylint: disable-all
+# flake8: noqa
+
+from datetime import datetime, timezone, timedelta
+import unittest
+from unittest.mock import patch, call
+import git
+
+from netkan.auto_freezer import AutoFreezer
+from netkan.repos import NetkanRepo
+from netkan.metadata import Netkan
+from netkan.github_pr import GitHubPR
+
+
+class TestAutoFreezer(unittest.TestCase):
+
+    now = datetime.now(timezone.utc)
+    a_while_ago = now - timedelta(days=1001)
+    a_long_time_ago = now - timedelta(days=1050)
+    IDENT_TIMESTAMPS = {
+        'Astrogator': a_while_ago,
+        'SmartTank':  a_long_time_ago,
+        'Ringworld':  now,
+    }
+
+    def test_find_idle_mods(self):
+        """
+        Return freshly idle mods, skip active and ancient mods
+        """
+
+        # Arrange
+        with patch('git.Repo') as repo_mock, \
+            patch('netkan.repos.NetkanRepo') as nk_repo_mock, \
+            patch('netkan.auto_freezer.ModStatus') as status_mock, \
+            patch('netkan.github_pr.GitHubPR') as pr_mock:
+
+            nk_repo_mock.return_value.netkans.return_value = [
+                Netkan(contents='{ "identifier": "Astrogator" }'),
+                Netkan(contents='{ "identifier": "SmartTank"  }'),
+                Netkan(contents='{ "identifier": "Ringworld"  }'),
+            ]
+            status_mock.get.side_effect = lambda ident: unittest.mock.Mock(release_date=self.IDENT_TIMESTAMPS[ident])
+            nk_repo = nk_repo_mock(git.Repo('/blah'))
+            github_pr = pr_mock('', '', '')
+            af = AutoFreezer(nk_repo, github_pr)
+
+            # Act
+            astrogator_dttm = af._last_timestamp('Astrogator')
+            smarttank_dttm = af._last_timestamp('SmartTank')
+            ringworld_dttm = af._last_timestamp('Ringworld')
+            idle_mods = af._find_idle_mods(1000, 21)
+
+            # Assert
+            self.assertEqual(astrogator_dttm, self.a_while_ago)
+            self.assertEqual(smarttank_dttm, self.a_long_time_ago)
+            self.assertEqual(ringworld_dttm, self.now)
+            self.assertEqual(idle_mods, [('Astrogator', self.a_while_ago)])
+
+    def test_submit_pr(self):
+        """
+        Check pull request format
+        """
+
+        # Arrange
+        with patch('git.Repo') as repo_mock, \
+            patch('netkan.repos.NetkanRepo') as nk_repo_mock, \
+            patch('netkan.github_pr.GitHubPR') as pr_mock:
+
+            unittest.util._MAX_LENGTH=999999999 # :snake:
+
+            nk_repo = nk_repo_mock(git.Repo('/blah'))
+            github_pr = pr_mock('', '', '')
+            af = AutoFreezer(nk_repo, github_pr)
+
+            # Act
+            af._submit_pr('test_branch_name', 69, [
+                ('Astrogator', datetime(2010, 1, 1, tzinfo=timezone.utc)),
+                ('SmartTank',  datetime(2015, 1, 1, tzinfo=timezone.utc)),
+                ('Ringworld',  datetime(2020, 1, 1, tzinfo=timezone.utc)),
+            ])
+
+            # Assert
+            self.assertEqual(nk_repo.git_repo.remotes.origin.push.mock_calls, [
+                call('test_branch_name:test_branch_name')
+            ])
+            self.assertEqual(pr_mock.return_value.create_pull_request.mock_calls, [
+                call(branch='test_branch_name',
+                     title='Freeze idle mods',
+                     body='The attached mods have not updated in 69 or more days. Freeze them to save the bot some CPU cycles.\n\nMod | Last Update\n:-- | :--\nAstrogator | 2010-01-01 00:00 UTC\nSmartTank | 2015-01-01 00:00 UTC\nRingworld | 2020-01-01 00:00 UTC'
+                )
+            ])

--- a/netkan/tests/csharp_compat.py
+++ b/netkan/tests/csharp_compat.py
@@ -7,6 +7,8 @@ class TestCsharpCompat(unittest.TestCase):
 
     def test_csharp_uri_tostring(self) -> None:
         """
+        Make sure we return the same string C# would for new System.Uri(url).ToString()
+
         https://docs.microsoft.com/en-us/dotnet/api/system.uri.tostring?view=netframework-4.7.2
 
         That documentation is incomplete or wrong; these tests determined empirically in Mono.

--- a/netkan/tests/csharp_compat.py
+++ b/netkan/tests/csharp_compat.py
@@ -2,6 +2,7 @@ import unittest
 
 from netkan.csharp_compat import csharp_uri_tostring
 
+
 class TestCsharpCompat(unittest.TestCase):
 
     def test_csharp_uri_tostring(self) -> None:

--- a/netkan/tests/indexer.py
+++ b/netkan/tests/indexer.py
@@ -1,3 +1,6 @@
+# pylint: disable-all
+# flake8: noqa
+
 import unittest
 import tempfile
 import shutil

--- a/netkan/tests/metadata.py
+++ b/netkan/tests/metadata.py
@@ -1,3 +1,6 @@
+# pylint: disable-all
+# flake8: noqa
+
 import unittest
 from pathlib import Path, PurePath
 from git import Repo

--- a/netkan/tests/repos.py
+++ b/netkan/tests/repos.py
@@ -1,3 +1,6 @@
+# pylint: disable-all
+# flake8: noqa
+
 import shutil
 import tempfile
 import unittest

--- a/netkan/tests/utils.py
+++ b/netkan/tests/utils.py
@@ -1,9 +1,9 @@
-from netkan.utils import repo_file_add_or_changed
-
 import unittest
 import tempfile
 from pathlib import Path
 from git import Repo
+
+from netkan.utils import repo_file_add_or_changed
 
 
 class TestNetKANUtilsRepoFileAddOrChange(unittest.TestCase):

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,4 @@
+[pytest]
+testpaths = netkan
+python_files = tests/__init__.py
+addopts = -p no:cacheprovider -v


### PR DESCRIPTION
## Background

In #212 we switched to using `pytest` to handle our tests, since it can drive other tools with plugins, such as `pytest-mypy` which we also added in that PR.

## Motivation

Pytest and mypy are nice, but we'd also like to use pylint and flake8.

## Changes

`setup.py`:

- `pytest-flake8` and `pytest-pylint` are added to the `[test]` dependencies group

New parameters in the `pytest.ini` file:

- `-p no:cacheprovider` turns off caching, because it just wastes CPU/IO in CI/CD (the cache folder is going to disappear at the end), and it causes false positives and false negatives locally if you edit which checks are disabled
- `--mypy --pylint --flake8` ensures that running `pytest` will always run mypy, pylint, and flake8. This way the individual dev doesn't have to know or remember which tools we use or how to call them; they'll all be pulled in automatically with a simpler command

Workflow step and Dockerfile:

- Now runs `pytest -v` which will run everything thanks to the `pytest.ini` changes

`.pylintrc`:

- Disabled the checks that are either too picky or would require large scale refactoring; we can re-enable some of these if we decide to refactor the affected code.

`.flake8`:

- Disabled checks for whitespace before/after colons and long lines

Lots of minor changes to code to fix complaints from the still-enabled checks from both tools.