### PR TITLE
Switch to main branches and support KSP2

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -3,7 +3,7 @@ name: Deploy NetKAN-Infra
 on:
   push:
     branches:
-      - master
+      - main
 
 jobs:
   build:

--- a/README.md
+++ b/README.md
@@ -16,8 +16,8 @@ Every once in a while, the Scheduler kicks off and submits NetKAN metadata for t
 
 The core of the system, it has the job to _inflate_ NetKAN metadata to CKAN metadata as described in the [Schema] and [Spec].
 
-[Spec]: https://github.com/KSP-CKAN/CKAN/blob/master/Spec.md
-[Schema]: https://github.com/KSP-CKAN/CKAN/blob/master/CKAN.schema
+[Spec]: https://github.com/KSP-CKAN/CKAN/blob/main/Spec.md
+[Schema]: https://github.com/KSP-CKAN/CKAN/blob/main/CKAN.schema
 
 #### Indexer
 
@@ -76,16 +76,16 @@ Cert Bot         | certbot/dns-route53    | certbot/certbot |
 
 [Webhooks]: #Webhooks
 
-[netkan/netkan/scheduler.py]: https://github.com/KSP-CKAN/NetKAN-Infra/blob/master/netkan/netkan/scheduler.py
-[Netkan/Processors/QueueHandler.cs]: https://github.com/KSP-CKAN/CKAN/blob/master/Netkan/Processors/QueueHandler.cs
-[netkan/netkan/indexer.py]: https://github.com/KSP-CKAN/NetKAN-Infra/blob/master/netkan/netkan/indexer.py
-[netkan/netkan/mirrorer.py]: https://github.com/KSP-CKAN/NetKAN-Infra/blob/master/netkan/netkan/mirrorer.py
-[netkan/netkan/download_counter.py]: https://github.com/KSP-CKAN/NetKAN-Infra/blob/master/netkan/netkan/download_counter.py
-[netkan/netkan/spacedock_adder.py]: https://github.com/KSP-CKAN/NetKAN-Infra/blob/master/netkan/netkan/spacedock_adder.py
-[netkan/netkan/ticket_closer.py]: https://github.com/KSP-CKAN/NetKAN-Infra/blob/master/netkan/netkan/ticket_closer.py
-[netkan/netkan/auto_freezer.py]: https://github.com/KSP-CKAN/NetKAN-Infra/blob/master/netkan/netkan/auto_freezer.py
-[netkan/netkan/cli/utilities.py]: https://github.com/KSP-CKAN/NetKAN-Infra/blob/master/netkan/netkan/cli/utilities.py
-[netkan/netkan/webhooks]: https://github.com/KSP-CKAN/NetKAN-Infra/blob/master/netkan/netkan/webhooks
+[netkan/netkan/scheduler.py]: https://github.com/KSP-CKAN/NetKAN-Infra/blob/main/netkan/netkan/scheduler.py
+[Netkan/Processors/QueueHandler.cs]: https://github.com/KSP-CKAN/CKAN/blob/main/Netkan/Processors/QueueHandler.cs
+[netkan/netkan/indexer.py]: https://github.com/KSP-CKAN/NetKAN-Infra/blob/main/netkan/netkan/indexer.py
+[netkan/netkan/mirrorer.py]: https://github.com/KSP-CKAN/NetKAN-Infra/blob/main/netkan/netkan/mirrorer.py
+[netkan/netkan/download_counter.py]: https://github.com/KSP-CKAN/NetKAN-Infra/blob/main/netkan/netkan/download_counter.py
+[netkan/netkan/spacedock_adder.py]: https://github.com/KSP-CKAN/NetKAN-Infra/blob/main/netkan/netkan/spacedock_adder.py
+[netkan/netkan/ticket_closer.py]: https://github.com/KSP-CKAN/NetKAN-Infra/blob/main/netkan/netkan/ticket_closer.py
+[netkan/netkan/auto_freezer.py]: https://github.com/KSP-CKAN/NetKAN-Infra/blob/main/netkan/netkan/auto_freezer.py
+[netkan/netkan/cli/utilities.py]: https://github.com/KSP-CKAN/NetKAN-Infra/blob/main/netkan/netkan/cli/utilities.py
+[netkan/netkan/webhooks]: https://github.com/KSP-CKAN/NetKAN-Infra/blob/main/netkan/netkan/webhooks
 
 ### Queues
 
@@ -146,7 +146,7 @@ Route                     | Parameters                                          
 
 [push API]: https://developer.github.com/webhooks/event-payloads/#push
 [release API]: https://developer.github.com/webhooks/event-payloads/#release
-[Adder code comments]: https://github.com/KSP-CKAN/NetKAN-Infra/blob/master/netkan/netkan/webhooks/spacedock_add.py#L12-L25
+[Adder code comments]: https://github.com/KSP-CKAN/NetKAN-Infra/blob/main/netkan/netkan/webhooks/spacedock_add.py#L12-L25
 
 ## Developing
 

--- a/netkan/netkan/auto_freezer.py
+++ b/netkan/netkan/auto_freezer.py
@@ -16,7 +16,7 @@ class AutoFreezer:
         self.github_pr = github_pr
 
     def freeze_idle_mods(self, days_limit: int, days_till_ignore: int) -> None:
-        self.nk_repo.git_repo.remotes.origin.pull('master', strategy_option='ours')
+        self.nk_repo.git_repo.remotes.origin.pull('main', strategy_option='ours')
         idle_mods = self._find_idle_mods(days_limit, days_till_ignore)
         if idle_mods:
             with self.nk_repo.change_branch(self.BRANCH_NAME):

--- a/netkan/netkan/common.py
+++ b/netkan/netkan/common.py
@@ -30,7 +30,7 @@ def sqs_batch_entries(messages: Iterable[Dict[str, str]],
 
 def pull_all(repos: Iterable[Repo]) -> None:
     for repo in repos:
-        repo.remotes.origin.pull('master', strategy_option='theirs')
+        repo.remotes.origin.pull('main', strategy_option='theirs')
 
 
 def github_limit_remaining(token: str) -> int:

--- a/netkan/netkan/download_counter.py
+++ b/netkan/netkan/download_counter.py
@@ -278,13 +278,13 @@ class DownloadCounter:
                 'NetKAN Updating Download Counts'
             )
             logging.info('Download counts changed and committed')
-            self.ckm_repo.git_repo.remotes.origin.push('master')
+            self.ckm_repo.git_repo.remotes.origin.push('main')
 
     def update_counts(self) -> None:
         if self.output_file:
             self.get_counts()
             self.ckm_repo.git_repo.remotes.origin.pull(
-                'master', strategy_option='ours'
+                'main', strategy_option='ours'
             )
             self.write_json()
             if repo_file_add_or_changed(self.ckm_repo.git_repo, self.output_file):

--- a/netkan/netkan/github_pr.py
+++ b/netkan/netkan/github_pr.py
@@ -12,7 +12,7 @@ class GitHubPR:
 
     def create_pull_request(self, title: str, branch: str, body: str, labels: Optional[List[str]] = None) -> None:
         try:
-            pull = self.repo.create_pull(title, body, 'master', branch)
+            pull = self.repo.create_pull(title, body, 'main', branch)
             logging.info('Pull request for %s opened at %s', branch, pull.html_url)
 
             if labels:

--- a/netkan/netkan/indexer.py
+++ b/netkan/netkan/indexer.py
@@ -196,7 +196,7 @@ class MessageHandler:
             self.github_pr
         )
         if not ckan.Staged:
-            self.mamainster.append(ckan)
+            self.main.append(ckan)
         else:
             self.staged.append(ckan)
 

--- a/netkan/netkan/metadata.py
+++ b/netkan/netkan/metadata.py
@@ -328,7 +328,7 @@ class Ckan:
             return None
         return f'{self.cache_prefix}-{self.identifier}-{self.version.string.replace(":", "-")}.{self.MIME_TO_EXTENSION[self.download_content_type]}'
 
-    def source_download(self, branch: str = 'master') -> Optional[str]:
+    def source_download(self, branch: str = 'main') -> Optional[str]:
         # self?.resources?.repository
         repository = getattr(self, 'resources', {}).get('repository', None)
         if repository:

--- a/netkan/netkan/mirrorer.py
+++ b/netkan/netkan/mirrorer.py
@@ -307,8 +307,8 @@ class Mirrorer:
                     continue
                 # Get up to date copy of the metadata for the files we're mirroring
                 logging.info('Updating repo')
-                self.ckm_repo.git_repo.heads.master.checkout()
-                self.ckm_repo.git_repo.remotes.origin.pull('master', strategy_option='theirs')
+                self.ckm_repo.git_repo.heads.main.checkout()
+                self.ckm_repo.git_repo.remotes.origin.pull('main', strategy_option='theirs')
                 # Start processing the messages
                 to_delete = []
                 for msg in messages:
@@ -367,7 +367,7 @@ class Mirrorer:
                 # /HebaruSan/Astrogator/releases -> HebaruSan/Astrogator
                 full_name = '/'.join(parsed.path.split('/')[1:3])
                 return self._gh.get_repo(full_name).default_branch
-        return 'master'
+        return 'main'
 
     def purge_epochs(self, dry_run: bool) -> None:
         if dry_run:

--- a/netkan/netkan/repos.py
+++ b/netkan/netkan/repos.py
@@ -39,7 +39,7 @@ class XkanRepo:
         it doesn't quite mirror what Git will do directly. If the branch
         doesn't exist an 'AttributeError' will be thown.
 
-        repo.checkout_branch('master')
+        repo.checkout_branch('main')
         """
         branch = getattr(self.git_repo.heads, branch_name)
         branch.checkout()

--- a/netkan/netkan/spacedock_adder.py
+++ b/netkan/netkan/spacedock_adder.py
@@ -40,9 +40,9 @@ class SpaceDockAdder:
                 VisibilityTimeout=self.timeout,
             )
             if messages:
-                self.nk_repo.git_repo.heads.master.checkout()
+                self.nk_repo.git_repo.heads.main.checkout()
                 self.nk_repo.git_repo.remotes.origin.pull(
-                    'master', strategy_option='ours')
+                    'main', strategy_option='ours')
 
                 # Start processing the messages
                 to_delete = []
@@ -76,7 +76,7 @@ class SpaceDockAdder:
                 getattr(  # type: ignore[arg-type]
                     self.nk_repo.git_repo.remotes.origin.refs,
                     branch_name,
-                    self.nk_repo.git_repo.remotes.origin.refs.master
+                    self.nk_repo.git_repo.remotes.origin.refs.main
                 )
             )
         # Checkout branch

--- a/netkan/netkan/webhooks/github_mirror.py
+++ b/netkan/netkan/webhooks/github_mirror.py
@@ -19,7 +19,7 @@ github_mirror = Blueprint('github_mirror', __name__)  # pylint: disable=invalid-
 def mirror_hook() -> Tuple[Union[Response, str], int]:
     raw = request.get_json(silent=True)
     ref = raw.get('ref')  # type: ignore[union-attr]
-    expected_ref = current_config.ckm_repo.git_repo.heads.master.path
+    expected_ref = current_config.ckm_repo.git_repo.heads.main.path
     if ref != expected_ref:
         current_app.logger.info(
             "Wrong branch. Expected '%s', got '%s'", expected_ref, ref)

--- a/netkan/tests/indexer.py
+++ b/netkan/tests/indexer.py
@@ -50,7 +50,7 @@ class TestCkan(unittest.TestCase):
         cls.ckan_meta.index.add(cls.ckan_meta.untracked_files)
         cls.ckan_meta.index.commit('Test Data')
         cls.ckan_meta.create_remote('origin', upstream.as_posix())
-        cls.ckan_meta.remotes.origin.push('master:master')
+        cls.ckan_meta.remotes.origin.push('main:main')
         cls.ckm_repo = CkanMetaRepo(cls.ckan_meta)
         cls.message = CkanMessage(cls.msg, cls.ckm_repo)
 
@@ -175,12 +175,12 @@ class TestStagedCkan(TestUpdateCkan):
         self.assertTrue(self.message.Staged)
 
     def test_ckan_message_change_branch(self):
-        self.assertEqual(str(self.ckan_meta.active_branch), 'master')
+        self.assertEqual(str(self.ckan_meta.active_branch), 'main')
         with self.message.ckm_repo.change_branch(self.message.mod_version):
             self.assertEqual(
                 str(self.ckan_meta.active_branch), 'DogeCoinFlag-v1.02'
             )
-        self.assertEqual(str(self.ckan_meta.active_branch), 'master')
+        self.assertEqual(str(self.ckan_meta.active_branch), 'main')
 
     def test_ckan_message_status_attrs(self):
         attrs = self.message.status_attrs(new=True)

--- a/netkan/tests/repos.py
+++ b/netkan/tests/repos.py
@@ -27,7 +27,7 @@ class TestRepo(unittest.TestCase):
         cls.repo.index.add(cls.repo.untracked_files)
         cls.repo.index.commit('Test Data')
         cls.repo.create_remote('origin', cls.upstream.as_posix())
-        cls.repo.remotes.origin.push('master:master')
+        cls.repo.remotes.origin.push('main:main')
 
     @classmethod
     def tearDownClass(cls):
@@ -37,7 +37,7 @@ class TestRepo(unittest.TestCase):
     def tearDown(self):
         meta = self.repo
         meta.git.clean('-df')
-        meta.heads.master.checkout()
+        meta.heads.main.checkout()
         try:
             cleanup = meta.create_head('cleanup', 'HEAD~1')
             meta.head.reference = cleanup
@@ -56,16 +56,16 @@ class TestNetkanRepo(TestRepo):
         self.assertTrue(self.nk_repo.nk_path('DogeCoinFlag').exists())
 
     def test_active_branch(self):
-        self.assertEqual(self.nk_repo.active_branch, 'master')
+        self.assertEqual(self.nk_repo.active_branch, 'main')
 
     def test_is_active_branch(self):
-        self.assertTrue(self.nk_repo.is_active_branch('master'))
+        self.assertTrue(self.nk_repo.is_active_branch('main'))
         self.assertFalse(self.nk_repo.is_active_branch('some/other/branch'))
 
     def test_checkout_branch(self):
         with self.nk_repo.change_branch('a/branch'):
             pass
-        self.assertTrue(self.nk_repo.is_active_branch('master'))
+        self.assertTrue(self.nk_repo.is_active_branch('main'))
         self.nk_repo.checkout_branch('a/branch')
         self.assertTrue(self.nk_repo.is_active_branch('a/branch'))
 
@@ -73,16 +73,16 @@ class TestNetkanRepo(TestRepo):
         new_clone = Repo.init(Path(self.tmpdir.name, 'push_pull'))
         new_clone.create_remote('origin', self.upstream.as_posix())
         new_repo = NetkanRepo(new_clone)
-        new_repo.pull_remote_branch('master')
+        new_repo.pull_remote_branch('main')
         Path(new_repo.nk_dir, 'test_pushpull_file').write_text('I can haz cheezburger')
         new_repo.commit(new_repo.git_repo.untracked_files, 'Pls')
-        new_repo.push_remote_branch('master')
+        new_repo.push_remote_branch('main')
         self.assertFalse(Path(self.nk_repo.nk_dir, 'test_pushpull_file').exists())
-        self.nk_repo.pull_remote_branch('master')
+        self.nk_repo.pull_remote_branch('main')
         self.assertTrue(Path(self.nk_repo.nk_dir, 'test_pushpull_file').exists())
 
     def test_change_branch(self):
-        self.assertTrue(self.nk_repo.is_active_branch('master'))
+        self.assertTrue(self.nk_repo.is_active_branch('main'))
         staged = Path(self.nk_repo.nk_dir, 'StagedMod.netkan')
         self.assertFalse(staged.exists())
         with self.nk_repo.change_branch('some/other/branch'):


### PR DESCRIPTION
## Motivation

The new KSP2 metadata repos have `main` branches instead of `master`:

- <https://github.com/KSP-CKAN/KSP2-NetKAN>
- <https://github.com/KSP-CKAN/KSP2-CKAN-meta>

We have been intending to make this same change to the existing repos for a while.

Also KSP2 is in early access and needs a metadata bot.

## Changes

- Now all usages and mentions of a `master` branch are changed to `main`
- Now the Scheduler, Inflator (depends on Dockerfile change in KSP-CKAN/CKAN#3797), Indexer, Adder, Mirrorer, and DownloadCounter and their queues are duplicated for KSP2. (I just prefixed everything with `KSP2-` or `ksp2_`.)

We will have to be careful about how we merge this, as it will require merging KSP-CKAN/CKAN#3797 first _and_ renaming the `master` branches of NetKAN and CKAN-meta. It might be best to make a public announcement of 1–3 days of downtime ahead of time.

In @techman83's testing, GitHub automatically redirects the CKAN client's repo URL to the new branch. 🎉 

### Open questions

- [ ] How should we handle the Webhooks? The cleanest structure would be two separate instances, since we could swap out the queues and repos, but only one of them could listen on the HTTP(S) port(s).
