### PR TITLE
Indent YAML nested sequences

### DIFF
--- a/netkan/netkan/download_counter.py
+++ b/netkan/netkan/download_counter.py
@@ -7,7 +7,7 @@ from importlib.resources import read_text
 from string import Template
 from typing import Optional, Dict, Any
 
-from yaml.reader import ReaderError
+from ruamel.yaml.error import YAMLError
 import requests
 from requests.exceptions import RequestException
 
@@ -88,7 +88,7 @@ class NetkanDownloads(Netkan):
             except RequestException as exc:
                 logging.error('DownloadCounter metanetkan network request failed for %s: %s',
                               self.identifier, exc)
-            except ReaderError as exc:
+            except YAMLError as exc:
                 logging.error('DownloadCounter metanetkan failed YAML parse for %s: %s',
                               self.identifier, exc)
             # Can't get the metanetkan

--- a/netkan/netkan/metadata.py
+++ b/netkan/netkan/metadata.py
@@ -6,7 +6,7 @@ from hashlib import sha1
 import uuid
 import urllib.parse
 from typing import Optional, List, Tuple, Union, Any, Dict
-import yaml
+from ruamel.yaml import YAML
 import dateutil.parser
 
 from .csharp_compat import csharp_uri_tostring
@@ -22,8 +22,9 @@ class Netkan:
             self.contents = self.filename.read_text(encoding='UTF-8')
         elif contents:
             self.contents = contents
+        yaml = YAML(typ='safe')
         # YAML parser doesn't allow tabs, so replace with spaces
-        self._raw = yaml.safe_load(self.contents.replace('\t', '    '))
+        self._raw = yaml.load(self.contents.replace('\t', '    '))
         # Extract kref_src + kref_id from the kref
         self.kref_src: Optional[str]
         self.kref_id: Optional[str]

--- a/netkan/setup.py
+++ b/netkan/setup.py
@@ -26,7 +26,7 @@ setup(
         'gunicorn>=19.9,!=20.0.0',
         'discord.py>=1.6.0',
         'PyGithub',
-        'pyyaml',
+        'ruamel.yaml',
     ],
     entry_points={
         'console_scripts': [
@@ -48,7 +48,6 @@ setup(
             'types-requests',
             'types-Flask',
             'types-Jinja2',
-            'types-PyYAML',
         ],
         'test': [
             'pytest',
@@ -60,7 +59,6 @@ setup(
             'types-requests',
             'types-Flask',
             'types-Jinja2',
-            'types-PyYAML',
         ]
     },
 )


### PR DESCRIPTION
## Problem

The SpaceDock Adder can generate lists as of #233, but it doesn't indent the `-`:

```yaml
tags:
- plugin
- config
depends:
- name: ModuleManager
install:
- find: WGMP
  install_to: GameData
```

I'm pretty sure this is valid YAML syntax, but it's not how we've been formatting it so far, and it's not how https://codebeautify.org/json-to-yaml does it. It would be better for this to be consistent with the YAML metadata we've already built up.

## Cause

That's just how `PyYAML` formats its output, and there's no way to customize it.

## Changes

Now we've switched from `PyYAML` to `ruamel.yaml`, which is a fork based on `PyYAML` with more fixes and features. In particular, it allows calling code to customize the indenting, so we do, by adding two spaces before the `-` of a nested list.

```yaml
tags:
  - plugin
  - config
depends:
  - name: ModuleManager
install:
  - find: WGMP
    install_to: GameData
```