### PR TITLE
Preserve SpaceDock netkan key order

### DIFF
--- a/netkan/netkan/spacedock_adder.py
+++ b/netkan/netkan/spacedock_adder.py
@@ -77,7 +77,7 @@ class SpaceDockAdder:
         self.nk_repo.git_repo.heads[branch_name].checkout()
 
         # Create file
-        netkan_path.write_text(yaml.dump(netkan))
+        netkan_path.write_text(yaml.dump(netkan, sort_keys=False))
 
         # Add netkan to branch
         self.nk_repo.git_repo.index.add([netkan_path.as_posix()])


### PR DESCRIPTION
## Problem

After #221, KSP-CKAN/NetKAN#8572 was submitted in YAML syntax. It worked, but the properties needed some reordering to match other netkans.

## Cause

PyYAML's `dump` sorts the properties alphabetically by default., which we don't want.

## Changes

Now we pass `sort_keys=False` to keep the original ordering. This will work on Python 3.7 and later with PyYAML 5.1 and later.