### PR TITLE
Timeouts for requests calls

### DIFF
--- a/netkan/netkan/common.py
+++ b/netkan/netkan/common.py
@@ -48,6 +48,7 @@ def download_stream_to_file(download_url: str, dest_file: IO[bytes]) -> None:
     # Get big files in little chunks
     with requests.get(download_url,
                       headers={'User-Agent': USER_AGENT},
-                      stream=True) as req:
+                      stream=True,
+                      timeout=60) as req:
         for chunk in req.iter_content(chunk_size=8192):
             dest_file.write(chunk)

--- a/netkan/netkan/download_counter.py
+++ b/netkan/netkan/download_counter.py
@@ -94,9 +94,10 @@ class GraphQLQuery:
 
     def graphql_to_github(self, query: str) -> Dict[str, Any]:
         logging.info('Contacting GitHub')
-        return requests.post(self.GITHUB_API, headers={
-            'Authorization': f'bearer {self.github_token}'
-        }, json={'query': query}).json()
+        return requests.post(self.GITHUB_API,
+                             headers={'Authorization': f'bearer {self.github_token}'},
+                             json={'query': query},
+                             timeout=60).json()
 
     def sum_graphql_result(self, apidata: Dict[str, Any]) -> int:
         total = 0
@@ -127,7 +128,7 @@ class SpaceDockBatchedQuery:
         }
 
     def query_to_spacedock(self, query: Dict[str, Any]) -> Dict[str, Any]:
-        return requests.post(self.SPACEDOCK_API, data=query).json()
+        return requests.post(self.SPACEDOCK_API, data=query, timeout=60).json()
 
     def get_result(self, counts: Optional[Dict[str, int]]) -> Dict[str, int]:
         if not counts:

--- a/netkan/netkan/scheduler.py
+++ b/netkan/netkan/scheduler.py
@@ -107,9 +107,8 @@ class NetkanScheduler:
 
             end = datetime.datetime.utcnow()
             start = end - datetime.timedelta(minutes=10)
-            response = requests.get(
-                'http://169.254.169.254/latest/meta-data/instance-id'
-            )
+            response = requests.get('http://169.254.169.254/latest/meta-data/instance-id',
+                                    timeout=60)
             instance_id = response.text
             cloudwatch = boto3.client('cloudwatch')
 


### PR DESCRIPTION
## Problem

Deploy of #228 to master failed at Pylint:

https://github.com/KSP-CKAN/NetKAN-Infra/runs/8139758553

```
#24 25.58 =================================== FAILURES ===================================
#24 25.58 __________________________ [pylint] netkan/common.py ___________________________
#24 25.58 W: 49, 9: Missing timeout argument for method 'requests.get' can cause your program to hang indefinitely (missing-timeout)
#24 25.58 _____________________ [pylint] netkan/download_counter.py ______________________
#24 25.58 W: 97,15: Missing timeout argument for method 'requests.post' can cause your program to hang indefinitely (missing-timeout)
#24 25.58 W:130,15: Missing timeout argument for method 'requests.post' can cause your program to hang indefinitely (missing-timeout)
#24 25.58 _________________________ [pylint] netkan/scheduler.py _________________________
#24 25.58 W:110,23: Missing timeout argument for method 'requests.get' can cause your program to hang indefinitely (missing-timeout)
```

## Cause

Apparently `timeout` is a strongly recommended parameter according to recent versions of Pylint.

## Changes

Now we pass `timeout=60` in those places.

I'll self review this and merge to see if the deploy works.
