### PR TITLE
Trigger CKAN repo deploy workflow on deploy

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -61,21 +61,30 @@ jobs:
     runs-on: ubuntu-latest
     needs: [ 'build', 'webhooks' ]
     steps:
-    - uses: actions/checkout@v1
-    - name: Set up Python 3.7
-      uses: actions/setup-python@v1
-      with:
-        python-version: 3.7
-    - name: Install Dependencies
-      run: |
-        pip install netkan/.
-    - name: Re-deploy Containers
-      env:
-        AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
-        AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-        AWS_DEFAULT_REGION: ${{ secrets.AWS_DEFAULT_REGION }}
-      run: |
-        netkan redeploy-service --cluster NetKANCluster --service-name Indexer
-        netkan redeploy-service --cluster NetKANCluster --service-name Webhooks
-        netkan redeploy-service --cluster NetKANCluster --service-name Adder
-        netkan redeploy-service --cluster NetKANCluster --service-name Mirrorer
+      - uses: actions/checkout@v1
+      - name: Set up Python 3.7
+        uses: actions/setup-python@v1
+        with:
+          python-version: 3.7
+      - name: Install Dependencies
+        run: |
+          pip install netkan/.
+      - name: Re-deploy Containers
+        env:
+          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          AWS_DEFAULT_REGION: ${{ secrets.AWS_DEFAULT_REGION }}
+        run: |
+          netkan redeploy-service --cluster NetKANCluster --service-name Indexer
+          netkan redeploy-service --cluster NetKANCluster --service-name Webhooks
+          netkan redeploy-service --cluster NetKANCluster --service-name Adder
+          netkan redeploy-service --cluster NetKANCluster --service-name Mirrorer
+      - name: CKAN repo dispatch
+        env:
+          REPO_ACCESS_TOKEN: ${{ secrets.REPO_ACCESS_TOKEN }}
+        if: env.REPO_ACCESS_TOKEN
+        uses: peter-evans/repository-dispatch@v2
+        with:
+          repository: KSP-CKAN/CKAN
+          event-type: deploy
+          token: ${{ secrets.REPO_ACCESS_TOKEN }}


### PR DESCRIPTION
## Motivation

If this repo changes in a way that affects the metadata validator image, we would have to trigger the CKAN repo's `deploy` workflow manually, which is inconvenient, easy to forget, and non-discoverable for new maintainers.

## Background

KSP-CKAN/CKAN#3575 is adding a repository dispatch `deploy` event that other repositories will be able to use to trigger that workflow programmatically. That pull request should be merged before this one, so the trigger will be available when we try to use it.

This Action can be used for the triggering:

https://github.com/peter-evans/repository-dispatch

## Changes

Now a new step at the end of the `deploy` job of the `deploy` workflow triggers the `deploy` repo dispatch event in the CKAN repo so the metadata validation image will be rebuilt.

Note that this required adding a `REPO_ACCESS_TOKEN` secret to this repo containing a [Personal Access Token](https://docs.github.com/en/github/authenticating-to-github/creating-a-personal-access-token) with `public_repo` scope and `write` access to the CKAN repo. This has been done.

The indenting in the `deploy.yml` file is also now more consistent.