### PR TITLE
Fix Scheduler Permissions

### DIFF
--- a/prod-stack.py
+++ b/prod-stack.py
@@ -349,7 +349,8 @@ netkan_ecs_role = t.add_resource(Role(
 scheduler_resources = []
 for task in [
         'Scheduler', 'SchedulerWebhooksPass', 'CertBot', 'StatusDumper',
-        'DownloadCounter', 'TicketCloser', 'AutoFreezer', 'RestartWebhooks']:
+        'DownloadCounter', 'TicketCloser', 'AutoFreezer', 'RestartWebhooks',
+        'CleanCache']:
     scheduler_resources.append(Sub(
         'arn:aws:ecs:*:${AWS::AccountId}:task-definition/NetKANBot${Task}:*',
         Task=task


### PR DESCRIPTION
I got suss when the scheduled task wasn't even showing up in the stopped containers list.

This adds 'CleanCache' to the list of TaskDefinitions that the Event Scheduler is allowed to run.

This fix has been applied and is now working.