### PR TITLE
Remove stack trace from PR errors

### DIFF
--- a/netkan/netkan/github_pr.py
+++ b/netkan/netkan/github_pr.py
@@ -21,7 +21,7 @@ class GitHubPR:
 
         except GithubException as exc:
             logging.error('Pull request for %s failed: %s',
-                          branch, self.get_error_message(exc.data), exc_info=exc)
+                          branch, self.get_error_message(exc.data))
 
     @staticmethod
     def get_error_message(exc_data: Dict[str, Any]) -> str:


### PR DESCRIPTION
## Problem

Several of these came in recently while the aftermath of KSP-CKAN/CKAN#3568 was winding down:

![image](https://user-images.githubusercontent.com/1559108/182931723-4883fa96-c7f6-4b86-bf30-ed1f91699790.png)

It's correct for an error to be reported here, since the Indexer _should_ be trying to create pull requests, which should fail if they've already been created. But the stack trace is just visual clutter; we don't gain anything from knowing which lines of the PyGithub library were involved in trying to create the pull request.

## Changes

Now we don't pass the exception in the `exc_info` param, so the stack trace won't be printed. Only the error message on the first line will go to Discord, which is enough information for us to know what happened.
