### PR TITLE
Skip broken internetarchive release

### DIFF
--- a/netkan/setup.py
+++ b/netkan/setup.py
@@ -22,7 +22,7 @@ setup(
         'requests',
         'flask',
         'jinja2',
-        'internetarchive',
+        'internetarchive!=3.0.1',
         'gunicorn>=19.9,!=20.0.0',
         'discord.py>=1.6.0',
         'PyGithub',


### PR DESCRIPTION
## Problem

The build of the metadata validator image failed after KSP-CKAN/xKAN-meta_testing#87:

https://github.com/KSP-CKAN/CKAN/commit/1ad0b8289288b544d40c285de14c65a5b6f467e8/checks

```
    Traceback (most recent call last):
      File "<string>", line 1, in <module>
      File "/tmp/pip-install-q23j99vy/internetarchive/setup.py", line 3, in <module>
        setup()
      File "/usr/lib/python3/dist-packages/setuptools/__init__.py", line 145, in setup
        return distutils.core.setup(**attrs)
      File "/usr/lib/python3.7/distutils/core.py", line 121, in setup
        dist.parse_config_files()
      File "/usr/lib/python3/dist-packages/setuptools/dist.py", line 705, in parse_config_files
        ignore_option_errors=ignore_option_errors)
      File "/usr/lib/python3/dist-packages/setuptools/config.py", line 120, in parse_configuration
        meta.parse()
      File "/usr/lib/python3/dist-packages/setuptools/config.py", line 425, in parse
        section_parser_method(section_options)
      File "/usr/lib/python3/dist-packages/setuptools/config.py", line 398, in parse_section
        self[name] = value
      File "/usr/lib/python3/dist-packages/setuptools/config.py", line 183, in __setitem__
        value = parser(value)
      File "/usr/lib/python3/dist-packages/setuptools/config.py", line 513, in _parse_version
        version = self._parse_attr(value, self.package_dir)
      File "/usr/lib/python3/dist-packages/setuptools/config.py", line 348, in _parse_attr
        module = import_module(module_name)
      File "/usr/lib/python3.7/importlib/__init__.py", line 127, in import_module
        return _bootstrap._gcd_import(name[level:], package, level)
      File "<frozen importlib._bootstrap>", line 1006, in _gcd_import
      File "<frozen importlib._bootstrap>", line 983, in _find_and_load
      File "<frozen importlib._bootstrap>", line 967, in _find_and_load_unlocked
      File "<frozen importlib._bootstrap>", line 677, in _load_unlocked
      File "<frozen importlib._bootstrap_external>", line 728, in exec_module
      File "<frozen importlib._bootstrap>", line 219, in _call_with_frames_removed
      File "/tmp/pip-install-q23j99vy/internetarchive/internetarchive/__init__.py", line 42, in <module>
        from internetarchive.api import (
      File "/tmp/pip-install-q23j99vy/internetarchive/internetarchive/api.py", line 33, in <module>
        import requests
    ModuleNotFoundError: No module named 'requests'
```

## Cause

See pypa/setuptools#1724 and jjjake/internetarchive#533 and jjjake/internetarchive#534, `internetarchive`'s current release (3.0.1) is broken due to some kind of interaction with `setuptools`. Whatever the details, a fix was just merged.

## Changes

Now we depend on any version of `internetarchive` other than 3.0.1. This should revert to the previous working release for now, and then use any future releases that include the fix.
