### PR TITLE
Use template for ticket closer comment body

### DIFF
--- a/netkan/netkan/cli/utilities.py
+++ b/netkan/netkan/cli/utilities.py
@@ -143,7 +143,7 @@ def redeploy_service(cluster: str, service_name: str) -> None:
 @common_options
 @pass_state
 def ticket_closer(common: SharedArgs, days_limit: int) -> None:
-    TicketCloser(common.token).close_tickets(days_limit)
+    TicketCloser(common.token, common.user).close_tickets(days_limit)
 
 
 @click.command()

--- a/netkan/netkan/ticket_close_template.md
+++ b/netkan/netkan/ticket_close_template.md
@@ -1,0 +1,1 @@
+Hey there! I'm a fun-loving automated bot who's responsible for making sure old support tickets get closed out. As we haven't seen any activity on this ticket for a while, we're hoping the problem has been resolved and I'm closing out the ticket automatically. If I'm doing this in error, please add a comment to this ticket to let us know, and we'll re-open it!

--- a/prod-stack.py
+++ b/prod-stack.py
@@ -810,7 +810,9 @@ services = [
     {
         'name': 'TicketCloser',
         'command': 'ticket-closer',
-        'env': [],
+        'env': [
+            ('CKAN_USER', NETKAN_USER),
+        ],
         'secrets': ['GH_Token'],
         'schedule': 'rate(1 day)',
     },


### PR DESCRIPTION
## Motivation

The Ticket Closer from #87 has not had much work to do recently, but its coding style leaves some room for improvement.

- The comment body is embedded inline in the code where it's used, which makes it awkward to edit and potentially means the Python interpreter needs to regenerate it every time through the loop
- It hard-codes the `KSP-CKAN` user on GitHub, which in the rest of the code is configurable via command line parameters
- The names of the repos are likewise embedded where they're used

## Changes

- The comment body is moved to `netkan/netkan/ticket_close_template.md`, loaded into a `string.Template` and rendered so we can add variables to it easily later if we want to
- The `--user` parameter is now used to get the GitHub user via the `CKAN_USER` environment variable
- The repo names are moved to `TicketCloser.REPO_NAMES`
- The `datetime` import now uses `from` to avoid needing `datetime.` prefixes where it's used
- The indentation is more Python-style in some spots
