### PR TITLE
Better AutoFreezer PR continuation

### DIFF
--- a/netkan/netkan/download_counter.py
+++ b/netkan/netkan/download_counter.py
@@ -5,7 +5,7 @@ from pathlib import Path
 from importlib.resources import read_text
 from string import Template
 import urllib.parse
-from typing import Dict, Tuple, Any
+from typing import Dict, Tuple, Any, Optional
 
 import requests
 
@@ -90,7 +90,7 @@ class GraphQLQuery:
         """
         return fake_ident[1:].replace("_", "-")
 
-    def get_result(self, counts: Dict[str, int] = None) -> Dict[str, int]:
+    def get_result(self, counts: Optional[Dict[str, int]] = None) -> Dict[str, int]:
         if counts is None:
             counts = {}
         logging.info('Running GraphQL query')
@@ -155,7 +155,7 @@ class SpaceDockBatchedQuery:
     def query_to_spacedock(self, query: Dict[str, Any]) -> Dict[str, Any]:
         return requests.post(self.SPACEDOCK_API, data=query, timeout=60).json()
 
-    def get_result(self, counts: Dict[str, int] = None) -> Dict[str, int]:
+    def get_result(self, counts: Optional[Dict[str, int]] = None) -> Dict[str, int]:
         if counts is None:
             counts = {}
         full_query = self.get_query()
@@ -195,7 +195,7 @@ class InternetArchiveBatchedQuery:
     def add(self, ckan: Ckan) -> None:
         self.ids[ckan.identifier] = self._get_ia_ident(ckan)
 
-    def get_result(self, counts: Dict[str, int] = None) -> Dict[str, int]:
+    def get_result(self, counts: Optional[Dict[str, int]] = None) -> Dict[str, int]:
         if counts is None:
             counts = {}
         result = requests.get(self.IARCHIVE_API + ','.join(self.ids.values()),

--- a/netkan/netkan/github_pr.py
+++ b/netkan/netkan/github_pr.py
@@ -22,6 +22,9 @@ class GitHubPR:
         except GithubException as exc:
             logging.error('Pull request for %s failed: %s',
                           branch, self.get_error_message(exc.data))
+            for pull in self.repo.get_pulls(head=f'{self.repo.owner}:{branch}'):
+                # Post description as a comment if pull request exists
+                pull.create_issue_comment(body)
 
     @staticmethod
     def get_error_message(exc_data: Dict[str, Any]) -> str:

--- a/netkan/netkan/indexer.py
+++ b/netkan/netkan/indexer.py
@@ -19,7 +19,7 @@ from .github_pr import GitHubPR
 class CkanMessage:
 
     def __init__(self, msg: 'boto3.resources.factory.sqs.Message',
-                 ckm_repo: CkanMetaRepo, github_pr: GitHubPR = None) -> None:
+                 ckm_repo: CkanMetaRepo, github_pr: Optional[GitHubPR] = None) -> None:
         self.body = msg.body
         self.ckan = Ckan(contents=self.body)
         # pylint: disable=invalid-name
@@ -36,7 +36,7 @@ class CkanMessage:
             attr_type = f'{item[1]["DataType"]}Value'
             content = item[1][attr_type]
             if content.lower() in ['true', 'false']:
-                content = (content.lower() == 'true')
+                content = content.lower() == 'true'
             if item[0] == 'FileName':
                 content = PurePath(content).name
             setattr(self, item[0], content)
@@ -163,7 +163,7 @@ class CkanMessage:
 
 class MessageHandler:
 
-    def __init__(self, repo: CkanMetaRepo, github_pr: GitHubPR = None) -> None:
+    def __init__(self, repo: CkanMetaRepo, github_pr: Optional[GitHubPR] = None) -> None:
         self.ckm_repo = repo
         self.github_pr = github_pr
         self.master: Deque[CkanMessage] = deque()

--- a/netkan/netkan/metadata.py
+++ b/netkan/netkan/metadata.py
@@ -16,7 +16,7 @@ class Netkan:
 
     KREF_PATTERN = re.compile('^#/ckan/([^/]+)/(.+)$')
 
-    def __init__(self, filename: Union[str, Path] = None, contents: str = None) -> None:
+    def __init__(self, filename: Optional[Union[str, Path]] = None, contents: Optional[str] = None) -> None:
         if filename:
             self.filename = Path(filename)
             self.contents = self.filename.read_text(encoding='UTF-8')
@@ -84,13 +84,13 @@ class Netkan:
             'StringValue': val,
         }
 
-    def sqs_message_attribs(self, high_ver: 'Ckan.Version' = None) -> Dict[str, Any]:
+    def sqs_message_attribs(self, high_ver: Optional['Ckan.Version'] = None) -> Dict[str, Any]:
         attribs = {}
         if high_ver and not getattr(self, 'x_netkan_allow_out_of_order', False):
             attribs['HighestVersion'] = self.string_attrib(high_ver.string)
         return attribs
 
-    def sqs_message(self, high_ver: 'Ckan.Version' = None) -> Dict[str, Any]:
+    def sqs_message(self, high_ver: Optional['Ckan.Version'] = None) -> Dict[str, Any]:
         hex_id = uuid.uuid4().hex
         return {
             'Id': hex_id,
@@ -112,7 +112,7 @@ class Ckan:
             self.string = version_string
             match = self.PATTERN.fullmatch(self.string)
             if not match:
-                raise Exception('Invalid version format')
+                raise ValueError('Invalid version format')
             if match.group('epoch') and match.group('epoch').isnumeric():
                 self.epoch = int(match.group('epoch'))
             else:
@@ -121,7 +121,7 @@ class Ckan:
                 self.epoch = 0
             self.bare_version = match.group('version')
             if self.bare_version is None:
-                raise Exception
+                raise ValueError
 
         # @total_ordering doesn't generate this one right. Maybe it compares the strings?
         def __eq__(self, other: object) -> bool:
@@ -175,9 +175,9 @@ class Ckan:
                             _result = 0
                     else:
                         # Do an artificial __cmp__
-                        _result = ((str1 > str2) - (str1 < str2))
+                        _result = (str1 > str2) - (str1 < str2)
                 else:
-                    _result = ((str1 > str2) - (str1 < str2))
+                    _result = (str1 > str2) - (str1 < str2)
 
                 return _result, _first_remainder, _second_remainder
 
@@ -210,7 +210,7 @@ class Ckan:
                 else:
                     integer2 = 0
 
-                _result = ((integer1 > integer2) - (integer1 < integer2))
+                _result = (integer1 > integer2) - (integer1 < integer2)
                 return _result, _first_remainder, _second_remainder
 
             # Here begins the main comparison logic
@@ -269,7 +269,7 @@ class Ckan:
         'release_date'
     ]
 
-    def __init__(self, filename: Union[str, Path] = None, contents: str = None) -> None:
+    def __init__(self, filename: Optional[Union[str, Path]] = None, contents: Optional[str] = None) -> None:
         if filename:
             self.filename = Path(filename)
             self.contents = self.filename.read_text(encoding='UTF-8')
@@ -304,7 +304,7 @@ class Ckan:
     def version(self) -> Version:
         raw_ver = self._raw.get('version')
         if not raw_ver:
-            raise Exception('Required property `version` not found')
+            raise AttributeError('Required property `version` not found')
         return self.Version(raw_ver)
 
     @property

--- a/netkan/netkan/mirrorer.py
+++ b/netkan/netkan/mirrorer.py
@@ -134,7 +134,7 @@ class CkanMirror(Ckan):
 
     EPOCH_VERSION_REGEXP = re.compile('^[0-9]+:')
 
-    def __init__(self, collection: str, filename: Union[str, Path] = None, contents: str = None) -> None:
+    def __init__(self, collection: str, filename: Optional[Union[str, Path]] = None, contents: Optional[str] = None) -> None:
         Ckan.__init__(self, filename, contents)
         self.collection = collection
 
@@ -280,7 +280,7 @@ class Mirrorer:
     EPOCH_ID_REGEXP = re.compile('-[0-9]+-')
     EPOCH_TITLE_REGEXP = re.compile(' - [0-9]+:')
 
-    def __init__(self, ckm_repo: CkanMetaRepo, ia_access: str, ia_secret: str, ia_collection: str, token: str = None) -> None:
+    def __init__(self, ckm_repo: CkanMetaRepo, ia_access: str, ia_secret: str, ia_collection: str, token: Optional[str] = None) -> None:
         self.ckm_repo = ckm_repo
         self.ia_collection = ia_collection
         self.ia_access = ia_access

--- a/netkan/netkan/spacedock_adder.py
+++ b/netkan/netkan/spacedock_adder.py
@@ -22,7 +22,7 @@ class SpaceDockAdder:
 
     PR_BODY_TEMPLATE = Template(read_text('netkan', 'pr_body_template.md'))
 
-    def __init__(self, queue: str, timeout: int, nk_repo: NetkanRepo, github_pr: GitHubPR = None) -> None:
+    def __init__(self, queue: str, timeout: int, nk_repo: NetkanRepo, github_pr: Optional[GitHubPR] = None) -> None:
         sqs = boto3.resource('sqs')
         self.sqs_client = boto3.client('sqs')
         self.queue = sqs.get_queue_by_name(QueueName=queue)


### PR DESCRIPTION
## Problem

I let KSP-CKAN/NetKAN#9471 sit without review for quite a while, and in the meantime we had 9 weekly checks go by without any new commits pushed. Probably quite a few abandoned mods have slipped through the cracks, which we should probably catch up at some point.

## Cause

The branch checkout logic in the AutoFreezer was trying to re-use an existing branch if there was one, but it was missing a step: it fetched the remote branch, and it tried to check it out, but it never created a local branch corresponding to the remote branch. So checking it out failed, and it always fell back to creating a new branch. Then later the attempt to push to the server would fail because the branch already existed with conflicts.

## Changes

- Now the AutoFreezer uses the shared `NetkanRepo.change_branch` function instead of rolling its own version of that logic, which will fix the problem and reduce code duplication
- To help with review, the bot will now post its intended PR body as a comment when it pushes commits to an existing open PR. This way the person reviewing will see the table of the newly added mods with their last update and links.

This way if we miss a week of review, the next week's idle mods will get cleanly added on to the existing PR, and none will be missed.

Note that this branch shares the test-fixes commit with #280, but not the one with that PR's actual functionality. I think we can merge either one first or not at all and the other one should be fine to continue or not.