### PR TITLE
Set pull request labels in separate API request

### DIFF
--- a/netkan/netkan/github_pr.py
+++ b/netkan/netkan/github_pr.py
@@ -25,7 +25,6 @@ class GitHubPR:
                 'base': 'master',
                 'head': branch,
                 'body': body,
-                'labels': labels or [],
             }),
         )
         if response.status_code not in [200, 201, 204]:
@@ -41,3 +40,15 @@ class GitHubPR:
         pr_json = response.json()
         logging.info('PR for %s opened at %s',
                      branch, pr_json['html_url'])
+        if labels:
+            # Labels have to be set separately via the issues API
+            requests.post(
+                f'https://api.github.com/repos/{self.user}/{self.repo}/issues/{pr_json["number"]}/labels',
+                headers={
+                    'Authorization': f'token {self.token}',
+                    'Content-Type': 'application/json'
+                },
+                data=json.dumps({
+                    'labels': labels
+                })
+            )


### PR DESCRIPTION
## Problem

The label part of #230 hasn't worked; pull requests submitted subsequently have had no labels.

## Cause

The pull request API accepts a fragment of a pull request object including the title, body, etc., but the `labels` property is missing:

- https://docs.github.com/en/rest/reference/pulls#create-a-pull-request

But at a database level, a pull request is implemented as a special type of issue, and labels can be set at issue creation:

- https://docs.github.com/en/rest/reference/issues#create-an-issue

Surely this is also possible for pull requests, and they just forgot to include it in the documentation?

No:  https://github.community/t/create-pull-request-and-add-labels-in-a-single-request/116146

## Changes

Now if you pass labels to a PR creation call, we make a second API call to set them.

I am planning to self-review and merge this so I can see whether it works the next time we have a PR from the bot.
