### PR TITLE
Count downloads without routine attribute errors

### DIFF
--- a/netkan/netkan/download_counter.py
+++ b/netkan/netkan/download_counter.py
@@ -97,10 +97,16 @@ class NetkanDownloads(Netkan):
         return self
 
     def get_count(self) -> int:
-        count = 0
         if self.has_kref:
             try:
-                count = getattr(self, f'count_from_{self.kref_src}')()
+                if self.kref_src == 'github':
+                    return self.count_from_github()
+                if self.kref_src == 'spacedock':
+                    return self.count_from_spacedock()
+                if self.kref_src == 'curse':
+                    return self.count_from_curse()
+                if self.kref_src == 'netkan':
+                    return self.count_from_netkan()
             except JSONDecodeError as exc:
                 logging.error('DownloadCounter failed JSON parse for %s: %s',
                               self.identifier, exc)
@@ -116,7 +122,7 @@ class NetkanDownloads(Netkan):
             except Exception as exc:  # pylint: disable=broad-except
                 logging.error('DownloadCounter surprising error for %s: %s',
                               self.identifier, exc)
-        return count
+        return 0
 
 
 class GraphQLQuery:


### PR DESCRIPTION
## Problem

Since #225 these errors are logged to the Discord each time the download counter runs:

![image](https://user-images.githubusercontent.com/1559108/126049670-8784c4e2-fc27-42cb-8be2-f6545863434f.png)

## Cause

To dispatch based on the kref, we build a string, then retrieve the function by that name from `self` and call it:

https://github.com/KSP-CKAN/NetKAN-Infra/blob/8220909ea3c2437c4c685e8651db614d30b3d951/netkan/netkan/download_counter.py#L103

When the above exceptions are raised, we are trying to call `self.count_from_jenkins()` and `self.count_from_http()`, and since neither of these exist, `AttributeError` is thrown.

Prior to #225, `AttributeError` was handled with `logging.info` instead of `logging.error` (and so effectively ignored since only errors are sent to Discord). The problem with this is a problem exceptions often have: If some _other_ code raises `AttributeError` rather than the place from which we expect it to come, then it will be mishandled. (We definitely want to know about it if a coding error causes an `AttributeError` to be thrown by some other spot!)

This highlights a coding style problem: Exceptions should be _exceptional_, in other words unusual conditions that disrupt the normal functioning of the code. The current approach treats them as part of the routine code flow, in that they will always be thrown and handled several times as part of this dispatching mechanism when the download counter runs.

There's another coding practice problem: Since the name of the function we're calling isn't available until runtime, our static analysis tools (mypy, etc.) can't perform type safety and other checks here. Not only do we not know whether the functions we try to call _exist_, we also don't know **that they are functions**, that they can be called without parameters, that they return `int`, etc. Currently they do happen to be functions with no required parameters that return integers, but if some future code change violated that assumption, our tools would not catch it.

## Changes

Now we inspect the kref with simple `if` statements and call the corresponding functions. For jenkins and http krefs, `get_count` now returns 0 without throwing or handling exceptions; nothing will be logged because this is expected and routine. Otherwise the behavior is exactly the same as before.

### Considered and not done

In previous comments I said:

> Or maybe we need to make kref-specific child classes of `NetkanDownloads` (like `GitHubDownloads`, `SpaceDockDownloads`, etc.) that override `get_count`, and then a factory method that generates the right type of object based on the kref. That's probably the right way of representing the kind of behavior that we're trying to achieve here.

I started a branch for this, but the changes are absolutely enormous (almost every line of the file is changed) for the tiny degree of functional change involved. I also felt that the factory method with child classes obscure rather than illuminate what the code is doing: branching to a few well known functions based on a string. The more naïve approach in this pull request makes that absolutely plain as day.