### PR TITLE
Submit pull requests via Github library

### DIFF
--- a/netkan/netkan/common.py
+++ b/netkan/netkan/common.py
@@ -34,7 +34,7 @@ def pull_all(repos: Iterable[Repo]) -> None:
 
 
 def github_limit_remaining(token: str) -> int:
-    return github.Github(token).get_rate_limit().core.remaining
+    return github.Github(token, user_agent=USER_AGENT).get_rate_limit().core.remaining
 
 
 def deletion_msg(msg: 'boto3.resources.factory.sqs.Message') -> Dict[str, Any]:

--- a/netkan/netkan/mirrorer.py
+++ b/netkan/netkan/mirrorer.py
@@ -15,7 +15,7 @@ from jinja2 import Template
 
 from .metadata import Ckan
 from .repos import CkanMetaRepo
-from .common import deletion_msg, download_stream_to_file
+from .common import deletion_msg, download_stream_to_file, USER_AGENT
 
 
 class CkanMirror(Ckan):
@@ -290,7 +290,9 @@ class Mirrorer:
                 'secret': ia_secret,
             }
         })
-        self._gh = github.Github(token) if token else github.Github()
+        self._gh = (github.Github(token, user_agent=USER_AGENT)
+                    if token else
+                    github.Github(user_agent=USER_AGENT))
 
     def process_queue(self, queue_name: str, timeout: int) -> None:
         queue = boto3.resource('sqs').get_queue_by_name(QueueName=queue_name)

--- a/netkan/netkan/ticket_closer.py
+++ b/netkan/netkan/ticket_closer.py
@@ -5,6 +5,8 @@ from collections import defaultdict
 from string import Template
 import github
 
+from .common import USER_AGENT
+
 
 class TicketCloser:
 
@@ -12,7 +14,7 @@ class TicketCloser:
     BODY_TEMPLATE = Template(read_text('netkan', 'ticket_close_template.md'))
 
     def __init__(self, token: str, user_name: str) -> None:
-        self._gh = github.Github(token)
+        self._gh = github.Github(token, user_agent=USER_AGENT)
         self._user_name = user_name
 
     def close_tickets(self, days_limit: int = 7) -> None:


### PR DESCRIPTION
## Motivation

The Indexer, AutoFreezer, and SpaceDockAdder use the `GitHubPR` class to submit pull requests. Internally, this class uses the `requests` and `json` libraries to create and submit HTTPS messages to hard coded GitHub API URLs, then parse the responses.

There's a `github` library that abstracts this logic for us, which we are already using in a few other places.

## Changes

`GitHubPR` now uses the `github` library and is much, much shorter.

All of the other places that were already using the `github` library now set the user agent from #236.

This one should probably be reviewed, as there may be functional changes, especially since the error handling has been changed from parsing JSON to catching exceptions thrown by the library.
