### PR TITLE
Include source link in SpaceDock add PRs

### DIFF
--- a/netkan/mypy.ini
+++ b/netkan/mypy.ini
@@ -4,7 +4,6 @@ warn_redundant_casts = true
 show_error_context = true
 show_column_numbers = true
 show_error_codes = true
-pretty = true
 
 # Don't increase strictness for tests
 [mypy-netkan.*]

--- a/netkan/netkan/cli/utilities.py
+++ b/netkan/netkan/cli/utilities.py
@@ -64,8 +64,7 @@ def download_counter(common: SharedArgs) -> None:
     help='Dump status to S3 every `interval` seconds',
 )
 def export_status_s3(status_bucket: str, status_key: str, interval: bool) -> None:
-    frequency = 'every {} seconds'.format(
-        interval) if interval else 'once'
+    frequency = f'every {interval} seconds' if interval else 'once'
     logging.info('Exporting to s3://%s/%s %s',
                  status_bucket, status_key, frequency)
     while True:
@@ -107,7 +106,7 @@ def recover_status_timestamps(common: SharedArgs) -> None:
 )
 def redeploy_service(cluster: str, service_name: str) -> None:
     click.secho(
-        'Forcing redeployment of {}:{}'.format(cluster, service_name),
+        f'Forcing redeployment of {cluster}:{service_name}',
         fg='green'
     )
     client = boto3.client('ecs')
@@ -120,8 +119,7 @@ def redeploy_service(cluster: str, service_name: str) -> None:
             [f.split('/')[1].split('-')[1] for f in services]
         )
         raise click.UsageError(
-            "Service '{}' not found. Available services:\n    - {}".format(
-                service_name, available)
+            f"Service '{service_name}' not found. Available services:\n    - {available}"
         ) from exc
     client.update_service(
         cluster=cluster,
@@ -161,12 +159,10 @@ def clean_cache(days: int, cache: str) -> None:
     older_than = (
         datetime.datetime.now() - datetime.timedelta(days=int(days))
     ).timestamp()
-    click.echo('Checking cache for files older than {} days'.format(days))
+    click.echo(f'Checking cache for files older than {days} days')
     for item in Path(cache).glob('*'):
         if item.is_file() and item.stat().st_mtime < older_than:
-            click.echo('Purging {} from ckan cache'.format(
-                item.name
-            ))
+            click.echo(f'Purging {item.name} from ckan cache')
             item.unlink()
 
 

--- a/netkan/netkan/download_counter.py
+++ b/netkan/netkan/download_counter.py
@@ -262,7 +262,8 @@ class DownloadCounter:
 
     def write_json(self) -> None:
         self.output_file.write_text(
-            json.dumps(self.counts, sort_keys=True, indent=4)
+            json.dumps(self.counts, sort_keys=True, indent=4),
+            encoding='UTF-8'
         )
 
     def commit_counts(self) -> None:

--- a/netkan/netkan/github_pr.py
+++ b/netkan/netkan/github_pr.py
@@ -14,7 +14,7 @@ class GitHubPR:
 
     def create_pull_request(self, title: str, branch: str, body: str) -> None:
         headers = {
-            'Authorization': 'token {}'.format(self.token),
+            'Authorization': f'token {self.token}',
             'Content-Type': 'application/json'
         }
         data = {
@@ -24,9 +24,7 @@ class GitHubPR:
             'body': body,
         }
         response = requests.post(
-            'https://api.github.com/repos/{}/{}/pulls'.format(
-                self.user, self.repo
-            ),
+            f'https://api.github.com/repos/{self.user}/{self.repo}/pulls',
             headers=headers,
             data=json.dumps(data),
         )

--- a/netkan/netkan/indexer.py
+++ b/netkan/netkan/indexer.py
@@ -8,7 +8,7 @@ from types import TracebackType
 
 import boto3  # pylint: disable=unused-import
 from dateutil.parser import parse
-from git import Commit
+from git.objects.commit import Commit
 
 from .metadata import Ckan
 from .repos import CkanMetaRepo

--- a/netkan/netkan/indexer.py
+++ b/netkan/netkan/indexer.py
@@ -33,7 +33,7 @@ class CkanMessage:
         # pylint: enable=invalid-name
         self.indexed = False
         for item in msg.message_attributes.items():
-            attr_type = '{}Value'.format(item[1]['DataType'])
+            attr_type = f'{item[1]["DataType"]}Value'
             content = item[1][attr_type]
             if content.lower() in ['true', 'false']:
                 content = (content.lower() == 'true')
@@ -47,7 +47,7 @@ class CkanMessage:
         self.github_pr = github_pr
 
     def __str__(self) -> str:
-        return '{}: {}'.format(self.ModIdentifier, self.CheckTime)
+        return f'{self.ModIdentifier}: {self.CheckTime}'
 
     @property
     def mod_path(self) -> Path:
@@ -74,7 +74,7 @@ class CkanMessage:
 
     def write_metadata(self) -> None:
         self.mod_path.mkdir(exist_ok=True)
-        with open(self.mod_file, mode='w') as file:
+        with open(self.mod_file, mode='w', encoding='UTF-8') as file:
             file.write(self.body)
 
     def commit_metadata(self, file_created: bool) -> Commit:

--- a/netkan/netkan/metadata.py
+++ b/netkan/netkan/metadata.py
@@ -19,7 +19,7 @@ class Netkan:
     def __init__(self, filename: Union[str, Path] = None, contents: str = None) -> None:
         if filename:
             self.filename = Path(filename)
-            self.contents = self.filename.read_text()
+            self.contents = self.filename.read_text(encoding='UTF-8')
         elif contents:
             self.contents = contents
         # YAML parser doesn't allow tabs, so replace with spaces
@@ -271,7 +271,7 @@ class Ckan:
     def __init__(self, filename: Union[str, Path] = None, contents: str = None) -> None:
         if filename:
             self.filename = Path(filename)
-            self.contents = self.filename.read_text()
+            self.contents = self.filename.read_text(encoding='UTF-8')
         elif contents:
             self.contents = contents
         self._raw = json.loads(self.contents, object_hook=self._custom_parser)
@@ -325,12 +325,7 @@ class Ckan:
             return None
         if not self.version:
             return None
-        return '{}-{}-{}.{}'.format(
-            self.cache_prefix,
-            self.identifier,
-            self.version.string.replace(':', '-'),
-            self.MIME_TO_EXTENSION[self.download_content_type],
-        )
+        return f'{self.cache_prefix}-{self.identifier}-{self.version.string.replace(":", "-")}.{self.MIME_TO_EXTENSION[self.download_content_type]}'
 
     def source_download(self, branch: str = 'master') -> Optional[str]:
         # self?.resources?.repository

--- a/netkan/netkan/mirrorer.py
+++ b/netkan/netkan/mirrorer.py
@@ -166,32 +166,18 @@ class CkanMirror(Ckan):
         return False
 
     def mirror_item(self, with_epoch: bool = True) -> str:
-        return '{}-{}'.format(
-            self.identifier,
-            self._format_version(with_epoch)
-        )
+        return f'{self.identifier}-{self._format_version(with_epoch)}'
 
     def mirror_filename(self, with_epoch: bool = True) -> Optional[str]:
         if 'download_hash' not in self._raw:
             return None
-        return '{}-{}-{}.{}'.format(
-            self.download_hash['sha1'][0:8],
-            self.identifier,
-            self._format_version(with_epoch),
-            Ckan.MIME_TO_EXTENSION[self.download_content_type],
-        )
+        return f'{self.download_hash["sha1"][0:8]}-{self.identifier}-{self._format_version(with_epoch)}.{Ckan.MIME_TO_EXTENSION[self.download_content_type]}'
 
     def mirror_source_filename(self, with_epoch: bool = True) -> str:
-        return '{}-{}.source.zip'.format(
-            self.identifier,
-            self._format_version(with_epoch)
-        )
+        return f'{self.identifier}-{self._format_version(with_epoch)}.source.zip'
 
     def mirror_title(self, with_epoch: bool = True) -> str:
-        return '{} - {}'.format(
-            self.name,
-            self._format_version(with_epoch),
-        )
+        return f'{self.name} - {self._format_version(with_epoch)}'
 
     @property
     def item_metadata(self) -> Dict[str, Any]:

--- a/netkan/netkan/mirrorer.py
+++ b/netkan/netkan/mirrorer.py
@@ -294,32 +294,33 @@ class Mirrorer:
 
     def process_queue(self, queue_name: str, timeout: int) -> None:
         queue = boto3.resource('sqs').get_queue_by_name(QueueName=queue_name)
-        while True:
-            messages = queue.receive_messages(
-                MaxNumberOfMessages=10,
-                MessageAttributeNames=['All'],
-                VisibilityTimeout=timeout,
-            )
-            if messages:
-                # Check if archive.org is overloaded
-                if self.ia_overloaded():
-                    logging.info('The Internet Archive is overloaded, try again later')
-                    continue
-                # Get up to date copy of the metadata for the files we're mirroring
-                logging.info('Updating repo')
-                self.ckm_repo.git_repo.heads.master.checkout()
-                self.ckm_repo.git_repo.remotes.origin.pull('master', strategy_option='theirs')
-                # Start processing the messages
-                to_delete = []
-                for msg in messages:
-                    path = Path(self.ckm_repo.git_repo.working_dir, msg.body)
-                    if self.try_mirror(CkanMirror(self.ia_collection, path)):
-                        # Successfully handled -> OK to delete
-                        to_delete.append(deletion_msg(msg))
-                if to_delete:
-                    queue.delete_messages(Entries=to_delete)
-                # Clean up GitPython's lingering file handles between batches
-                self.ckm_repo.git_repo.close()
+        if self.ckm_repo.git_repo.working_dir:
+            while True:
+                messages = queue.receive_messages(
+                    MaxNumberOfMessages=10,
+                    MessageAttributeNames=['All'],
+                    VisibilityTimeout=timeout,
+                )
+                if messages:
+                    # Check if archive.org is overloaded
+                    if self.ia_overloaded():
+                        logging.info('The Internet Archive is overloaded, try again later')
+                        continue
+                    # Get up to date copy of the metadata for the files we're mirroring
+                    logging.info('Updating repo')
+                    self.ckm_repo.git_repo.heads.master.checkout()
+                    self.ckm_repo.git_repo.remotes.origin.pull('master', strategy_option='theirs')
+                    # Start processing the messages
+                    to_delete = []
+                    for msg in messages:
+                        path = Path(self.ckm_repo.git_repo.working_dir, msg.body)
+                        if self.try_mirror(CkanMirror(self.ia_collection, path)):
+                            # Successfully handled -> OK to delete
+                            to_delete.append(deletion_msg(msg))
+                    if to_delete:
+                        queue.delete_messages(Entries=to_delete)
+                    # Clean up GitPython's lingering file handles between batches
+                    self.ckm_repo.git_repo.close()
 
     def try_mirror(self, ckan: CkanMirror) -> bool:
         if not ckan.can_mirror:

--- a/netkan/netkan/pr_body_template.txt
+++ b/netkan/netkan/pr_body_template.txt
@@ -8,5 +8,6 @@ Mod details:
     Abstract = $short_description
     License = $license
     Homepage = $external_link
+    Source code = $source_link
     Description =
 $description

--- a/netkan/netkan/repos.py
+++ b/netkan/netkan/repos.py
@@ -2,7 +2,8 @@ from contextlib import contextmanager
 from pathlib import Path
 from typing import Iterable, List, Optional, Generator, Union
 
-from git import Repo, Commit, GitCommandError
+from git import Repo, GitCommandError
+from git.objects.commit import Commit
 from .metadata import Netkan, Ckan
 
 
@@ -116,7 +117,8 @@ class NetkanRepo(XkanRepo):
 
     @property
     def nk_dir(self) -> Path:
-        return Path(self.git_repo.working_dir, self.NETKAN_DIR)
+        return (Path(self.git_repo.working_dir, self.NETKAN_DIR)
+                if self.git_repo.working_dir else Path(self.NETKAN_DIR))
 
     def nk_path(self, identifier: str) -> Path:
         return self.nk_dir.joinpath(f'{identifier}.{self.UNFROZEN_SUFFIX}')
@@ -149,7 +151,8 @@ class CkanMetaRepo(XkanRepo):
 
     @property
     def ckm_dir(self) -> Path:
-        return Path(self.git_repo.working_dir)
+        return (Path(self.git_repo.working_dir)
+                if self.git_repo.working_dir else Path('.'))
 
     def mod_path(self, identifier: str) -> Path:
         return self.ckm_dir.joinpath(identifier)

--- a/netkan/netkan/status.py
+++ b/netkan/netkan/status.py
@@ -90,11 +90,11 @@ class ModStatus(Model):
     # this operation once to seed the existing history.
     @classmethod
     def restore_status(cls, filename: str) -> None:
-        existing = json.loads(Path(filename).read_text())
+        existing = json.loads(Path(filename).read_text(encoding='UTF-8'))
         with cls.batch_write() as batch:
             for key, item in existing.items():
                 for item_key in ['checked', 'indexed', 'inflated']:
-                    update_key = 'last_{}'.format(item_key)
+                    update_key = f'last_{item_key}'
                     if not item[update_key]:
                         continue
                     item[update_key] = parse(

--- a/netkan/netkan/utils.py
+++ b/netkan/netkan/utils.py
@@ -28,12 +28,12 @@ def init_ssh(key: str, key_path: Path) -> None:
     key_path.mkdir(exist_ok=True)
     key_file = Path(key_path, 'id_rsa')
     if not key_file.exists():
-        key_file.write_text('{}\n'.format(key))
+        key_file.write_text(f'{key}\n', encoding='UTF-8')
         key_file.chmod(0o400)
         scan = subprocess.run([
             'ssh-keyscan', '-t', 'rsa', 'github.com'
         ], stdout=subprocess.PIPE, check=False)
-        Path(key_path, 'known_hosts').write_text(scan.stdout.decode('utf-8'))
+        Path(key_path, 'known_hosts').write_text(scan.stdout.decode('utf-8'), encoding='UTF-8')
 
 
 def repo_file_add_or_changed(repo: Repo, filename: Union[str, Path]) -> bool:

--- a/netkan/netkan/webhooks/inflate.py
+++ b/netkan/netkan/webhooks/inflate.py
@@ -13,20 +13,21 @@ inflate = Blueprint('inflate', __name__)  # pylint: disable=invalid-name
 # Payload: { "identifiers": [ "Id1", "Id2", ... ] }
 @inflate.route('/inflate', methods=['POST'])
 def inflate_hook() -> Tuple[str, int]:
-    # SpaceDock doesn't set the `Content-Type: application/json` header
-    raw = request.get_json(force=True)
-    ids = raw.get('identifiers')  # type: ignore[union-attr]
-    if not ids:
-        current_app.logger.info('No identifiers received')
-        return 'An array of identifiers is required', 400
-    # Make sure our NetKAN and CKAN-meta repos are up to date
-    pull_all(current_config.repos)
-    messages = (nk.sqs_message(current_config.ckm_repo.highest_version(nk.identifier))
-                for nk in netkans(current_config.nk_repo.git_repo.working_dir, ids))
-    for batch in sqs_batch_entries(messages):
-        current_app.logger.info(f'Queueing inflation request batch: {batch}')
-        current_config.client.send_message_batch(
-            QueueUrl=current_config.inflation_queue.url,
-            Entries=batch
-        )
+    if current_config.nk_repo.git_repo.working_dir:
+        # SpaceDock doesn't set the `Content-Type: application/json` header
+        raw = request.get_json(force=True)
+        ids = raw.get('identifiers')  # type: ignore[union-attr]
+        if not ids:
+            current_app.logger.info('No identifiers received')
+            return 'An array of identifiers is required', 400
+        # Make sure our NetKAN and CKAN-meta repos are up to date
+        pull_all(current_config.repos)
+        messages = (nk.sqs_message(current_config.ckm_repo.highest_version(nk.identifier))
+                    for nk in netkans(str(current_config.nk_repo.git_repo.working_dir), ids))
+        for batch in sqs_batch_entries(messages):
+            current_app.logger.info(f'Queueing inflation request batch: {batch}')
+            current_config.client.send_message_batch(
+                QueueUrl=current_config.inflation_queue.url,
+                Entries=batch
+            )
     return '', 204

--- a/netkan/netkan/webhooks/spacedock_add.py
+++ b/netkan/netkan/webhooks/spacedock_add.py
@@ -20,6 +20,7 @@ spacedock_add = Blueprint('spacedock_add', __name__)  # pylint: disable=invalid-
 #     short_description: A mod that you should definitely install
 #     description:       A mod that you should definitely install, and so on and so on
 #     external_link:     https://forum.kerbalspaceprogram.com/index.php?/topic/999999-ThreadTitle
+#     source_link:       https://github.com/user/repo
 #     user_url:          https://spacedock.info/profile/ModAuthor1
 #     mod_url:           https://spacedock.info/mod/12345
 #     site_name:         SpaceDock

--- a/netkan/tests/utils.py
+++ b/netkan/tests/utils.py
@@ -38,7 +38,7 @@ class TestNetKANUtilsRepoFileAddOrChange(unittest.TestCase):
 
     def test_changes(self):
         existing = Path(self.working, 'existing.txt')
-        existing.write_text('I made a change')
+        existing.write_text('I made a change', encoding='UTF-8')
         self.assertTrue(repo_file_add_or_changed(self.repo, existing))
 
     def test_new_nested(self):
@@ -48,5 +48,5 @@ class TestNetKANUtilsRepoFileAddOrChange(unittest.TestCase):
 
     def test_changes_nested(self):
         existing = Path(self.nested, 'existing_nested.txt')
-        existing.write_text('text')
+        existing.write_text('text', encoding='UTF-8')
         self.assertTrue(repo_file_add_or_changed(self.repo, existing))


### PR DESCRIPTION
## Motivation

See KSP-SpaceDock/SpaceDock#393, let's add the source code link to the PRs that add new mods from SpaceDock.

## Changes

Now the PR body template has a new line that contains `$source_link`, which will be available after KSP-SpaceDock/SpaceDock#393 is merged.

That required no code changes, but our testing apparatus reported a bunch of new errors and warnings anyway, so I added code changes to fix them. `mypy`'s standards or the type signatures of the various Python libraries or both seem to be in constant flux.