### PR TITLE
Pull shallowly and collect garbage

### DIFF
--- a/netkan/netkan/common.py
+++ b/netkan/netkan/common.py
@@ -27,7 +27,8 @@ def sqs_batch_entries(messages: Iterable[Dict[str, str]],
 
 def pull_all(repos: Iterable[Repo]) -> None:
     for repo in repos:
-        repo.remotes.origin.pull('master', strategy_option='theirs')
+        repo.remotes.origin.pull('master', strategy_option='theirs', depth='1', allow_unrelated_histories=True)
+        repo.git.gc(prune='all')
 
 
 def github_limit_remaining(token: str) -> int:

--- a/netkan/netkan/mirrorer.py
+++ b/netkan/netkan/mirrorer.py
@@ -322,7 +322,8 @@ class Mirrorer:
                 # Get up to date copy of the metadata for the files we're mirroring
                 logging.info('Updating repo')
                 self.ckm_repo.git_repo.heads.master.checkout()
-                self.ckm_repo.git_repo.remotes.origin.pull('master', strategy_option='theirs')
+                self.ckm_repo.git_repo.remotes.origin.pull('master', strategy_option='theirs', depth='1', allow_unrelated_histories=True)
+                self.ckm_repo.git_repo.git.gc(prune='all')
                 # Start processing the messages
                 to_delete = []
                 for msg in messages:

--- a/netkan/netkan/repos.py
+++ b/netkan/netkan/repos.py
@@ -39,8 +39,12 @@ class XkanRepo:
         branch = getattr(self.git_repo.heads, branch_name)
         branch.checkout()
 
-    def pull_remote_branch(self, branch_name: str, strategy_option: str = 'ours') -> None:
-        self.git_repo.remotes.origin.pull(branch_name, strategy_option=strategy_option)
+    def pull_remote_branch(self, branch_name: str, strategy_option: str = 'ours', deep_clone: bool = False) -> None:
+        if deep_clone:
+            self.git_repo.remotes.origin.pull(branch_name, strategy_option=strategy_option)
+        else:
+            self.git_repo.remotes.origin.pull(branch_name, strategy_option=strategy_option, depth='1', allow_unrelated_histories=True)
+        self.git_repo.git.gc(prune='all')
 
     def push_remote_branch(self, branch_name: str) -> None:
         self.git_repo.remotes.origin.push(branch_name)

--- a/netkan/netkan/spacedock_adder.py
+++ b/netkan/netkan/spacedock_adder.py
@@ -35,7 +35,8 @@ class SpaceDockAdder:
             )
             if messages:
                 self.nk_repo.git_repo.heads.master.checkout()
-                self.nk_repo.git_repo.remotes.origin.pull('master', strategy_option='ours')
+                self.nk_repo.git_repo.remotes.origin.pull('master', strategy_option='ours', depth='1', allow_unrelated_histories=True)
+                self.nk_repo.git_repo.git.gc(prune='all')
 
                 # Start processing the messages
                 to_delete = []

--- a/netkan/tests/repos.py
+++ b/netkan/tests/repos.py
@@ -50,6 +50,10 @@ class TestNetkanRepo(TestRepo):
 
     def setUp(self):
         self.nk_repo = NetkanRepo(self.repo)
+        cfg = self.nk_repo.git_repo.config_writer()
+        cfg.set_value('user', 'name',  'NetKAN inflator Robot TESTER')
+        cfg.set_value('user', 'email', 'netkan-bot@ksp-ckan.space')
+        cfg.release()
 
     def test_nk_path(self):
         self.assertTrue(self.nk_repo.nk_path('DogeCoinFlag').exists())


### PR DESCRIPTION
## Problem

We're seeing occasional/periodic issues where the volume credits for the bot plummet sharply:

![graph](https://cdn.discordapp.com/attachments/601455398553387008/823358933241561108/unknown.png)

## Cause

We don't really know; there just isn't a lot of evidence at this point. One consensus possibility is that it has to do with git and/or gitpython getting slower and/or using more RAM over time as more and more commits accumulate in the history.

(I'm privately skeptical of this explanation, as I work with plenty of full-depth clones of plenty of repos and have not seen slowness or memory issues in working with them, and git is pretty well designed in general to avoid rookie mistakes. However, I also can't rule it out.)

## Changes

Now our `git pull` commands use `--depth=1` to keep the clone shallow. `--allow-unrelated-histories` is needed to merge the remote into the local master without a common base commit.
Then we `git gc --prune=all` to remove dangling objects.

This should eliminate all accumulation of complex data in git. If the de-shallowing of our clones is a cause, then this will fix the problems. If it isn't, then now we will know that for sure.