### PR TITLE
Delete cached downloads when a mod is frozen

### DIFF
--- a/netkan/netkan/webhooks/github_inflate.py
+++ b/netkan/netkan/webhooks/github_inflate.py
@@ -94,4 +94,14 @@ def freeze(ids: List[str]) -> None:
             except ModStatus.DoesNotExist:
                 # No status, don't need to freeze
                 pass
+            # Delete cached downloads
+            cached_downloads = list(filter(
+                None,
+                (ck.cache_find_file
+                 for ck in current_config.ckm_repo.ckans(ident))))
+            if cached_downloads:
+                logging.info('Purging %s files from cache for %s',
+                             len(cached_downloads), ident)
+                for download in cached_downloads:
+                    download.unlink()
         logging.info('Done!')


### PR DESCRIPTION
## Problem

![image](https://user-images.githubusercontent.com/1559108/164317181-d3641121-f4ed-4004-90ee-134fef5bef90.png)

## Cause

The disk may be full, but I'm skeptical of that because this download is only 278 MB:

https://github.com/SpaceODY/PRVE/releases/tag/v1.7.1

Regardless, I had an idea for saving space.

## Changes

Now when we freeze a mod, we remove its downloads from the bot's cache, since they won't be needed for future bot passes. This should help to reduce the risk of the disk filling up. If we need to unfreeze the mod in the future, then it would be re-downloaded at that time.

This will only affect freshly frozen mods; we will not attempt to purge mods that were frozen in the past.
