### PR TITLE
Catch missing file exceptions in Mirrorer

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ __pycache__
 .mypy_cache/
 .pytest_cache/
 .eggs
+netkan/build/


### PR DESCRIPTION
## Problem

This exception is now repeating every 5 minutes in Discord:

```
Uncaught exception:
Traceback (most recent call last):
  File ".local/bin/netkan", line 8, in <module>
    sys.exit(netkan())
  File "/home/netkan/.local/lib/python3.7/site-packages/click/core.py", line 1130, in __call__
    return self.main(*args, **kwargs)
  File "/home/netkan/.local/lib/python3.7/site-packages/click/core.py", line 1055, in main
    rv = self.invoke(ctx)
  File "/home/netkan/.local/lib/python3.7/site-packages/click/core.py", line 1657, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/home/netkan/.local/lib/python3.7/site-packages/click/core.py", line 1404, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "/home/netkan/.local/lib/python3.7/site-packages/click/core.py", line 760, in invoke
    return __callback(*args, **kwargs)
  File "/home/netkan/.local/lib/python3.7/site-packages/click/decorators.py", line 84, in new_func
    return ctx.invoke(f, obj, *args, **kwargs)
  File "/home/netkan/.local/lib/python3.7/site-packages/click/core.py", line 760, in invoke
    return __callback(*args, **kwargs)
  File "/home/netkan/.local/lib/python3.7/site-packages/netkan/cli/services.py", line 76, in mirrorer
    ).process_queue(common.queue, common.timeout)
  File "/home/netkan/.local/lib/python3.7/site-packages/netkan/mirrorer.py", line 319, in process_queue
    if self.try_mirror(CkanMirror(self.ia_collection, path)):
  File "/home/netkan/.local/lib/python3.7/site-packages/netkan/mirrorer.py", line 138, in __init__
    Ckan.__init__(self, filename, contents)
  File "/home/netkan/.local/lib/python3.7/site-packages/netkan/metadata.py", line 275, in __init__
    self.contents = self.filename.read_text(encoding='UTF-8')
  File "/usr/local/lib/python3.7/pathlib.py", line 1221, in read_text
    with self.open(mode='r', encoding=encoding, errors=errors) as f:
  File "/usr/local/lib/python3.7/pathlib.py", line 1208, in open
    opener=self._opener)
  File "/usr/local/lib/python3.7/pathlib.py", line 1063, in _o
    return self._accessor.open(self, flags, mode)
FileNotFoundError: [Errno 2] No such file or directory: '/tmp/CKAN-meta/PhotoRealisticVisualEnhancement/PhotoRealisticVisualEnhancement-1-1.7.ckan'
```

## Cause

PRVE just had 12 PRs opened and closed in rapid sequence because releases kept appearing and disappearing and the bot was trying to keep up. During all that I deleted the `.ckan` file for a version that had disappeared before it was mirrored, so now it's stuck in the Mirrorer's input queue.

## Changes

Now the Mirrorer catches that exception, logs it, and lets the message die.

Also I added a line to `.gitignore` to cover the folder that is created when you run `pip install .`.