### PR TITLE
Access ModStatus.resources as dict

### DIFF
--- a/netkan/netkan/auto_freezer.py
+++ b/netkan/netkan/auto_freezer.py
@@ -95,7 +95,7 @@ class AutoFreezer:
         resources = getattr(status, 'resources', None)
         if resources:
             links = r' \| '.join(f'[{key}]({url})'
-                                 for key, url in resources.items())
+                                 for key, url in resources.as_dict().items())
             return f'**{ident}**<br>{links}'
         return f'**{ident}**'
 

--- a/netkan/netkan/spacedock_adder.py
+++ b/netkan/netkan/spacedock_adder.py
@@ -72,7 +72,7 @@ class SpaceDockAdder:
         if branch_name not in self.nk_repo.git_repo.heads:
             self.nk_repo.git_repo.create_head(
                 branch_name,
-                getattr(
+                getattr( # type: ignore[arg-type]
                     self.nk_repo.git_repo.remotes.origin.refs,
                     branch_name,
                     self.nk_repo.git_repo.remotes.origin.refs.master

--- a/netkan/netkan/status.py
+++ b/netkan/netkan/status.py
@@ -51,11 +51,12 @@ class ModStatus(Model):
         for key in self.get_attributes().keys():
             if key == 'ModIdentifier':
                 continue
-            attributes[key] = getattr(self, key, None)
-            if isinstance(attributes[key], datetime):
-                attributes[key] = attributes[key].isoformat()
-            elif isinstance(attributes[key], MapAttribute):
-                attributes[key] = attributes[key].as_dict()
+            attr = getattr(self, key, None)
+            attributes[key] = (
+                attr.isoformat() if attr and isinstance(attr, datetime)
+                else attr.as_dict() if attr and isinstance(attr, MapAttribute)
+                else attr
+            )
         return attributes
 
     # If we ever have more than 1MB of Status in the DB we'll need paginate,

--- a/netkan/tests/auto_freezer.py
+++ b/netkan/tests/auto_freezer.py
@@ -5,6 +5,7 @@ from datetime import datetime, timezone, timedelta
 import unittest
 from unittest.mock import patch, call
 import git
+from pynamodb.attributes import MapAttribute
 
 from netkan.auto_freezer import AutoFreezer
 from netkan.repos import NetkanRepo
@@ -80,7 +81,7 @@ class TestAutoFreezer(unittest.TestCase):
 
             status_mock.get.side_effect = lambda ident: unittest.mock.Mock(
                 release_date=self.IDENT_TIMESTAMPS[ident],
-                resources=self.IDENT_RESOURCES[ident])
+                resources=MapAttribute(**self.IDENT_RESOURCES[ident]))
             unittest.util._MAX_LENGTH=999999999 # :snake:
 
             nk_repo = nk_repo_mock(git.Repo('/blah'))


### PR DESCRIPTION
## Problem

```
Uncaught exception:
Traceback (most recent call last):
  File ".local/bin/netkan", line 8, in <module>
    sys.exit(netkan())
  File "/home/netkan/.local/lib/python3.7/site-packages/click/core.py", line 1128, in __call__
    return self.main(*args, **kwargs)
  File "/home/netkan/.local/lib/python3.7/site-packages/click/core.py", line 1053, in main
    rv = self.invoke(ctx)
  File "/home/netkan/.local/lib/python3.7/site-packages/click/core.py", line 1659, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/home/netkan/.local/lib/python3.7/site-packages/click/core.py", line 1395, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "/home/netkan/.local/lib/python3.7/site-packages/click/core.py", line 754, in invoke
    return __callback(*args, **kwargs)
  File "/home/netkan/.local/lib/python3.7/site-packages/click/decorators.py", line 84, in new_func
    return ctx.invoke(f, obj, *args, **kwargs)
  File "/home/netkan/.local/lib/python3.7/site-packages/click/core.py", line 754, in invoke
    return __callback(*args, **kwargs)
  File "/home/netkan/.local/lib/python3.7/site-packages/netkan/cli/utilities.py", line 36, in auto_freezer
    afr.freeze_idle_mods(days_limit, days_till_ignore)
  File "/home/netkan/.local/lib/python3.7/site-packages/netkan/auto_freezer.py", line 30, in freeze_idle_mods
    self._submit_pr(self.BRANCH_NAME, days_limit, idle_mods)
  File "/home/netkan/.local/lib/python3.7/site-packages/netkan/auto_freezer.py", line 109, in _submit_pr
    body=(f'The attached mods have not updated in {days} or more days.'
  File "/home/netkan/.local/lib/python3.7/site-packages/netkan/auto_freezer.py", line 89, in _mod_table
    for mod in idle_mods]
  File "/home/netkan/.local/lib/python3.7/site-packages/netkan/auto_freezer.py", line 89, in <listcomp>
    for mod in idle_mods]
  File "/home/netkan/.local/lib/python3.7/site-packages/netkan/auto_freezer.py", line 98, in _mod_cell
    for key, url in resources.items())
  File "/home/netkan/.local/lib/python3.7/site-packages/pynamodb/attributes.py", line 890, in __getattr__
    raise AttributeError("'{}' has no attribute '{}'".format(self.__class__.__name__, attr))
AttributeError: 'MapAttribute' has no attribute 'items'
```

## Cause

`ModStatus.resources` stores a JSON object, which works like a `dict` in Python. But PynamoDB stores it as a `MapAttribute`, which doesn't support the `items()` method for iterating over a `dict` because ... those devs like causing bugs? :man_shrugging:

## Changes

Luckily `MapAttribute` has an `as_dict()` method that should convert it into something usable:

https://github.com/pynamodb/PynamoDB/blob/4929aee27a81b7389fd7a38e3af19fff2d7c4b59/pynamodb/attributes.py#L1027-L1031

Now we call that. :crossed_fingers: 

Some other changes are also made to try to address some Mypy errors.