### PR TITLE
Raise error on failed push

### DIFF
--- a/netkan/netkan/repos.py
+++ b/netkan/netkan/repos.py
@@ -102,7 +102,7 @@ class XkanRepo:
                 pass
             self.git_repo.remotes.origin.push(
                 f'{branch_name}:{branch_name}'
-            )
+            ).raise_if_error()
             self.checkout_branch(active_branch)
 
 


### PR DESCRIPTION
I have been trying to figure out why #281 didn't work, and I'm stumped.

The push must be failing, but it's silently ignored. Now it'll throw an exception on failure, so we can get more clues about why we never see the AutoFreezer's additional commits when the remote branch exists.

<https://gitpython.readthedocs.io/en/stable/tutorial.html#handling-remotes>