### PR TITLE
Submit YAML netkans from SpaceDock

### DIFF
--- a/netkan/netkan/spacedock_adder.py
+++ b/netkan/netkan/spacedock_adder.py
@@ -6,6 +6,7 @@ from collections import defaultdict
 from typing import Dict, Any
 import git
 import boto3
+import yaml
 
 from .github_pr import GitHubPR
 from .common import deletion_msg
@@ -76,7 +77,7 @@ class SpaceDockAdder:
         self.nk_repo.git_repo.heads[branch_name].checkout()
 
         # Create file
-        netkan_path.write_text(json.dumps(netkan, indent=4))
+        netkan_path.write_text(yaml.dump(netkan))
 
         # Add netkan to branch
         self.nk_repo.git_repo.index.add([netkan_path.as_posix()])


### PR DESCRIPTION
## Motivation

As of KSP-CKAN/CKAN#3367, netkans are allowed to use YAML format. I don't know how quickly we want to convert random mods to YAML since that would represent a dependency on YAML and we would lose the option to roll it back to JSON, but at some point it might be nice to start changing over.

Thought of while reviewing KSP-CKAN/NetKAN#8568, in which the YAML validator complained about a missing newline at the end of the file. Rather than just adding a newline, we might as well take full advantage of the YAML work.

## Changes

Now if we merge this PR, newly added mods on SpaceDock with the CKAN badge will have the netkans in their pull requests submitted in YAML instead of JSON. This should make them easier to read and edit, without disrupting already indexed mods.