### PR TITLE
Analyze SD mod ZIPs for more properties in PRs

### DIFF
--- a/netkan/netkan/mod_analyzer.py
+++ b/netkan/netkan/mod_analyzer.py
@@ -1,0 +1,113 @@
+import re
+import tempfile
+from pathlib import Path
+from zipfile import ZipFile, is_zipfile
+from typing import Dict, Any
+import requests
+
+
+class ModAnalyzer:
+
+    USER_AGENT = 'Mozilla/5.0 (compatible; Netkanbot/1.0; CKAN; +https://github.com/KSP-CKAN/NetKAN-Infra'
+    MM_PATTERN = re.compile(r'^\s*[@+$\-!%]|^\s*[a-zA-Z0-9_]+:',
+                            re.MULTILINE)
+    PARTS_PATTERN = re.compile(r'^\s*PART\b',
+                               re.MULTILINE)
+
+    def __init__(self, ident: str, download_url: str) -> None:
+        self.ident = ident
+        self.download_file = tempfile.NamedTemporaryFile()
+        self.download_file.write(requests.get(
+            download_url,
+            headers={ 'User-Agent': self.USER_AGENT }
+        ).content)
+        self.download_file.flush()
+        self.zip = (ZipFile(self.download_file, 'r')
+                    if is_zipfile(self.download_file)
+                    else None)
+        # Dir entries are optional, so try to ignore them
+        self.files = ([] if not self.zip else
+                      [zi for zi in self.zip.infolist()
+                       if not zi.is_dir()])
+
+    def has_version_file(self) -> bool:
+        return any(zi.filename.lower().endswith('.version')
+                   for zi in self.files)
+
+    def has_dll(self) -> bool:
+        return any(zi.filename.lower().endswith('.dll')
+                   for zi in self.files)
+
+    def has_cfg(self) -> bool:
+        return any(zi.filename.lower().endswith('.cfg')
+                   for zi in self.files)
+
+    def str_has_mm_syntax(self, cfg_str: str) -> bool:
+        return self.MM_PATTERN.search(cfg_str) is not None
+
+    def has_mm_syntax(self) -> bool:
+        return (False if not self.zip
+                else any(zi.filename.lower().endswith('.cfg')
+                         and self.str_has_mm_syntax(
+                             self.zip.read(zi.filename).decode("utf-8"))
+                         for zi in self.files))
+
+    def str_has_parts(self, cfg_str: str) -> bool:
+        return self.PARTS_PATTERN.search(cfg_str) is not None
+
+    def has_parts(self) -> bool:
+        return (False if not self.zip
+                else any(zi.filename.lower().endswith('.cfg')
+                         and self.str_has_parts(
+                             self.zip.read(zi.filename).decode("utf-8"))
+                         for zi in self.files))
+
+    def has_ident_folder(self) -> bool:
+        return any(self.ident in Path(zi.filename).parts[:-1]
+                   for zi in self.files)
+
+    def find_folder(self) -> str:
+        # First look for a unique entry directly under GameData
+        dir_parts = {Path(zi.filename).parts[:-1] for zi in self.files}
+        dirs_with_gamedata = {(dirs, dirs.index('GameData'))
+                              for dirs in dir_parts
+                              if 'GameData' in dirs}
+        parts_after_gd = {dirs[i + 1]
+                          for dirs, i in dirs_with_gamedata
+                          if i < len(dirs) - 1}
+        if len(parts_after_gd) > 1:
+            # Multiple folders under GameData, manual review required
+            return ''
+        if len(parts_after_gd) == 1:
+            # Found GameData with only one subdir, return it
+            return next(iter(parts_after_gd))
+        # If no GameData, look for unique folder in root
+        first_parts = {dirs[0] for dirs in dir_parts}
+        if len(first_parts) == 1:
+            # No GameData but only one root folder, return it
+            return next(iter(first_parts))
+        # No GameData, multiple folders in root, manual review required
+        return ''
+
+    def get_netkan_properties(self) -> Dict[str, Any]:
+        props: Dict[str, Any] = { }
+        if self.has_version_file():
+            props['$vref'] = '#/ckan/ksp-avc'
+        props['tags'] = []
+        if self.has_dll():
+            props['tags'].append('plugin')
+        if self.has_parts():
+            props['tags'].append('parts')
+        elif self.has_cfg():
+            # Mark .cfg files with no parts as config
+            props['tags'].append('config')
+        if self.has_mm_syntax():
+            props['depends'] = [ {
+                'name': 'ModuleManager'
+            } ]
+        if not self.has_ident_folder():
+            props['install'] = [ {
+                'find': self.find_folder(),
+                'install_to': 'GameData'
+            } ]
+        return props

--- a/netkan/netkan/spacedock_adder.py
+++ b/netkan/netkan/spacedock_adder.py
@@ -9,6 +9,7 @@ import boto3
 import yaml
 
 from .github_pr import GitHubPR
+from .mod_analyzer import ModAnalyzer
 from .common import deletion_msg
 
 from .repos import NetkanRepo
@@ -105,11 +106,18 @@ class SpaceDockAdder:
         return True
 
     @staticmethod
+    def sd_download_url(info: Dict[str, Any]) -> str:
+        return f"https://spacedock.info/mod/{info.get('id', '')}/{info.get('name', '')}/download"
+
+    @staticmethod
     def make_netkan(info: Dict[str, Any]) -> Dict[str, Any]:
+        ident = re.sub(r'\W+', '', info.get('name', ''))
+        mod = ModAnalyzer(ident, SpaceDockAdder.sd_download_url(info))
         return {
             'spec_version': 'v1.4',
-            'identifier': re.sub(r'\W+', '', info.get('name', '')),
+            'identifier': ident,
             '$kref': f"#/ckan/spacedock/{info.get('id', '')}",
             'license': info.get('license', '').strip().replace(' ', '-'),
+            **mod.get_netkan_properties(),
             'x_via': f"Automated {info.get('site_name')} CKAN submission"
         }


### PR DESCRIPTION
## Motivation

See https://github.com/KSP-CKAN/NetKAN/pull/8887#issuecomment-982876650 and https://github.com/KSP-CKAN/NetKAN/pull/8887#issuecomment-982879270 for user feedback for the SpaceDock Adder:

> Was the first time I used Spacedock to make the netkan, not really happy, will go back to my local automated process

> Probably because I'm used to my system, which does the tags, license, etc.

## Cause

The SpaceDock Adder's .netkan file generator is still pretty rudimentary; it just takes values pushed from SpaceDock and dumps them into a string template. It may be possible to automate more of the process.

## Changes

A new `ModAnalyzer` class is created in `netkan/netkan/mod_analyzer.py`, which downloads a ZIP from a given URL and examines it to deduce additional .netkan file properties:

- `tags` is set to an empty list by default rather than being absent completely, as a reminder to fill it in
  - If the ZIP contains a `.dll` file, then the `plugin` tag is added
  - If the ZIP contains a `.cfg` file with a `PART` in it, then the `parts` tag is added
  - If the ZIP file contains no parts but does have a `.cfg` file, then the `config` tag is added
- If a `.version` file is found, a `$vref` property is added
- If a `.cfg` file with ModuleManager syntax is found, an MM dependency is added
- If the ZIP doesn't contain a folder name matching the identifier (so the default install stanza won't work), an attempt is made to auto-generate the `install` property
  - If there's a GameData folder with _one_ subfolder, install that subfolder
  - If there's no GameData folder but the root of the ZIP has only one folder, install that folder
  - Otherwise install an empty string so the reviewers can look into it
- `SpaceDockAdder` now uses `ModAnalyzer.get_netkan_properties()` to supplement the .netkan file that is submitted in the PR

This should mean that more incoming PRs will "just work" with less manual intervention, even though some checking will still be required.

I think I'll self-review this so I can watch for the next PR and apply fixes if needed.