### PR TITLE
Make GraphQL queries 20% smaller

### DIFF
--- a/netkan/netkan/download_counter.py
+++ b/netkan/netkan/download_counter.py
@@ -131,7 +131,7 @@ class GraphQLQuery:
     GITHUB_API = 'https://api.github.com/graphql'
 
     # Get this many modules per request
-    MODULES_PER_GRAPHQL = 50
+    MODULES_PER_GRAPHQL = 40
 
     # The request we send to GitHub, with a parameter for the module specific section
     GRAPHQL_TEMPLATE = Template(read_text('netkan', 'downloads_query.graphql'))


### PR DESCRIPTION
## Problem

#232 successfully revealed this:

![image](https://user-images.githubusercontent.com/1559108/144640778-609b74b7-92ba-42c6-9089-adda374fe9e6.png)

## Cause

A timeout is plausible, since the error happens inconsistently, which points to something external like a race condition or a resource limit. If the code was doing something wrong, it should error out the same way every time.

## Changes

Now the number of mods per GraphQL query is reduced from 50 to 40. This should make timeouts less common, if that's what's happening.

Blah blah blah self-review blah blah blah.