### PR TITLE
Add GitLab token secret

### DIFF
--- a/prod-stack.py
+++ b/prod-stack.py
@@ -744,7 +744,7 @@ services = [
         'name': 'Inflator',
         'image': 'kspckan/inflator',
         'memory': '256',
-        'secrets': ['GH_Token'],
+        'secrets': ['GH_Token', 'GL_Token'],
         'env': [
             (
                 'QUEUES', Sub(


### PR DESCRIPTION
## Motivation

In KSP-CKAN/CKAN#3661 we added the ability to index mods hosted on GitLab. This included the ability to provide a GitLab authentication token from the command line, but the Inflator isn't using this capability yet. We should add that eventually for completeness, see https://github.com/KSP-CKAN/CKAN/pull/3661#discussion_r966544529.

## Changes

Now if the container configuration has a `GL_Token` secret, it will be provided to the inflator.
Another pull request in the CKAN repo will handle passing the env var to the command line.
