### PR TITLE
Batch metanetkan download counts

### DIFF
--- a/netkan/netkan/metadata.py
+++ b/netkan/netkan/metadata.py
@@ -35,6 +35,12 @@ class Netkan:
             self.kref_src = None
             self.kref_id = None
 
+    def __repr__(self) -> str:
+        try:
+            return f'<{self.__class__.__name__}({self.identifier})>'
+        except AttributeError:
+            return f'<{self.__class__.__name__}(identifier undefined)>'
+
     def __getattr__(self, name: str) -> Any:
         # Return kref host, ie `self.on_spacedock`. Current krefs include
         # github, spacedock, curse and netkan.
@@ -269,6 +275,12 @@ class Ckan:
         elif contents:
             self.contents = contents
         self._raw = json.loads(self.contents, object_hook=self._custom_parser)
+
+    def __repr__(self) -> str:
+        try:
+            return f'<{self.__class__.__name__}({self.identifier}, {self.version})>'
+        except AttributeError:
+            return f'<{self.__class__.__name__}(identifier or version undefined)>'
 
     def _custom_parser(self, dct: Dict[str, Any]) -> Dict[str, Any]:
         # Special handling for DateTime fields

--- a/netkan/netkan/repos.py
+++ b/netkan/netkan/repos.py
@@ -15,6 +15,9 @@ class XkanRepo:
     def __init__(self, git_repo: Repo) -> None:
         self.git_repo = git_repo
 
+    def __repr__(self) -> str:
+        return f'<{self.__class__.__name__}({self.git_repo.__repr__()})>'
+
     def commit(self, files: List[Union[str, Path]], commit_message: str) -> Commit:
         index = self.git_repo.index
         index.add([x.as_posix() if isinstance(x, Path) else x for x in files])
@@ -155,5 +158,5 @@ class CkanMetaRepo(XkanRepo):
         return (Ckan(f) for f in self.mod_path(identifier).glob(self.CKANMETA_GLOB))
 
     def highest_version(self, identifier: str) -> Optional[Ckan.Version]:
-        highest = max(self.ckans(identifier), default=None, key=lambda ck: ck.version)  # type: ignore[type-var]
+        highest = max(self.ckans(identifier), default=None, key=lambda ck: ck.version)
         return highest.version if highest else None

--- a/netkan/netkan/spacedock_adder.py
+++ b/netkan/netkan/spacedock_adder.py
@@ -109,6 +109,6 @@ class SpaceDockAdder:
             'spec_version': 'v1.4',
             'identifier': re.sub(r'\W+', '', info.get('name', '')),
             '$kref': f"#/ckan/spacedock/{info.get('id', '')}",
-            'license': info.get('license', '').replace(' ', '-'),
+            'license': info.get('license', '').strip().replace(' ', '-'),
             'x_via': f"Automated {info.get('site_name')} CKAN submission"
         }

--- a/netkan/tests/download_counter.py
+++ b/netkan/tests/download_counter.py
@@ -60,7 +60,7 @@ class TestNetKANNetkanCounts(TestNetKANCounter):
 
     def test_remote_netkan(self):
         self.assertEqual(
-            self.netkan.remote_netkan,
+            self.netkan.kref_id,
             'http://ksp-ckan.space/netkan/DogeCoinFlag.netkan'
         )
 


### PR DESCRIPTION
## Problem

The bot barfed this up a little while ago:

```
Uncaught exception:
Traceback (most recent call last):
  File ".local/bin/netkan", line 8, in <module>
    sys.exit(netkan())
  File "/home/netkan/.local/lib/python3.7/site-packages/click/core.py", line 1137, in __call__
    return self.main(*args, **kwargs)
  File "/home/netkan/.local/lib/python3.7/site-packages/click/core.py", line 1062, in main
    rv = self.invoke(ctx)
  File "/home/netkan/.local/lib/python3.7/site-packages/click/core.py", line 1668, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/home/netkan/.local/lib/python3.7/site-packages/click/core.py", line 1404, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "/home/netkan/.local/lib/python3.7/site-packages/click/core.py", line 763, in invoke
    return __callback(*args, **kwargs)
  File "/home/netkan/.local/lib/python3.7/site-packages/click/decorators.py", line 84, in new_func
    return ctx.invoke(f, obj, *args, **kwargs)
  File "/home/netkan/.local/lib/python3.7/site-packages/click/core.py", line 763, in invoke
    return __callback(*args, **kwargs)
  File "/home/netkan/.local/lib/python3.7/site-packages/netkan/cli/utilities.py", line 48, in download_counter
    common.token
  File "/home/netkan/.local/lib/python3.7/site-packages/netkan/download_counter.py", line 249, in update_counts
    self.get_counts()
  File "/home/netkan/.local/lib/python3.7/site-packages/netkan/download_counter.py", line 227, in get_counts
    count = netkan_dl.get_count()
  File "/home/netkan/.local/lib/python3.7/site-packages/netkan/download_counter.py", line 89, in get_count
    count = getattr(self, f'count_from_{self.kref_src}')()
  File "/home/netkan/.local/lib/python3.7/site-packages/netkan/download_counter.py", line 81, in count_from_netkan
    contents=requests.get(self.remote_netkan).text
  File "/home/netkan/.local/lib/python3.7/site-packages/netkan/download_counter.py", line 21, in __init__
    super().__init__(filename, contents)
  File "/home/netkan/.local/lib/python3.7/site-packages/netkan/metadata.py", line 26, in __init__
    self._raw = yaml.safe_load(self.contents.replace('\t', '    '))
  File "/home/netkan/.local/lib/python3.7/site-packages/yaml/__init__.py", line 162, in safe_load
    return load(stream, SafeLoader)
  File "/home/netkan/.local/lib/python3.7/site-packages/yaml/__init__.py", line 112, in load
    loader = Loader(stream)
  File "/home/netkan/.local/lib/python3.7/site-packages/yaml/loader.py", line 34, in __init__
    Reader.__init__(self, stream)
  File "/home/netkan/.local/lib/python3.7/site-packages/yaml/reader.py", line 74, in __init__
    self.check_printable(stream)
  File "/home/netkan/.local/lib/python3.7/site-packages/yaml/reader.py", line 144, in check_printable
    'unicode', "special characters are not allowed")
yaml.reader.ReaderError: unacceptable character #x0080: special characters are not allowed
  in "<unicode string>", position 10842
```

It suggests that some metanetkan now contains Unicode 0x0080, the PAD character:

- https://www.compart.com/en/unicode/U+0080

I don't know how likely that is to be true, but it's hard to investigate without knowing which mod it is.

## Cause

JSON parsing errors are caught and logged but YAML parsing errors are not.

## Motivation

While investigating the above, I realized (or remembered?) that any metanetkan with a GitHub kref will be handled individually, whereas all other GitHub krefs are processed in batches via GraphQL (see #185). There are ~~at least~~ 68 such mods (~~maybe more if some of the 13 `None`s in my command line output were due to rate limiting without a token~~—these were metanetkans with hard coded `download` properties), which would constitute about 1.4 batches, so this means the download counter currently performs 66 more network requests than strictly needed, with minor excess costs imposed on the container and API rate limiting allowances.

## Changes

- The download counter's error logging is improved:
  - YAML parsing errors are caught and pretty-printed
  - All messages now start with `DownloadCounter`
    - Messages about metanetkans start with `DownloadCounter metanetkan`, to allow us to tell whether a problem happened while processing the main netkan or the metanetkan
  - All messages then print a brief message containing the identifier followed by the source exception
  - One mod with an exception can no longer derail the entire counting loop
- Metanetkans with GitHub krefs are included in the GraphQL batches. This is done via a new `DownloadCounts.resolve_meta()` function that returns the non-metanetkan corresponding to a netkan, either itself or retrieved from the network.

### Debuggability

You can run `python` from the command line and import our classes for interactive investigation. If you evaluate an expression that contains objects, the `__repr__` function is called to generate their string representations. Since we didn't define this for `Netkan` and `Ckan` or their child classes, the default representation of the long type name and memory address is used, which is not useful:

```
[<netkan.download_counter.NetkanDownloads object at 0x7fb10d042610>, <netkan.download_counter.NetkanDownloads object at 0x7fb10d04a490>, <netkan.download_counter.NetkanDownloads object at 0x7fb10d04a130>, ...
```

Now `__repr__` is defined for these classes as `classname(identifier)` or `classname(identifier, version)` depending on which class, so we can tell which mods are being processed. `self.__class__.__name__` is used so inherited classes will also benefit. A similar change is made for `XkanRepo` so we can tell where our repos live.

```
[<NetkanDownloads(AdvancedJetEngine)>, <NetkanDownloads(AlcubierreStandalone)>, <NetkanDownloads(AT-Utils)>, ...

<NetkanRepo(<git.repo.base.Repo '/home/user/Downloads/KSP/NetKAN/.git'>)>
```

### SpaceDock license formatting

We've had a few requests come in from SpaceDock recently with trailing `-` characters in the license. I think people are typing (or pasting) an extra space and we're substituting it. Now we trim excess whitespace from licenses.

- https://github.com/KSP-CKAN/NetKAN/pull/8639/commits/3496514ff821c65dc9fcafa6ca3ceb76ae934f20 (from KSP-CKAN/NetKAN#8639)
- https://github.com/KSP-CKAN/NetKAN/pull/8630/commits/0e516a426290368af48d7bb0dc8dbf87bc2dfa78 (from KSP-CKAN/NetKAN#8630)
