### PR TITLE
Add resource links to AutoFreezer pull requests

### DIFF
--- a/netkan/netkan/auto_freezer.py
+++ b/netkan/netkan/auto_freezer.py
@@ -85,9 +85,19 @@ class AutoFreezer:
         return '\n'.join([
             'Mod | Last Update',
             ':-- | :--',
-            *[f'{mod[0]} | {mod[1].astimezone(timezone.utc):%Y-%m-%d %H:%M %Z}'
+            *[f'{AutoFreezer._mod_cell(mod[0])} | {mod[1].astimezone(timezone.utc):%Y-%m-%d %H:%M %Z}'
               for mod in idle_mods]
         ])
+
+    @staticmethod
+    def _mod_cell(ident: str) -> str:
+        status = ModStatus.get(ident)
+        resources = getattr(status, 'resources', None)
+        if resources:
+            links = r' \| '.join(f'[{key}]({url})'
+                                 for key, url in resources.items())
+            return f'**{ident}**<br>{links}'
+        return f'**{ident}**'
 
     def _submit_pr(self, branch_name: str, days: int, idle_mods: List[Tuple[str, datetime]]) -> None:
         if self.github_pr:


### PR DESCRIPTION
## Motivation

Following up on AutoFreezer pull requests can be tedious because finding the mods' resource links requires opening the status page and typing the mod name to filter.

## Changes

This is KSP-CKAN/CKAN#3454 for the AutoFreezer. The pull request table will contain links to the resources, just like on the status page.

- Resources are retrieved from the `ModStatus` table as in KSP-CKAN/NetKAN-status#9
- The mod name cell is split into two lines with `<br>`, which seems to be the way to have multiple lines in Markdown tables
- Pipes are inserted between links with ` \| ` because `|` is the cell separator in Markdown tables
- Mod names are bold to make them stand out more from the links
- The AutoFreezer tests are updated to exercise the new format

This will make it easier to get to the forum page, repo, SpaceDock page, etc. for mods selected for freezing.