### PR TITLE
Automatically tag contract packs

### DIFF
--- a/netkan/netkan/mod_analyzer.py
+++ b/netkan/netkan/mod_analyzer.py
@@ -29,6 +29,7 @@ class ModAnalyzer:
         CfgAspect(r'^\s*@Kopernicus\b',                ['planet-pack'], ['Kopernicus']),
         CfgAspect(r'^\s*STATIC\b',                     ['buildings'],   ['KerbalKonstructs']),
         CfgAspect(r'^\s*TUFX_PROFILE\b',               ['graphics'],    ['TUFX']),
+        CfgAspect(r'^\s*CONTRACT_TYPE\b',              ['career'],      ['ContractConfigurator']),
     ]
     FILTERS = [
         '__MACOSX', '.DS_Store',


### PR DESCRIPTION
See? I [told you](https://github.com/KSP-CKAN/NetKAN-Infra/pull/245) this would be easy!
Now mods with `.cfg` files containing `CONTRACT_TYPE` config nodes will be tagged with `career` and have a `ContractConfigurator` depends added automatically.
Inspired by and tested with KSP-CKAN/NetKAN#8920.
