### PR TITLE
Strip BOM when parsing cfg files in mod analyzer

### DIFF
--- a/netkan/netkan/mod_analyzer.py
+++ b/netkan/netkan/mod_analyzer.py
@@ -83,7 +83,7 @@ class ModAnalyzer:
         return (False if not self.zip
                 else any(zi.filename.lower().endswith('.cfg')
                          and pattern.search(
-                             self.zip.read(zi.filename).decode('utf8', errors='ignore'))
+                             self.zip.read(zi.filename).decode('utf-8-sig', errors='ignore'))
                          for zi in self.files))
 
     def has_ident_folder(self) -> bool:


### PR DESCRIPTION
## Problem

KSP-CKAN/NetKAN#8968 and KSP-CKAN/NetKAN#8969 were submitted for mods containing `PART` config nodes, but the initial tags were only `config`, not `parts`.

## Cause

These cfg files start with [BOMs](https://en.wikipedia.org/wiki/Byte_order_mark), which are included in the string we retrieve from the ZIP and which do not match our regex. This could affect any of the patterns we use to interpret cfg file contents.

## Changes

Now we pass `utf-8-sig` to `decode` to strip the BOMs, which makes the regex work again for these files. Files without BOMs also still work.

https://docs.python.org/3/library/codecs.html#standard-encodings
