### PR TITLE
Catch ModStatus.DoesNotExist in AutoFreezer

### DIFF
--- a/netkan/netkan/auto_freezer.py
+++ b/netkan/netkan/auto_freezer.py
@@ -68,10 +68,14 @@ class AutoFreezer:
 
     @staticmethod
     def _last_timestamp(ident: str) -> Optional[datetime]:
-        status = ModStatus.get(ident)
-        return getattr(status, 'release_date',
-                       getattr(status, 'last_indexed',
-                               None))
+        try:
+            status = ModStatus.get(ident)
+            return getattr(status, 'release_date',
+                           getattr(status, 'last_indexed',
+                                   None))
+        except ModStatus.DoesNotExist:
+            # No timestamp if mod isn't in the status table (very freshly merged)
+            return None
 
     def _add_freezee(self, ident: str) -> None:
         self.nk_repo.git_repo.index.move([


### PR DESCRIPTION
## Problem

```
Uncaught exception:
Traceback (most recent call last):
  File ".local/bin/netkan", line 8, in <module>
    sys.exit(netkan())
  File "/home/netkan/.local/lib/python3.7/site-packages/click/core.py", line 1128, in __call__
    return self.main(*args, **kwargs)
  File "/home/netkan/.local/lib/python3.7/site-packages/click/core.py", line 1053, in main
    rv = self.invoke(ctx)
  File "/home/netkan/.local/lib/python3.7/site-packages/click/core.py", line 1659, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/home/netkan/.local/lib/python3.7/site-packages/click/core.py", line 1395, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "/home/netkan/.local/lib/python3.7/site-packages/click/core.py", line 754, in invoke
    return __callback(*args, **kwargs)
  File "/home/netkan/.local/lib/python3.7/site-packages/click/decorators.py", line 84, in new_func
    return ctx.invoke(f, obj, *args, **kwargs)
  File "/home/netkan/.local/lib/python3.7/site-packages/click/core.py", line 754, in invoke
    return __callback(*args, **kwargs)
  File "/home/netkan/.local/lib/python3.7/site-packages/netkan/cli/utilities.py", line 36, in auto_freezer
    afr.freeze_idle_mods(days_limit, days_till_ignore)
  File "/home/netkan/.local/lib/python3.7/site-packages/netkan/auto_freezer.py", line 21, in freeze_idle_mods
    idle_mods = self._find_idle_mods(days_limit, days_till_ignore)
  File "/home/netkan/.local/lib/python3.7/site-packages/netkan/auto_freezer.py", line 63, in _find_idle_mods
    dttm = self._last_timestamp(ident)
  File "/home/netkan/.local/lib/python3.7/site-packages/netkan/auto_freezer.py", line 71, in _last_timestamp
    status = ModStatus.get(ident)
  File "/home/netkan/.local/lib/python3.7/site-packages/pynamodb/models.py", line 551, in get
    raise cls.DoesNotExist()
netkan.status.ModStatus.DoesNotExist: None
```

## Cause

Apparently I merged KSP-CKAN/NetKAN#8967 immediately before the AutoFreezer ran, so the .netkan existed but the mod wasn't added to `ModStatus` yet. (If the bot had inflated that mod even once, it would have been added to the database.) When we tried to look up that mod's timestamp, this exception was thrown.

## Changes

Now we catch `ModStatus.DoesNotExist` and return `None`, since it indicates we don't have a timestamp for that mod. This will exclude such a mod from further processing.

This week's freezable mods should be included in next week's pass as well, so no special cleanup is needed.