### PR TITLE
Ensure unique mirror hook ids

### DIFF
--- a/netkan/netkan/webhooks/github_mirror.py
+++ b/netkan/netkan/webhooks/github_mirror.py
@@ -53,7 +53,7 @@ forbidden_id_chars = re.compile('[^-_A-Za-z0-9]')  # pylint: disable=invalid-nam
 def batch_message(path: Path) -> Dict[str, Any]:
     body = path.as_posix()
     return {
-        'Id':                     forbidden_id_chars.sub('_', body)[0:80],
+        'Id':                     forbidden_id_chars.sub('_', body)[-80:],
         'MessageBody':            body,
         'MessageGroupId':         '1',
         'MessageDeduplicationId': md5(body.encode()).hexdigest()


### PR DESCRIPTION
## Problem

```
Uncaught exception:
Traceback (most recent call last):
  File "/home/netkan/.local/lib/python3.7/site-packages/flask/app.py", line 1516, in full_dispatch_request
    rv = self.dispatch_request()
  File "/home/netkan/.local/lib/python3.7/site-packages/flask/app.py", line 1502, in dispatch_request
    return self.ensure_sync(self.view_functions[rule.endpoint])(**req.view_args)
  File "/home/netkan/.local/lib/python3.7/site-packages/netkan/webhooks/github_utils.py", line 17, in decorated_function
    return func(*args, **kwargs)
  File "/home/netkan/.local/lib/python3.7/site-packages/netkan/webhooks/github_mirror.py", line 45, in mirror_hook
    Entries=batch
  File "/home/netkan/.local/lib/python3.7/site-packages/botocore/client.py", line 395, in _api_call
    return self._make_api_call(operation_name, kwargs)
  File "/home/netkan/.local/lib/python3.7/site-packages/botocore/client.py", line 725, in _make_api_call
    raise error_class(parsed_response, operation_name)
botocore.errorfactory.BatchEntryIdsNotDistinct: An error occurred (AWS.SimpleQueueService.BatchEntryIdsNotDistinct) when calling the SendMessageBatch operation: Id RocketSoundEnhancement-Config-Default_RocketSoundEnhancement-Config-Default-0_5_ repeated.
```

## Cause

SQS requires us to specify an arbitrary ID string for each message. They must be unique and 80 characters or less (see #140). Currently the mirror queue uses the first 80 characters of the filename (with some trivial character substitutions), which is not unique when we (re-)index multiple versions of the same mod with a long identifier+version.

In this case, the filenames were:

- `RocketSoundEnhancement-Config-Default/RocketSoundEnhancement-Config-Default-0.5.1.ckan`
- `RocketSoundEnhancement-Config-Default/RocketSoundEnhancement-Config-Default-0.5.2.ckan`
- `RocketSoundEnhancement-Config-Default/RocketSoundEnhancement-Config-Default-0.5.3.ckan`
- `RocketSoundEnhancement-Config-Default/RocketSoundEnhancement-Config-Default-0.5.4.ckan`

... which resulted in an id of `RocketSoundEnhancement-Config-Default_RocketSoundEnhancement-Config-Default-0_5_` for each one.

## Changes

Now we use the _last_ 80 characters instead, which should be more reliably unique.

For these files, the `Rocket` prefix is dropped:

- `SoundEnhancement-Config-Default_RocketSoundEnhancement-Config-Default-0_5_1_ckan`
- `SoundEnhancement-Config-Default_RocketSoundEnhancement-Config-Default-0_5_2_ckan`
- `SoundEnhancement-Config-Default_RocketSoundEnhancement-Config-Default-0_5_3_ckan`
- `SoundEnhancement-Config-Default_RocketSoundEnhancement-Config-Default-0_5_4_ckan`
