### PR TITLE
Fix AttributeError in Indexer with staging

### DIFF
--- a/netkan/netkan/repos.py
+++ b/netkan/netkan/repos.py
@@ -79,7 +79,8 @@ class XkanRepo:
                 self.git_repo.heads, branch_name
             )
             branch.checkout()
-        except GitCommandError:
+        except (GitCommandError, AttributeError):
+            # Branch doesn't exist on remote, just create it locally
             if branch_name not in self.git_repo.heads:
                 branch = self.git_repo.create_head(branch_name)
             else:


### PR DESCRIPTION
## Problem

The bot is repeating this about every 5 minutes:

```
Uncaught exception:
Traceback (most recent call last):
  File ".local/bin/netkan", line 8, in <module>
    sys.exit(netkan())
  File "/home/netkan/.local/lib/python3.7/site-packages/click/core.py", line 1128, in __call__
    return self.main(*args, **kwargs)
  File "/home/netkan/.local/lib/python3.7/site-packages/click/core.py", line 1053, in main
    rv = self.invoke(ctx)
  File "/home/netkan/.local/lib/python3.7/site-packages/click/core.py", line 1659, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/home/netkan/.local/lib/python3.7/site-packages/click/core.py", line 1395, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "/home/netkan/.local/lib/python3.7/site-packages/click/core.py", line 754, in invoke
    return __callback(*args, **kwargs)
  File "/home/netkan/.local/lib/python3.7/site-packages/click/decorators.py", line 84, in new_func
    return ctx.invoke(f, obj, *args, **kwargs)
  File "/home/netkan/.local/lib/python3.7/site-packages/click/core.py", line 754, in invoke
    return __callback(*args, **kwargs)
  File "/home/netkan/.local/lib/python3.7/site-packages/netkan/cli/services.py", line 32, in indexer
    handler.process_ckans()
  File "/home/netkan/.local/lib/python3.7/site-packages/netkan/indexer.py", line 220, in process_ckans
    self._process_queue(self.staged)
  File "/home/netkan/.local/lib/python3.7/site-packages/netkan/indexer.py", line 206, in _process_queue
    ckan.process_ckan()
  File "/home/netkan/.local/lib/python3.7/site-packages/netkan/indexer.py", line 142, in process_ckan
    with self.ckm_repo.change_branch(self.staging_branch_name):
  File "/usr/local/lib/python3.7/contextlib.py", line 112, in __enter__
    return next(self.gen)
  File "/home/netkan/.local/lib/python3.7/site-packages/netkan/repos.py", line 75, in change_branch
    branch_name
  File "/home/netkan/.local/lib/python3.7/site-packages/git/util.py", line 1001, in __getattr__
    return list.__getattribute__(self, attr)
AttributeError: 'IterableList' object has no attribute 'origin/add/LessRealThanReal-v2.0.2'
```

## Cause

This branch was first created for #2518, which I closed quickly. Then everything was fine for several hours. I deleted the branch but the bot restored it early on, presumably by pushing the same changes again. Then KSP-CKAN/NetKAN-Infra#239 was merged, which had the side effect of restarting the bot. At that point the exceptions started. I tried deleting the branch, then restoring it, but the exceptions continued.

Inflations happen every 30 minutes, but the message handling timeout on the queue is 5 minutes, so the 5 minute interval suggests there's an old inflation of that mod stuck in the queue, see #2518. But what we really want is the new inflation that shouldn't need staging, see KSP-CKAN/NetKAN#8900. I'm not sure why that isn't coming through, maybe queue deduplication is blocking it until the old message is cleared.

## Changes

Now the `try` block within which this exception is thrown also catches `AttributeError`. I'm hoping this will allow the branch creation to succeed, and then we'll see what happens next.

After merging this (right after a fresh error), I'm going to try deleting the branch again so it isn't present when the bot's working copy is cloned. Hopefully that will reset the bot back to its initial state.