### PR TITLE
Tune auto garbage collection

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,6 +16,9 @@ jobs:
       - name: Install test dependencies
         working-directory: netkan
         run: pip install .[test]
+      - name: force our git config
+        working-directory: netkan
+        run: cp .gitconfig ~/.
       - name: Run pytest
         working-directory: netkan
         run: pytest -v

--- a/netkan/.gitconfig
+++ b/netkan/.gitconfig
@@ -1,3 +1,10 @@
 [user]
 	email = netkan-bot@ksp-ckan.space
 	name = NetKAN inflator Robot
+
+[gc]
+	auto = 2700
+	reflogExpire = 1
+	worktreePruneExpire = now
+	reflogExpireUnreachable = now
+	pruneExpire = now

--- a/netkan/tests/repos.py
+++ b/netkan/tests/repos.py
@@ -100,3 +100,25 @@ class TestCkanMetaRepo(TestRepo):
 
     def test_mod_path(self):
         self.assertTrue(self.ckm_repo.mod_path('AwesomeMod').exists())
+
+
+class TestRepoConfig(TestRepo):
+    test_data = Path(PurePath(__file__).parent, 'testdata/CKAN-meta')
+
+    def setUp(self):
+        self.ckm_repo = CkanMetaRepo(self.repo)
+
+    def test_gc_auto(self):
+        self.assertEqual(self.ckm_repo.git_repo.config_reader().get_value('gc','auto'), 2700)
+
+    def test_gc_reflog_expire(self):
+        self.assertEqual(self.ckm_repo.git_repo.config_reader().get_value('gc','reflogExpire'), 1)
+
+    def test_gc_worktreePruneExpire(self):
+        self.assertEqual(self.ckm_repo.git_repo.config_reader().get_value('gc','worktreePruneExpire'), 'now')
+
+    def test_gc_reflog_expire_unreachable(self):
+        self.assertEqual(self.ckm_repo.git_repo.config_reader().get_value('gc','reflogExpireUnreachable'), 'now')
+
+    def test_gc_prune_expire(self):
+        self.assertEqual(self.ckm_repo.git_repo.config_reader().get_value('gc','pruneExpire'), 'now')


### PR DESCRIPTION
## Problem
The indexer will randomly start causing disk thrashing and using up all our burst credits for the volume. This often coincides with a number staging branches being generated.

## Proposal: Tune GC
According to the information I can find, git does run an auto gc during "porcelain" commands (pull/push/checkout/commit etc). Whilst `gitpython` doesn't use some of these when dealing with the index (commits, creating new branches etc), on the surface it appears to use push/pull, which is called at least once per 10 items in the incoming queue (more often if there is staging actions). As seen with the trace output

```
DEBUG:git.cmd:Popen(['git', 'pull', '-v', '--strategy-option=ours', 'origin', 'DogeCoinFlag-v1.02'], cwd=/tmp/tmp_ya6lcmx/working, universal_newlines=True, shell=None, istream=None)
DEBUG:git.cmd:Popen(['git', 'checkout', 'master'], cwd=/tmp/tmp_ya6lcmx/working, universal_newlines=False, shell=None, istream=None)
DEBUG:git.cmd:Popen(['git', 'clean', '-df'], cwd=/tmp/tmp_ya6lcmx/working, universal_newlines=False, shell=None, istream=None)
DEBUG:git.cmd:Popen(['git', 'push', '--porcelain', 'origin', 'DogeCoinFlag-v1.02:DogeCoinFlag-v1.02'], cwd=/tmp/tmp_ya6lcmx/working, universal_newlines=True, shell=None, istream=None)
```

Currently the service uses the defaults for git garbage collection:
```
netkan@1035f18b9c46:~$ git config gc.auto && git config gc.reflogExpire && git config gc.worktreePruneExpire && git config gc.reflogExpireUnreachable && git config gc.worktreePruneExpire && git config gc.pruneExpire
netkan@1035f18b9c46:~$
```
From git config --help
>gc.auto
>When there are approximately more than this many loose objects in the repository, git gc --auto will pack them. Some Porcelain commands use this command to perform a light-weight garbage collection from time to time. The default value is 6700.
>
>Setting this to 0 disables not only automatic packing based on the number of loose objects, but any other heuristic git gc --auto will otherwise use to determine if there’s work to do, such as gc.autoPackLimit.
>
>gc.autoPackLimit
>When there are more than this many packs that are not marked with *.keep file in the repository, git gc --auto consolidates them into one larger pack. The default value is 50. Setting this to 0 disables it. Setting gc.auto to 0 will also disable this.
>
>See the gc.bigPackThreshold configuration variable below. When in use, it’ll affect how the auto pack limit works.
>
>gc.autoDetach
>Make git gc --auto return immediately and run in background if the system supports it. Default is true.
>
>gc.bigPackThreshold
>If non-zero, all packs larger than this limit are kept when git gc is run. This is very similar to --keep-largest-pack except that all packs that meet the threshold are kept, not just the largest pack. Defaults to zero. Common unit suffixes of k, m, or g are supported.
>
>    Note that if the number of kept packs is more than gc.autoPackLimit, this configuration variable is ignored, all packs except the base pack will be repacked. After this the number of packs should go below gc.autoPackLimit and gc.bigPackThreshold should be respected again.
>
>    If the amount of memory estimated for git repack to run smoothly is not available and gc.bigPackThreshold is not set, the largest pack will also be excluded (this is the equivalent of running git gc with --keep-largest-pack).
>
>gc.writeCommitGraph
>If true, then gc will rewrite the commit-graph file when git-gc(1) is run. When using git gc --auto the commit-graph will be updated if housekeeping is required. Default is true. See git-commit-graph(1) for details.
>
>gc.logExpiry
>If the file gc.log exists, then git gc --auto will print its content and exit with status zero instead of running unless that file is more than gc.logExpiry old. Default is "1.day". See gc.pruneExpire for more ways to specify its value.
>
>gc.packRefs
>Running git pack-refs in a repository renders it unclonable by Git versions prior to 1.5.1.2 over dumb transports such as HTTP. This variable determines whether git gc runs git pack-refs. This can be set to notbare to enable it within all non-bare repos or it can be set to a boolean value. The default is true.
>
>gc.pruneExpire
>When git gc is run, it will call prune --expire 2.weeks.ago. Override the grace period with this config variable. The value "now" may be used to disable this grace period and always prune unreachable objects immediately, or "never" may be used to suppress pruning. This feature helps prevent corruption when git gc runs concurrently with another process
>writing to the repository; see the "NOTES" section of git-gc(1).
>
>gc.worktreePruneExpire
>When git gc is run, it calls git worktree prune --expire 3.months.ago. This config variable can be used to set a different grace period. The value "now" may be used to disable the grace period and prune $GIT_DIR/worktrees immediately, or "never" may be used to suppress pruning.
>
>`gc.reflogExpire`, `gc.<pattern>.reflogExpire`
>git reflog expire removes reflog entries older than this time; defaults to 90 days. The value "now" expires all entries immediately, and "never" suppresses expiration altogether. With `"<pattern>"` (e.g. "refs/stash") in the middle the setting applies only to the refs that match the `<pattern>`.
>
>`gc.reflogExpireUnreachable`, `gc.<pattern>.reflogExpireUnreachable`
>git reflog expire removes reflog entries older than this time and are not reachable from the current tip; defaults to 30 days. The value "now" expires all entries immediately, and "never" suppresses expiration altogether. With `"<pattern>"` (e.g. "refs/stash") in the middle, the setting applies only to the refs that match the `<pattern>`.
>
>These types of entries are generally created as a result of using git commit --amend or git rebase and are the commits prior to the amend or rebase occurring. Since these changes are not part of the current project most users will want to expire them sooner, which is why the default is more aggressive than gc.reflogExpire.

However it is very likely the container will be long recycled before the time limits of any of the dangling references will ever be pruned. These references are also not applicable to a headless service that is being recycled frequently, so keeping them around is likely isn't useful.

Setting the git config shows up in the output of the config
```
netkan@74eb0d1b61dd:~/workspace/netkan$ git config gc.auto && git config gc.reflogExpire && git config gc.worktreePruneExpire && git config gc.reflogExpireUnreachable && git config gc.worktreePruneExpire && git config gc.pruneExpire
2700
1
now
now
now
now
```

## Extra
I've added some tests to check that the client is reading these values:
```
netkan@74eb0d1b61dd:~/workspace/netkan$ python -m unittest -v tests.repos.TestRepoConfig
test_gc_auto (tests.repos.TestRepoConfig) ... ok
test_gc_prune_expire (tests.repos.TestRepoConfig) ... ok
test_gc_reflog_expire (tests.repos.TestRepoConfig) ... ok
test_gc_reflog_expire_unreachable (tests.repos.TestRepoConfig) ... ok
test_gc_worktreePruneExpire (tests.repos.TestRepoConfig) ... ok

----------------------------------------------------------------------
Ran 5 tests in 0.113s

OK
```
It is possible that gc isn't being called, but checking at various times the loose item count is < 6700 (the default value) which indicates it likely is.