### PR TITLE
fix: Redeploy Perms

### DIFF
--- a/prod-stack.py
+++ b/prod-stack.py
@@ -416,7 +416,7 @@ netkan_scheduler_role = t.add_resource(Role(
 # redeployment of services.
 ksp_builder_group = t.add_resource(Group("KspCkanBuilderGroup"))
 builder_services = []
-for service in ['Indexer', 'Inflator', 'Webhooks', 'Adder', 'Mirrorer']:
+for service in ['Indexer', 'InflatorKsp', 'InflatorKsp2', 'Webhooks', 'Adder', 'Mirrorer']:
     builder_services.append(
         Sub(
             'arn:aws:ecs:${AWS::Region}:${AWS::AccountId}:service/NetKANCluster/${service}',


### PR DESCRIPTION
The permissions for re-deploying services were missing the renamed inflator and the new inflator, this addresses that and allows for deployment to proceed.