### PR TITLE
Allow YAML format for .netkans

### DIFF
--- a/netkan/.pylintrc
+++ b/netkan/.pylintrc
@@ -11,3 +11,4 @@ disable =
     too-many-return-statements,
     too-many-branches,
     too-many-arguments,
+    consider-using-with,

--- a/netkan/netkan/cli/common.py
+++ b/netkan/netkan/cli/common.py
@@ -14,7 +14,8 @@ from ..github_pr import GitHubPR
 def ctx_callback(ctx: click.Context, param: click.Parameter,
                  value: Union[str, int]) -> Union[str, int]:
     shared = ctx.ensure_object(SharedArgs)
-    setattr(shared, param.name, value)
+    if param.name:
+        setattr(shared, param.name, value)
     return value
 
 

--- a/netkan/netkan/metadata.py
+++ b/netkan/netkan/metadata.py
@@ -1,4 +1,5 @@
 import json
+import yaml
 import re
 from functools import total_ordering
 from pathlib import Path
@@ -21,7 +22,7 @@ class Netkan:
             self.contents = self.filename.read_text()
         elif contents:
             self.contents = contents
-        self._raw = json.loads(self.contents)
+        self._raw = yaml.safe_load(self.contents)
         # Extract kref_src + kref_id from the kref
         self.kref_src: Optional[str]
         self.kref_id: Optional[str]

--- a/netkan/netkan/metadata.py
+++ b/netkan/netkan/metadata.py
@@ -1,5 +1,4 @@
 import json
-import yaml
 import re
 from functools import total_ordering
 from pathlib import Path
@@ -7,6 +6,7 @@ from hashlib import sha1
 import uuid
 import urllib.parse
 from typing import Optional, List, Tuple, Union, Any, Dict
+import yaml
 import dateutil.parser
 
 from .csharp_compat import csharp_uri_tostring

--- a/netkan/netkan/webhooks/github_inflate.py
+++ b/netkan/netkan/webhooks/github_inflate.py
@@ -1,7 +1,7 @@
 import logging
 from pathlib import Path
-from typing import List, Tuple, Iterable, Dict, Any, Set
-from flask import Blueprint, current_app, request, jsonify
+from typing import List, Tuple, Iterable, Dict, Any, Set, Union
+from flask import Blueprint, current_app, request, jsonify, Response
 
 from ..common import netkans, sqs_batch_entries, pull_all
 from ..status import ModStatus
@@ -15,7 +15,7 @@ github_inflate = Blueprint('github_inflate', __name__)  # pylint: disable=invali
 # Handles: https://netkan.ksp-ckan.space/gh/inflate
 @github_inflate.route('/inflate', methods=['POST'])
 @signature_required
-def inflate_hook() -> Tuple[str, int]:
+def inflate_hook() -> Tuple[Union[Response, str], int]:
     raw = request.get_json(silent=True)
     branch = raw.get('ref')
     if branch != current_config.nk_repo.git_repo.head.ref.path:

--- a/netkan/netkan/webhooks/github_inflate.py
+++ b/netkan/netkan/webhooks/github_inflate.py
@@ -17,11 +17,11 @@ github_inflate = Blueprint('github_inflate', __name__)  # pylint: disable=invali
 @signature_required
 def inflate_hook() -> Tuple[Union[Response, str], int]:
     raw = request.get_json(silent=True)
-    branch = raw.get('ref') # mypy: ignore[union-attr]
+    branch = raw.get('ref')  # type: ignore[union-attr]
     if branch != current_config.nk_repo.git_repo.head.ref.path:
         current_app.logger.info('Received inflation request for wrong ref %s, ignoring', branch)
         return jsonify({'message': 'Wrong branch'}), 200
-    commits = raw.get('commits') # mypy: ignore[union-attr]
+    commits = raw.get('commits')  # type: ignore[union-attr]
     if not commits:
         current_app.logger.info('No commits received')
         return jsonify({'message': 'No commits received'}), 200

--- a/netkan/netkan/webhooks/github_inflate.py
+++ b/netkan/netkan/webhooks/github_inflate.py
@@ -17,11 +17,11 @@ github_inflate = Blueprint('github_inflate', __name__)  # pylint: disable=invali
 @signature_required
 def inflate_hook() -> Tuple[Union[Response, str], int]:
     raw = request.get_json(silent=True)
-    branch = raw.get('ref')
+    branch = raw.get('ref') # mypy: ignore[union-attr]
     if branch != current_config.nk_repo.git_repo.head.ref.path:
         current_app.logger.info('Received inflation request for wrong ref %s, ignoring', branch)
         return jsonify({'message': 'Wrong branch'}), 200
-    commits = raw.get('commits')
+    commits = raw.get('commits') # mypy: ignore[union-attr]
     if not commits:
         current_app.logger.info('No commits received')
         return jsonify({'message': 'No commits received'}), 200

--- a/netkan/netkan/webhooks/github_mirror.py
+++ b/netkan/netkan/webhooks/github_mirror.py
@@ -18,18 +18,18 @@ github_mirror = Blueprint('github_mirror', __name__)  # pylint: disable=invalid-
 @signature_required
 def mirror_hook() -> Tuple[Union[Response, str], int]:
     raw = request.get_json(silent=True)
-    ref = raw.get('ref')
+    ref = raw.get('ref') # mypy: ignore[union-attr]
     expected_ref = current_config.ckm_repo.git_repo.heads.master.path
     if ref != expected_ref:
         current_app.logger.info(
             "Wrong branch. Expected '%s', got '%s'", expected_ref, ref)
         return jsonify({'message': 'Wrong branch'}), 200
-    commits = raw.get('commits')
+    commits = raw.get('commits') # mypy: ignore[union-attr]
     if not commits:
         current_app.logger.info('No commits received')
         return jsonify({'message': 'No commits received'}), 200
     # Make sure it's not from the crawler
-    sender = raw.get('sender')
+    sender = raw.get('sender') # mypy: ignore[union-attr]
     if sender:
         login = sender.get('login')
         if login:

--- a/netkan/netkan/webhooks/github_mirror.py
+++ b/netkan/netkan/webhooks/github_mirror.py
@@ -18,18 +18,18 @@ github_mirror = Blueprint('github_mirror', __name__)  # pylint: disable=invalid-
 @signature_required
 def mirror_hook() -> Tuple[Union[Response, str], int]:
     raw = request.get_json(silent=True)
-    ref = raw.get('ref') # mypy: ignore[union-attr]
+    ref = raw.get('ref')  # type: ignore[union-attr]
     expected_ref = current_config.ckm_repo.git_repo.heads.master.path
     if ref != expected_ref:
         current_app.logger.info(
             "Wrong branch. Expected '%s', got '%s'", expected_ref, ref)
         return jsonify({'message': 'Wrong branch'}), 200
-    commits = raw.get('commits') # mypy: ignore[union-attr]
+    commits = raw.get('commits')  # type: ignore[union-attr]
     if not commits:
         current_app.logger.info('No commits received')
         return jsonify({'message': 'No commits received'}), 200
     # Make sure it's not from the crawler
-    sender = raw.get('sender') # mypy: ignore[union-attr]
+    sender = raw.get('sender')  # type: ignore[union-attr]
     if sender:
         login = sender.get('login')
         if login:

--- a/netkan/netkan/webhooks/github_mirror.py
+++ b/netkan/netkan/webhooks/github_mirror.py
@@ -1,8 +1,8 @@
 import re
 from pathlib import Path
 from hashlib import md5
-from typing import Tuple, List, Iterable, Dict, Any, Set
-from flask import Blueprint, current_app, request, jsonify
+from typing import Tuple, List, Iterable, Dict, Any, Set, Union
+from flask import Blueprint, current_app, request, jsonify, Response
 
 from .github_utils import signature_required
 from ..common import sqs_batch_entries
@@ -16,7 +16,7 @@ github_mirror = Blueprint('github_mirror', __name__)  # pylint: disable=invalid-
 # Handles: https://netkan.ksp-ckan.space/gh/mirror
 @github_mirror.route('/mirror', methods=['POST'])
 @signature_required
-def mirror_hook() -> Tuple[str, int]:
+def mirror_hook() -> Tuple[Union[Response, str], int]:
     raw = request.get_json(silent=True)
     ref = raw.get('ref')
     expected_ref = current_config.ckm_repo.git_repo.heads.master.path

--- a/netkan/netkan/webhooks/inflate.py
+++ b/netkan/netkan/webhooks/inflate.py
@@ -14,7 +14,8 @@ inflate = Blueprint('inflate', __name__)  # pylint: disable=invalid-name
 @inflate.route('/inflate', methods=['POST'])
 def inflate_hook() -> Tuple[str, int]:
     # SpaceDock doesn't set the `Content-Type: application/json` header
-    ids = request.get_json(force=True).get('identifiers')
+    raw = request.get_json(force=True)
+    ids = raw.get('identifiers') # mypy: ignore[union-attr]
     if not ids:
         current_app.logger.info('No identifiers received')
         return 'An array of identifiers is required', 400

--- a/netkan/netkan/webhooks/inflate.py
+++ b/netkan/netkan/webhooks/inflate.py
@@ -15,7 +15,7 @@ inflate = Blueprint('inflate', __name__)  # pylint: disable=invalid-name
 def inflate_hook() -> Tuple[str, int]:
     # SpaceDock doesn't set the `Content-Type: application/json` header
     raw = request.get_json(force=True)
-    ids = raw.get('identifiers') # mypy: ignore[union-attr]
+    ids = raw.get('identifiers')  # type: ignore[union-attr]
     if not ids:
         current_app.logger.info('No identifiers received')
         return 'An array of identifiers is required', 400

--- a/netkan/setup.py
+++ b/netkan/setup.py
@@ -26,6 +26,7 @@ setup(
         'gunicorn>=19.9,!=20.0.0',
         'discord.py>=1.6.0',
         'PyGithub',
+        'pyyaml',
     ],
     entry_points={
         'console_scripts': [

--- a/netkan/tests/metadata.py
+++ b/netkan/tests/metadata.py
@@ -134,6 +134,36 @@ class TestNetKANVref(TestNetKAN):
         self.assertFalse(self.netkan.hook_only())
 
 
+class TestNetKANYAML(TestNetKAN):
+
+    def setUp(self):
+        self.netkan = Netkan(contents="""
+spec_version: v1.4
+identifier:   Cosmogator
+$kref:        "#/ckan/github/HebaruSan/Astrogator"
+license:      GPL-3.0
+tags:
+    - plugin
+    - information
+    - control
+install:
+    - find: Astrogator
+      install_to: GameData
+""")
+
+    def test_parsed_yaml_metadata(self):
+        self.assertEqual(self.netkan.spec_version, "v1.4")
+        self.assertEqual(self.netkan.identifier, "Cosmogator")
+        self.assertEqual(self.netkan.kref_src, "github")
+        self.assertEqual(self.netkan.kref_id, "HebaruSan/Astrogator")
+        self.assertEqual(self.netkan.license, "GPL-3.0")
+        self.assertEqual(self.netkan.tags, ["plugin", "information", "control"])
+        self.assertEqual(self.netkan.install, [ {
+            "find": "Astrogator",
+            "install_to": "GameData"
+        } ])
+
+
 class TestCkanSimple(unittest.TestCase):
 
     def setUp(self):


### PR DESCRIPTION
## Motivation

See KSP-CKAN/CKAN#3367, we might want to allow .netkans to use YAML format. If so, the Infra will need to be able to handle that.

## Changes

Now when we load a .netkan file from the repo, we call `yaml.safe_load` instead of `json.loads`, so YAML format is allowed. The return format is the same, and it can still parse JSON files, so there should be no change other than YAML files working.

mypy and friends seem to have gotten smarter and dumber lately, so other updates are made to get the tests passing again.