### PR TITLE
Increase Instance Memory

### DIFF
--- a/netkan/netkan/indexer.py
+++ b/netkan/netkan/indexer.py
@@ -126,11 +126,8 @@ class CkanMessage:
             elif (getattr(status, 'last_warnings', None) != self.WarningMessages and self.WarningMessages is not None):
                 logging.error('New inflation warnings for %s: %s',
                               self.ModIdentifier, self.WarningMessages)
-            actions = [
-                getattr(ModStatus, key).set(
-                    attrs[key]
-                ) for key in attrs
-            ]
+            actions = [getattr(ModStatus, key).set(val)
+                       for key, val in attrs.items()]
             status.update(actions=actions)
         except ModStatus.DoesNotExist:
             ModStatus(**self.status_attrs(True)).save()

--- a/netkan/setup.py
+++ b/netkan/setup.py
@@ -44,6 +44,12 @@ setup(
             'pytest-pylint',
             'pylint',
             'pytest-flake8',
+            'types-python-dateutil',
+            'types-click',
+            'types-requests',
+            'types-Flask',
+            'types-Jinja2',
+            'types-PyYAML',
         ],
         'test': [
             'pytest',

--- a/prod-stack.py
+++ b/prod-stack.py
@@ -628,8 +628,8 @@ docker_service = InitService(
 netkan_instance = Instance(
     'NetKANCompute',
     # ECS Optimised us-west-2
-    ImageId='ami-0e434a58221275ed4',
-    InstanceType='t3.micro',
+    ImageId='ami-064803387adcb64b3',
+    InstanceType='t3.small',
     IamInstanceProfile=Ref(netkan_profile),
     KeyName='techman83_alucard',
     SecurityGroups=['ckan-bot'],
@@ -681,7 +681,7 @@ services = [
     {
         'name': 'Indexer',
         'command': 'indexer',
-        'memory': '156',
+        'memory': '256',
         'secrets': [
             'SSH_KEY', 'GH_Token',
         ],
@@ -743,7 +743,7 @@ services = [
     {
         'name': 'Inflator',
         'image': 'kspckan/inflator',
-        'memory': '156',
+        'memory': '256',
         'secrets': ['GH_Token'],
         'env': [
             (
@@ -833,7 +833,7 @@ services = [
             {
                 'name': 'webhooks',
                 'entrypoint': '.local/bin/gunicorn',
-                'memory': '128',
+                'memory': '256',
                 'command': [
                     '-b', '0.0.0.0:5000', '--access-logfile', '-',
                     '--preload', 'netkan.webhooks:create_app()'
@@ -919,7 +919,7 @@ for service in services:
         linux_parameters = container.get('linux_parameters')
         definition = ContainerDefinition(
             Image=container.get('image', 'kspckan/netkan'),
-            Memory=container.get('memory', '96'),
+            Memory=container.get('memory', '128'),
             Name=container['name'],
             Secrets=[
                 Secret(


### PR DESCRIPTION
This is an informative PR as the changes have been applied.

## Problem
With the extra tasks and the growth of the repos, we've started bumping up against the limits of running the service in a single micro.

## Solution
Long term it would be interesting to see if pygit2 was more efficient than gitpython, as it has come a long way since the service was written. In the short term with the testing improvements we did terminate a t2.small, so we have room to go from a t3.micro -> t3.small. I also updated the AMI to the latest available.

Tasks performed (extra to the changes in this pr):
- Created a changeset via aws cli 
  ```
  aws cloudformation create-change-set --stack-name NetKANBot --template-body "`python3 prod-stack.py`" --capabilities 
  CAPABILITY_IAM --profile ckan --region us-west-2 --change-set-name NetkanBot-`date +%s`
  ```
- Instance failed to start the ecs service, shelled in and rebooted it manually so that cloudformation would continue (not sure why)
- Forced a run of the Certbot task to provision the ssl certificate
  ```
   aws ecs run-task --cluster NetKANCluster --task-definition NetKANBotCertBot --profile ckan --region us-west-2
   ```
- Kicked off a inflator schedule for testing
   ```
   aws ecs run-task --cluster NetKANCluster --task-definition NetKANBotScheduler --profile ckan --region us-west-2
   ```
## Results
More memory!
```
              total        used        free      shared  buff/cache   available
Mem:           1954         608          96           0        1249        1204
Swap:             0           0           0
Total:         1954         608          96
```
