### PR TITLE
Detect Waterfall configs in mod analyzer

### DIFF
--- a/netkan/netkan/mod_analyzer.py
+++ b/netkan/netkan/mod_analyzer.py
@@ -36,6 +36,8 @@ class ModAnalyzer:
         CfgAspect(r'^\s*@CUSTOMBARNKIT\b',  [],               ['CustomBarnKit']),
         CfgAspect(r'^\s*name\s*=\s*ModuleB9PartSwitch\b',
                                             [],               ['B9PartSwitch']),
+        CfgAspect(r'^\s*name\s*=\s*ModuleWaterfallFX\b',
+                                            ['graphics'],     ['Waterfall']),
     ]
     FILTERS = [
         '__MACOSX', '.DS_Store',


### PR DESCRIPTION
We got 2 out of the 3 dependencies for KSP-CKAN/NetKAN#8973 automatically. The odd one out was Waterfall. Its wiki explains how to use it:

https://github.com/post-kerbin-mining-corporation/Waterfall/wiki/ModuleWaterfallFX

```
  MODULE
  {
    name = ModuleWaterfallFX
```

Now if we find that in any cfg file, we add the `graphics` tag and a dependency on `Waterfall`.