### PR TITLE
Stream downloads

### DIFF
--- a/netkan/netkan/common.py
+++ b/netkan/netkan/common.py
@@ -1,11 +1,14 @@
-from typing import List, Iterable, Dict, Any
+from typing import List, Iterable, Dict, Any, IO
 import boto3  # pylint: disable=unused-import
 
+import requests
 import github
 from git import Repo
 
 from .metadata import Netkan
 from .repos import NetkanRepo
+
+USER_AGENT = 'Mozilla/5.0 (compatible; Netkanbot/1.0; CKAN; +https://github.com/KSP-CKAN/NetKAN-Infra)'
 
 
 def netkans(path: str, ids: Iterable[str]) -> Iterable[Netkan]:
@@ -39,3 +42,12 @@ def deletion_msg(msg: 'boto3.resources.factory.sqs.Message') -> Dict[str, Any]:
         'Id':            msg.message_id,
         'ReceiptHandle': msg.receipt_handle,
     }
+
+
+def download_stream_to_file(download_url: str, dest_file: IO[bytes]) -> None:
+    # Get big files in little chunks
+    with requests.get(download_url,
+                      headers={'User-Agent': USER_AGENT},
+                      stream=True) as req:
+        for chunk in req.iter_content(chunk_size=8192):
+            dest_file.write(chunk)

--- a/netkan/netkan/mirrorer.py
+++ b/netkan/netkan/mirrorer.py
@@ -16,7 +16,7 @@ from jinja2 import Template
 
 from .metadata import Ckan
 from .repos import CkanMetaRepo
-from .common import deletion_msg
+from .common import deletion_msg, download_stream_to_file
 
 
 class CkanMirror(Ckan):
@@ -135,8 +135,6 @@ class CkanMirror(Ckan):
 
     EPOCH_VERSION_REGEXP = re.compile('^[0-9]+:')
 
-    USER_AGENT = 'Mozilla/5.0 (compatible; Netkanbot/1.0; CKAN; +https://github.com/KSP-CKAN/NetKAN-Infra)'
-
     def __init__(self, collection: str, filename: Union[str, Path] = None, contents: str = None) -> None:
         Ckan.__init__(self, filename, contents)
         self.collection = collection
@@ -237,10 +235,7 @@ class CkanMirror(Ckan):
         if target_path:
             with tempfile.NamedTemporaryFile() as tmp:
                 logging.info('Downloading %s', self.download)
-                tmp.write(requests.get(
-                    self.download,
-                    headers={ 'User-Agent': self.USER_AGENT }
-                ).content)
+                download_stream_to_file(self.download, tmp)
                 tmp.flush()
                 tmp_path = Path(tmp.name)
                 file = self.open_if_hash_match(tmp_path)
@@ -348,10 +343,7 @@ class Mirrorer:
             if source_url:
                 with tempfile.NamedTemporaryFile() as tmp:
                     logging.info('Attempting to archive source from %s', source_url)
-                    tmp.write(requests.get(
-                        source_url,
-                        headers={ 'User-Agent': CkanMirror.USER_AGENT }
-                    ).content)
+                    download_stream_to_file(source_url, tmp)
                     tmp.flush()
                     item.upload_file(tmp.name, ckan.mirror_source_filename(),
                                      ckan.item_metadata,

--- a/netkan/netkan/mod_analyzer.py
+++ b/netkan/netkan/mod_analyzer.py
@@ -3,12 +3,12 @@ import tempfile
 from pathlib import Path
 from zipfile import ZipFile, is_zipfile
 from typing import Dict, List, Any, Union, Pattern
-import requests
+
+from .common import download_stream_to_file
 
 
 class ModAnalyzer:
 
-    USER_AGENT = 'Mozilla/5.0 (compatible; Netkanbot/1.0; CKAN; +https://github.com/KSP-CKAN/NetKAN-Infra)'
     MM_PATTERN = re.compile(r'^\s*[@+$\-!%]|^\s*[a-zA-Z0-9_]+:',
                             re.MULTILINE)
     PARTS_PATTERN = re.compile(r'^\s*PART\b',
@@ -32,10 +32,7 @@ class ModAnalyzer:
     def __init__(self, ident: str, download_url: str) -> None:
         self.ident = ident
         self.download_file = tempfile.NamedTemporaryFile()
-        self.download_file.write(requests.get(
-            download_url,
-            headers={ 'User-Agent': self.USER_AGENT }
-        ).content)
+        download_stream_to_file(download_url, self.download_file)
         self.download_file.flush()
         self.zip = (ZipFile(self.download_file, 'r')
                     if is_zipfile(self.download_file)


### PR DESCRIPTION
## Problem

See #242, the `ModAnalyzer` can throw `OSError: [Errno 14] Bad address`.

## Cause

Apparently that exception means "out of memory". The `SpaceDockAdder` instance is configured to have 128 MiB of RAM, and it was trying to download a 250 MiB file.

I just wanted to dump the response into the file, but `Response.content` has to download the entire file into memory first.

## Changes

Now the downloading code is refactored into `common.download_stream_to_file`, which retrieves and stores one 8 KiB chunk at a time. This also allowed the consolidation of the `User-Agent` handling. After this the `ModAnalyzer` and the `Mirrorer` should be able to handle big files using less memory.