### PR TITLE
Increase spec version for SpaceDock pull requests

### DIFF
--- a/netkan/netkan/spacedock_adder.py
+++ b/netkan/netkan/spacedock_adder.py
@@ -130,7 +130,7 @@ class SpaceDockAdder:
             logging.error('%s failed to analyze %s from %s',
                 cls.__name__, ident, url, exc_info=exc)
         return {
-            'spec_version': 'v1.4',
+            'spec_version': 'v1.10',
             'identifier': ident,
             '$kref': f"#/ckan/spacedock/{info.get('id', '')}",
             'license': info.get('license', '').strip().replace(' ', '-'),


### PR DESCRIPTION
In #234 the `SpaceDockAdder` gained the ability to submit netkans with `filter_regexp`, but `spec_version` was still always `v1.4`.

In KSP-CKAN/CKAN#3494 we started enforcing the requirement that `spec_version` must be `v1.10` or greater for `filter_regexp`.

The `SpaceDockAdder` submitted KSP-CKAN/NetKAN#8958 for a mod with a `.mdb` file that should be filtered out, so `filter_regexp` was included in the `install` stanza, and [the initial inflation failed](https://github.com/KSP-CKAN/NetKAN/runs/4797383005):

![image](https://user-images.githubusercontent.com/1559108/149380164-b1a6748b-769e-4997-8837-17e661a0b608.png)

Now the `spec_version` is increased to `v1.10` so we can use `filter_regexp` if we need to. I don't think there's any real disadvantage to this even if `filter_regexp` is _not_ used for a particular pull request, since we never made a particular effort to decrease it from `v1.4` to `1` when that would have been possible.