### PR TITLE
Replace tab characters before passing to YAML parser

### DIFF
--- a/netkan/netkan/metadata.py
+++ b/netkan/netkan/metadata.py
@@ -22,7 +22,8 @@ class Netkan:
             self.contents = self.filename.read_text()
         elif contents:
             self.contents = contents
-        self._raw = yaml.safe_load(self.contents)
+        # YAML parser doesn't allow tabs, so replace with spaces
+        self._raw = yaml.safe_load(self.contents.replace('\t', '    '))
         # Extract kref_src + kref_id from the kref
         self.kref_src: Optional[str]
         self.kref_id: Optional[str]


### PR DESCRIPTION
## Problem

After #219, the scheduler now reports this to the Discord notifications channel:

```
Uncaught exception:
Traceback (most recent call last):
  File ".local/bin/netkan", line 8, in <module>
    sys.exit(netkan())
  File "/home/netkan/.local/lib/python3.7/site-packages/click/core.py", line 1137, in __call__
    return self.main(*args, **kwargs)
  File "/home/netkan/.local/lib/python3.7/site-packages/click/core.py", line 1062, in main
    rv = self.invoke(ctx)
  File "/home/netkan/.local/lib/python3.7/site-packages/click/core.py", line 1668, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/home/netkan/.local/lib/python3.7/site-packages/click/core.py", line 1404, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "/home/netkan/.local/lib/python3.7/site-packages/click/core.py", line 763, in invoke
    return __callback(*args, **kwargs)
  File "/home/netkan/.local/lib/python3.7/site-packages/click/decorators.py", line 84, in new_func
    return ctx.invoke(f, obj, *args, **kwargs)
  File "/home/netkan/.local/lib/python3.7/site-packages/click/core.py", line 763, in invoke
    return __callback(*args, **kwargs)
  File "/home/netkan/.local/lib/python3.7/site-packages/netkan/cli/services.py", line 65, in scheduler
    sched.schedule_all_netkans()
  File "/home/netkan/.local/lib/python3.7/site-packages/netkan/scheduler.py", line 43, in schedule_all_netkans
    for batch in sqs_batch_entries(messages):
  File "/home/netkan/.local/lib/python3.7/site-packages/netkan/common.py", line 19, in sqs_batch_entries
    for msg in messages:
  File "/home/netkan/.local/lib/python3.7/site-packages/netkan/scheduler.py", line 41, in <genexpr>
    messages = (nk.sqs_message(self.ckm_repo.highest_version(nk.identifier))
  File "/home/netkan/.local/lib/python3.7/site-packages/netkan/repos.py", line 132, in <genexpr>
    return (Netkan(f) for f in self.all_nk_paths())
  File "/home/netkan/.local/lib/python3.7/site-packages/netkan/metadata.py", line 25, in __init__
    self._raw = yaml.safe_load(self.contents)
  File "/home/netkan/.local/lib/python3.7/site-packages/yaml/__init__.py", line 162, in safe_load
    return load(stream, SafeLoader)
  File "/home/netkan/.local/lib/python3.7/site-packages/yaml/__init__.py", line 114, in load
    return loader.get_single_data()
  File "/home/netkan/.local/lib/python3.7/site-packages/yaml/constructor.py", line 49, in get_single_data
    node = self.get_single_node()
  File "/home/netkan/.local/lib/python3.7/site-packages/yaml/composer.py", line 35, in get_single_node
    if not self.check_event(StreamEndEvent):
  File "/home/netkan/.local/lib/python3.7/site-packages/yaml/parser.py", line 98, in check_event
    self.current_event = self.state()
  File "/home/netkan/.local/lib/python3.7/site-packages/yaml/parser.py", line 143, in parse_implicit_document_start
    StreamEndToken):
  File "/home/netkan/.local/lib/python3.7/site-packages/yaml/scanner.py", line 116, in check_token
    self.fetch_more_tokens()
  File "/home/netkan/.local/lib/python3.7/site-packages/yaml/scanner.py", line 260, in fetch_more_tokens
    self.get_mark())
yaml.scanner.ScannerError: while scanning for the next token
found character '\t' that cannot start any token
  in "<unicode string>", line 2, column 1:
        "spec_version": 1,
    ^
```

## Cause

We switched netkans from a JSON parser to a YAML parser. YAML claims to be a superset of JSON, which is strange because JSON explicitly allows tab characters ("character tabulation (U+0009)"):

- https://www.ecma-international.org/wp-content/uploads/ECMA-404_2nd_edition_december_2017.pdf

> Insignificant whitespace is allowed before or after any token. Whitespace is any sequence of one or more of
the following code points: character tabulation (U+0009), line feed (U+000A), carriage return (U+000D), and
space (U+0020). Whitespace is not allowed within any token, except that space is allowed in strings.

And YAML explicitly forbids tab characters:

- http://yaml.org/faq.html

> Tabs have been outlawed since they are treated differently by different editors and tools. And since indentation is so critical to proper interpretation of YAML, this issue is just too tricky to even attempt. Indeed Guido van Rossum of Python has acknowledged that allowing TABs in Python source is a headache for many people and that were he to design Python again, he would forbid them.

So a YAML parser attempting to load a JSON file with tab characters will fail. :clap: 

## Changes

Now we replace tab characters with 4 spaces before passing to the parser. This should give a reasonable result unless some netkans have weird mixed tab and space combinations, in which case we will find that out.