### PR TITLE
Try to report GraphQL errors to Discord

### DIFF
--- a/netkan/netkan/download_counter.py
+++ b/netkan/netkan/download_counter.py
@@ -196,12 +196,17 @@ class GraphQLQuery:
             counts = {}
         full_query = self.get_query()
         result = self.graphql_to_github(full_query)
-        for fake_ident, apidata in result['data'].items():
-            if apidata:
-                real_ident = self.from_graphql_safe_identifier(fake_ident)
-                count = self.sum_graphql_result(apidata)
-                logging.info('Count for %s is %s', real_ident, count)
-                counts[real_ident] = count
+        if 'errors' in result:
+            logging.error('DownloadCounter GraphQL query failed: %s',
+                ', '.join(err['message'] for err in result['errors'])
+                if result['errors'] else 'Empty errors list')
+        else:
+            for fake_ident, apidata in result['data'].items():
+                if apidata:
+                    real_ident = self.from_graphql_safe_identifier(fake_ident)
+                    count = self.sum_graphql_result(apidata)
+                    logging.info('Count for %s is %s', real_ident, count)
+                    counts[real_ident] = count
         return counts
 
     def graphql_to_github(self, query: str) -> Dict[str, Any]:


### PR DESCRIPTION
## Problem

Every few days we see an error like this:

![image](https://user-images.githubusercontent.com/1559108/144248064-4accdca9-165e-4036-b72b-38deffff3991.png)

## Cause

The only `.items()` call is here:

https://github.com/KSP-CKAN/NetKAN-Infra/blob/243a96380688575c7838f5781ea2c9492759b345/netkan/netkan/download_counter.py#L198-L200

... which is trying to loop over the `data` property of the result. If `data` is a `NoneType`, then the response from GraphQL looked like this (ignore GitHub's buggy syntax coloring, `null` is a valid keyword in JSON):

```json
{
    "data": null,
    "more": "stuff??"
}
```

So maybe there is some other stuff in the response we can use to find out what's wrong. The GraphQL spec says:

http://spec.graphql.org/June2018/#sec-Data

> If an error was encountered during the execution that prevented a valid response, the data entry in the response should be null.

There's also a section on errors:

http://spec.graphql.org/June2018/#sec-Errors

> If the data entry in the response is present (including if it is the value null), the errors entry in the response may contain any errors that occurred during execution. If errors occurred during execution, it should contain those errors.

This leads me to believe there would be an `errors` property alongside a null `result`. It would contain a list of objects with `message` properties describing what went wrong.

## Changes

Now we check for an `errors` property in the result and send a message to Discord summarizing the messages if found. The `.items()` call is now inside an `else` after that because it won't work if there was an error anyway.

I'm planning to self-review this so we can see it in action next time this happens.