### PR TITLE
Standardize branch names, set pull request labels

### DIFF
--- a/netkan/netkan/auto_freezer.py
+++ b/netkan/netkan/auto_freezer.py
@@ -12,7 +12,7 @@ class AutoFreezer:
 
     BRANCH_NAME = 'freeze/auto'
 
-    def __init__(self, nk_repo: NetkanRepo, github_pr: GitHubPR = None) -> None:
+    def __init__(self, nk_repo: NetkanRepo, github_pr: GitHubPR) -> None:
         self.nk_repo = nk_repo
         self.github_pr = github_pr
 
@@ -63,6 +63,7 @@ class AutoFreezer:
             dttm = self._last_timestamp(ident)
             if dttm and too_old_cutoff < dttm < update_cutoff:
                 idle_mods.append((ident, dttm))
+        idle_mods.sort(key=lambda mod: mod[1])
         return idle_mods
 
     @staticmethod
@@ -81,7 +82,6 @@ class AutoFreezer:
 
     @staticmethod
     def _mod_table(idle_mods: List[Tuple[str, datetime]]) -> str:
-        idle_mods.sort(key=lambda mod: mod[1])
         return '\n'.join([
             'Mod | Last Update',
             ':-- | :--',
@@ -100,4 +100,5 @@ class AutoFreezer:
                       ' Freeze them to save the bot some CPU cycles.'
                       '\n\n'
                       f'{self._mod_table(idle_mods)}'),
+                labels=['Pull request', 'Freeze', 'Needs looking into'],
             )

--- a/netkan/netkan/github_pr.py
+++ b/netkan/netkan/github_pr.py
@@ -1,5 +1,6 @@
 import json
 import logging
+from typing import Optional, List
 import requests
 
 
@@ -12,21 +13,20 @@ class GitHubPR:
         self.repo = repo
         self.user = user
 
-    def create_pull_request(self, title: str, branch: str, body: str) -> None:
-        headers = {
-            'Authorization': f'token {self.token}',
-            'Content-Type': 'application/json'
-        }
-        data = {
-            'title': title,
-            'base': 'master',
-            'head': branch,
-            'body': body,
-        }
+    def create_pull_request(self, title: str, branch: str, body: str, labels: Optional[List[str]] = None) -> None:
         response = requests.post(
             f'https://api.github.com/repos/{self.user}/{self.repo}/pulls',
-            headers=headers,
-            data=json.dumps(data),
+            headers={
+                'Authorization': f'token {self.token}',
+                'Content-Type': 'application/json'
+            },
+            data=json.dumps({
+                'title': title,
+                'base': 'master',
+                'head': branch,
+                'body': body,
+                'labels': labels or [],
+            }),
         )
         if response.status_code not in [200, 201, 204]:
             error = ''

--- a/netkan/netkan/spacedock_adder.py
+++ b/netkan/netkan/spacedock_adder.py
@@ -58,7 +58,7 @@ class SpaceDockAdder:
             return True
 
         # Create branch
-        branch_name = f"add-{netkan.get('identifier')}"
+        branch_name = f"add/{netkan.get('identifier')}"
         try:
             self.nk_repo.git_repo.remotes.origin.fetch(branch_name)
         except git.GitCommandError:
@@ -99,7 +99,8 @@ class SpaceDockAdder:
             self.github_pr.create_pull_request(
                 title=f"Add {info.get('name')} from {info.get('site_name')}",
                 branch=branch_name,
-                body=self.PR_BODY_TEMPLATE.safe_substitute(defaultdict(lambda: '', info))
+                body=self.PR_BODY_TEMPLATE.safe_substitute(defaultdict(lambda: '', info)),
+                labels=['Pull request', 'Mod-request'],
             )
         return True
 

--- a/netkan/tests/auto_freezer.py
+++ b/netkan/tests/auto_freezer.py
@@ -86,6 +86,7 @@ class TestAutoFreezer(unittest.TestCase):
             self.assertEqual(pr_mock.return_value.create_pull_request.mock_calls, [
                 call(branch='test_branch_name',
                      title='Freeze idle mods',
-                     body='The attached mods have not updated in 69 or more days. Freeze them to save the bot some CPU cycles.\n\nMod | Last Update\n:-- | :--\nAstrogator | 2010-01-01 00:00 UTC\nSmartTank | 2015-01-01 00:00 UTC\nRingworld | 2020-01-01 00:00 UTC'
+                     body='The attached mods have not updated in 69 or more days. Freeze them to save the bot some CPU cycles.\n\nMod | Last Update\n:-- | :--\nAstrogator | 2010-01-01 00:00 UTC\nSmartTank | 2015-01-01 00:00 UTC\nRingworld | 2020-01-01 00:00 UTC',
+                     labels=['Pull request', 'Freeze', 'Needs looking into'],
                 )
             ])


### PR DESCRIPTION
## Motivation

- Branch names generated by the bot are inconsistent
  - Auto Freezer: `freeze/auto`
  - SpaceDock Adder: `add-identifier`
  - Indexer: `identifier-version`
- Pull requests submitted by the bot currently have no labels
- It was inconvenient that the Auto Freezer's commits were in alphabetical order while its pull request body listed the mods in chronological order

## Changes

- Now the branch names are consistent
  - Auto Freezer: `freeze/auto`
  - SpaceDock Adder: `add/identifier`
  - Indexer: `add/identifier-version`
- Now pull requests have labels
  - Auto Freezer: `Pull request`, `Freeze`, `Needs looking into`
  - SpaceDock Adder: `Pull request`, `Mod request`
  - Indexer: `Needs looking into`
- Now the Auto Freezer's commits and pull request body are both in chronological order