### PR TITLE
Check scheduler limits before cloning repos

### DIFF
--- a/netkan/netkan/cli/common.py
+++ b/netkan/netkan/cli/common.py
@@ -63,6 +63,7 @@ class SharedArgs:
         self._ckanmeta_repo: Optional[CkanMetaRepo] = None
         self._netkan_repo: Optional[NetkanRepo] = None
         self._github_pr: Optional[GitHubPR] = None
+        self.deep_clone = False
 
     def __getattribute__(self, name: str) -> Any:
         attr = super().__getattribute__(name)

--- a/netkan/netkan/cli/services.py
+++ b/netkan/netkan/cli/services.py
@@ -57,7 +57,7 @@ def indexer(common: SharedArgs) -> None:
 @pass_state
 def scheduler(common: SharedArgs, max_queued: int, group: str, min_cpu: int, min_io: int) -> None:
     sched = NetkanScheduler(
-        common.netkan_repo, common.ckanmeta_repo, common.queue, common.token,
+        common, common.queue, common.token,
         nonhooks_group=(group in ('all', 'nonhooks')),
         webhooks_group=(group in ('all', 'webhooks')),
     )

--- a/netkan/netkan/scheduler.py
+++ b/netkan/netkan/scheduler.py
@@ -8,14 +8,14 @@ import requests
 from .repos import NetkanRepo, CkanMetaRepo
 from .metadata import Netkan
 from .common import sqs_batch_entries, github_limit_remaining
+from .cli.common import SharedArgs
 
 
 class NetkanScheduler:
 
-    def __init__(self, nk_repo: NetkanRepo, ckm_repo: CkanMetaRepo, queue: str, github_token: str,
+    def __init__(self, common: SharedArgs, queue: str, github_token: str,
                  nonhooks_group: bool = False, webhooks_group: bool = False) -> None:
-        self.nk_repo = nk_repo
-        self.ckm_repo = ckm_repo
+        self.common = common
         self.nonhooks_group = nonhooks_group
         self.webhooks_group = webhooks_group
         self.github_token = github_token
@@ -27,6 +27,14 @@ class NetkanScheduler:
             sqs = boto3.resource('sqs')
             self.queue = sqs.get_queue_by_name(QueueName=queue)
             self.queue_url = self.queue.url
+
+    @property
+    def nk_repo(self) -> NetkanRepo:
+        return self.common.netkan_repo
+
+    @property
+    def ckm_repo(self) -> CkanMetaRepo:
+        return self.common.ckanmeta_repo
 
     def sqs_batch_attrs(self, batch: List[Dict[str, Any]]) -> Dict[str, Any]:
         return {


### PR DESCRIPTION
## Problem

During periods of low system resource availability, the Scheduler can fail before it even checks whether it's supposed to run:

```
Uncaught exception:
Traceback (most recent call last):
  File ".local/bin/netkan", line 8, in <module>
    sys.exit(netkan())
  File "/home/netkan/.local/lib/python3.7/site-packages/click/core.py", line 1130, in __call__
    return self.main(*args, **kwargs)
  File "/home/netkan/.local/lib/python3.7/site-packages/click/core.py", line 1055, in main
    rv = self.invoke(ctx)
  File "/home/netkan/.local/lib/python3.7/site-packages/click/core.py", line 1657, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/home/netkan/.local/lib/python3.7/site-packages/click/core.py", line 1404, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "/home/netkan/.local/lib/python3.7/site-packages/click/core.py", line 760, in invoke
    return __callback(*args, **kwargs)
  File "/home/netkan/.local/lib/python3.7/site-packages/click/decorators.py", line 84, in new_func
    return ctx.invoke(f, obj, *args, **kwargs)
  File "/home/netkan/.local/lib/python3.7/site-packages/click/core.py", line 760, in invoke
    return __callback(*args, **kwargs)
  File "/home/netkan/.local/lib/python3.7/site-packages/netkan/cli/services.py", line 60, in scheduler
    common.netkan_repo, common.ckanmeta_repo, common.queue, common.token,
  File "/home/netkan/.local/lib/python3.7/site-packages/netkan/cli/common.py", line 68, in __getattribute__
    attr = super().__getattribute__(name)
  File "/home/netkan/.local/lib/python3.7/site-packages/netkan/cli/common.py", line 101, in ckanmeta_repo
    init_repo(self._ckanmeta_remote, '/tmp/CKAN-meta', self.deep_clone))
  File "/home/netkan/.local/lib/python3.7/site-packages/netkan/utils.py", line 14, in init_repo
    Repo.clone_from(metadata, clone_path, depth=1))
  File "/home/netkan/.local/lib/python3.7/site-packages/git/repo/base.py", line 1275, in clone_from
    return cls._clone(git, url, to_path, GitCmdObjectDB, progress, multi_options, **kwargs)
  File "/home/netkan/.local/lib/python3.7/site-packages/git/repo/base.py", line 1194, in _clone
    finalize_process(proc, stderr=stderr)
  File "/home/netkan/.local/lib/python3.7/site-packages/git/util.py", line 419, in finalize_process
    proc.wait(**kwargs)
  File "/home/netkan/.local/lib/python3.7/site-packages/git/cmd.py", line 559, in wait
    raise GitCommandError(remove_password_if_present(self.args), status, errstr)
git.exc.GitCommandError: Cmd('git') failed due to: exit code(128)
  cmdline: git clone -v --depth=1 git@github.com:KSP-CKAN/CKAN-meta.git /tmp/CKAN-meta
  stderr: 'Cloning into '/tmp/CKAN-meta'...
```

## Cause

`NetkanScheduler.can_schedule` is responsible for checking whether we have sufficient resources to run a pass of the Inflator. However, before it even calls that, the Scheduler does a full clone of the NetKAN and CKAN-meta repos. This clone can fail if we're low on allowed bandwidth.

This also makes recovery slower when we're past the limits, because we do ~260 MiB of unnecesssary traffic every 30 minutes, only to quit immediately!

## Changes

Now the Scheduler only clones the repos if it's going to run. Since `SharedArgs` already has public on-demand properties providing these, `NetkanScheduler` now saves a reference to a `ShartedArgs` object and uses those properties.

Fixes #279 (or at least it ties up the last loose end after the problem stopped).

- [x] I'll figure out why the tests are failing after submitting this.
