### PR TITLE
Increase SD adder's spec version

### DIFF
--- a/netkan/netkan/spacedock_adder.py
+++ b/netkan/netkan/spacedock_adder.py
@@ -130,7 +130,7 @@ class SpaceDockAdder:
             logging.error('%s failed to analyze %s from %s',
                 cls.__name__, ident, url, exc_info=exc)
         return {
-            'spec_version': 'v1.10',
+            'spec_version': 'v1.18',
             'identifier': ident,
             '$kref': f"#/ckan/spacedock/{info.get('id', '')}",
             'license': info.get('license', '').strip().replace(' ', '-'),


### PR DESCRIPTION
## Problem

https://github.com/KSP-CKAN/NetKAN/runs/5226451616?check_suite_focus=true

> Error: 1433 [1] FATAL CKAN.NetKAN.Program (null) - spec_version v1.18+ required for 'as'
> ERROR:root:Test of NetKAN/YnoT1300.netkan failed!

## Cause

#257 added automatic generation of install stanzas for craft files, using the `as` property.

However, the `as` property requires a spec version of v1.18 (see KSP-CKAN/CKAN#2788), and the SpaceDock adder uses v1.10, so we'll get an inflation error whenever a ZIP contains a craft file.

## Changes

Now the spec version is incremented to v1.18.