### PR TITLE
Refactor Git Repos

### DIFF
--- a/netkan/netkan/auto_freezer.py
+++ b/netkan/netkan/auto_freezer.py
@@ -16,7 +16,7 @@ class AutoFreezer:
         self.github_pr = github_pr
 
     def freeze_idle_mods(self, days_limit: int, days_till_ignore: int) -> None:
-        self.nk_repo.git_repo.remotes.origin.pull('master', strategy_option='ours')
+        self.nk_repo.pull_remote_primary(strategy_option='ours')
         idle_mods = self._find_idle_mods(days_limit, days_till_ignore)
         if idle_mods:
             with self.nk_repo.change_branch(self.BRANCH_NAME):

--- a/netkan/netkan/cli/common.py
+++ b/netkan/netkan/cli/common.py
@@ -4,7 +4,6 @@ from pathlib import Path
 from typing import Union, Callable, Any, List, Optional, Tuple, Dict
 
 import click
-from git import Repo
 
 from ..repos import NetkanRepo, CkanMetaRepo
 from ..utils import init_repo, init_ssh
@@ -133,8 +132,8 @@ class Game:
         return self._netkan_repo
 
     @property
-    def repos(self) -> List[Repo]:
-        return [self.ckanmeta_repo.git_repo, self.netkan_repo.git_repo]
+    def repos(self) -> List[Union[NetkanRepo, CkanMetaRepo]]:
+        return [self.ckanmeta_repo, self.netkan_repo]
 
     @property
     def netkan_remote(self) -> str:

--- a/netkan/netkan/common.py
+++ b/netkan/netkan/common.py
@@ -1,12 +1,12 @@
 
-from typing import List, Iterable, IO, TYPE_CHECKING
+from typing import List, Iterable, IO, TYPE_CHECKING, Union
 
 import requests
 import github
 from git import Repo
 
 from .metadata import Netkan
-from .repos import NetkanRepo
+from .repos import NetkanRepo, CkanMetaRepo
 
 if TYPE_CHECKING:
     from mypy_boto3_sqs.service_resource import Message
@@ -40,9 +40,9 @@ def sqs_batch_entries(messages: Iterable[SendMessageBatchRequestEntryTypeDef],
         yield batch
 
 
-def pull_all(repos: Iterable[Repo]) -> None:
+def pull_all(repos: Iterable[Union[NetkanRepo, CkanMetaRepo]]) -> None:
     for repo in repos:
-        repo.remotes.origin.pull('master', strategy_option='theirs')
+        repo.pull_remote_primary(strategy_option='theirs')
 
 
 def github_limit_remaining(token: str) -> int:

--- a/netkan/netkan/download_counter.py
+++ b/netkan/netkan/download_counter.py
@@ -278,14 +278,12 @@ class DownloadCounter:
                 'NetKAN Updating Download Counts'
             )
             logging.info('Download counts changed and committed')
-            self.ckm_repo.git_repo.remotes.origin.push('master')
+            self.ckm_repo.push_remote_primary()
 
     def update_counts(self) -> None:
         if self.output_file:
             self.get_counts()
-            self.ckm_repo.git_repo.remotes.origin.pull(
-                'master', strategy_option='ours'
-            )
+            self.ckm_repo.pull_remote_primary(strategy_option='ours')
             self.write_json()
             if repo_file_add_or_changed(self.ckm_repo.git_repo, self.output_file):
                 self.commit_counts()

--- a/netkan/netkan/github_pr.py
+++ b/netkan/netkan/github_pr.py
@@ -24,9 +24,14 @@ class GitHubPR:
                 f'{self.user}/{self.git_repo}')
         return self._repo
 
+    @property
+    def default_branch(self) -> str:
+        return self.repo.default_branch
+
     def create_pull_request(self, title: str, branch: str, body: str, labels: Optional[List[str]] = None) -> None:
         try:
-            pull = self.repo.create_pull(title, body, 'master', branch)
+            pull = self.repo.create_pull(
+                title, body, self.default_branch, branch)
             logging.info('Pull request for %s opened at %s',
                          branch, pull.html_url)
 

--- a/netkan/netkan/mirrorer.py
+++ b/netkan/netkan/mirrorer.py
@@ -313,8 +313,8 @@ class Mirrorer:
                     continue
                 # Get up to date copy of the metadata for the files we're mirroring
                 logging.info('Updating repo')
-                self.ckm_repo.git_repo.heads.master.checkout()
-                self.ckm_repo.git_repo.remotes.origin.pull('master', strategy_option='theirs')
+                self.ckm_repo.checkout_primary()
+                self.ckm_repo.pull_remote_primary(strategy_option='theirs')
                 # Start processing the messages
                 to_delete: List[DeleteMessageBatchRequestEntryTypeDef] = []
                 for msg in messages:
@@ -373,7 +373,7 @@ class Mirrorer:
                 # /HebaruSan/Astrogator/releases -> HebaruSan/Astrogator
                 full_name = '/'.join(parsed.path.split('/')[1:3])
                 return self._gh.get_repo(full_name).default_branch
-        return 'master'
+        return 'main'
 
     def purge_epochs(self, dry_run: bool) -> None:
         if dry_run:

--- a/netkan/netkan/queue_handler.py
+++ b/netkan/netkan/queue_handler.py
@@ -30,10 +30,9 @@ class BaseMessageHandler:
     # we can ensure we call close on it and run our handler inside
     # a context manager
     def __enter__(self) -> 'BaseMessageHandler':
-        if not self.repo.is_active_branch('master'):
-            self.repo.checkout_branch('master')
-        self.repo.pull_remote_branch(
-            'master', strategy_option=self.STRATEGY_OPTION)
+        if not self.repo.is_primary_active():
+            self.repo.checkout_primary()
+        self.repo.pull_remote_primary(strategy_option=self.STRATEGY_OPTION)
         return self
 
     def __exit__(self, exc_type: Type[BaseException],

--- a/netkan/netkan/webhooks/github_mirror.py
+++ b/netkan/netkan/webhooks/github_mirror.py
@@ -25,7 +25,7 @@ def mirror_hook(game_id: str) -> Tuple[Union[Response, str], int]:
     raw = request.get_json(silent=True)
     ref = raw.get('ref')  # type: ignore[union-attr]
     expected_ref = current_config.common.game(
-        game_id).ckanmeta_repo.git_repo.heads.master.path
+        game_id).ckanmeta_repo.primary_branch_path
     if ref != expected_ref:
         current_app.logger.info(
             "Wrong branch. Expected '%s', got '%s'", expected_ref, ref)

--- a/netkan/tests/indexer.py
+++ b/netkan/tests/indexer.py
@@ -46,13 +46,18 @@ class TestCkan(unittest.TestCase):
         working = Path(cls.tmpdir.name, 'working')
         upstream = Path(cls.tmpdir.name, 'upstream')
         upstream.mkdir()
-        Repo.init(upstream, bare=True)
+        Repo.init(upstream, bare=True, initial_branch='main')
         shutil.copytree(cls.test_data, working)
         cls.ckan_meta = Repo.init(working)
+        Path(cls.ckan_meta.working_dir, '.git',
+             'HEAD').write_text('ref: refs/heads/main')
         cls.ckan_meta.index.add(cls.ckan_meta.untracked_files)
         cls.ckan_meta.index.commit('Test Data')
         cls.ckan_meta.create_remote('origin', upstream.as_posix())
-        cls.ckan_meta.remotes.origin.push('master:master')
+        cls.ckan_meta.remotes.origin.push('main:main')
+        # When we clone at repo access, we use a git clone which
+        # sets this automatically.
+        cls.ckan_meta.git.remote('set-head', 'origin', '-a')
         cls.ckm_repo = CkanMetaRepo(cls.ckan_meta)
         cls.message = CkanMessage(cls.msg, cls.ckm_repo)
 
@@ -185,12 +190,12 @@ class TestStagedCkan(TestUpdateCkan):
         self.assertTrue(self.message.Staged)
 
     def test_ckan_message_change_branch(self):
-        self.assertEqual(str(self.ckan_meta.active_branch), 'master')
+        self.assertEqual(str(self.ckan_meta.active_branch), 'main')
         with self.message.ckm_repo.change_branch(self.message.mod_version):
             self.assertEqual(
                 str(self.ckan_meta.active_branch), 'DogeCoinFlag-v1.02'
             )
-        self.assertEqual(str(self.ckan_meta.active_branch), 'master')
+        self.assertEqual(str(self.ckan_meta.active_branch), 'main')
 
     def test_ckan_message_status_attrs(self):
         attrs = self.message.status_attrs(new=True)
@@ -265,7 +270,7 @@ class TestMessageHandler(SharedArgsHarness):
         self.handler.append(self.mocked_message())
         self.assertEqual(len(self.handler), 1)
         self.assertEqual(
-            self.handler.master[0].ckan.name,
+            self.handler.primary[0].ckan.name,
             'Dogecoin Flag'
         )
 
@@ -281,7 +286,7 @@ class TestMessageHandler(SharedArgsHarness):
         self.handler.append(self.mocked_message())
         self.handler.append(self.mocked_message(staged=True))
         self.assertEqual(len(self.handler), 2)
-        self.assertEqual(len(self.handler.master), 1)
+        self.assertEqual(len(self.handler.primary), 1)
         self.assertEqual(len(self.handler.staged), 1)
 
     def test_branch_checkout_primary_on_enter(self):
@@ -291,7 +296,7 @@ class TestMessageHandler(SharedArgsHarness):
         repo.checkout_branch('test_branch')
         self.assertTrue(repo.is_active_branch('test_branch'))
         with MessageHandler(game=self.shared_args.game('ksp')) as handler:
-            self.assertTrue(repo.is_active_branch('master'))
+            self.assertTrue(repo.is_primary_active())
 
     @ mock.patch('netkan.indexer.CkanMessage.process_ckan')
     def test_process_ckans(self, mocked_process):

--- a/netkan/tests/repos.py
+++ b/netkan/tests/repos.py
@@ -20,14 +20,19 @@ class TestRepo(unittest.TestCase):
         cls.working = Path(cls.tmpdir.name, 'working')
         cls.upstream = Path(cls.tmpdir.name, 'upstream')
         cls.upstream.mkdir()
-        Repo.init(cls.upstream, bare=True)
+        Repo.init(cls.upstream, bare=True, initial_branch='main')
         shutil.copytree(cls.test_data, cls.working)
-        cls.repo = Repo.init(cls.working)
-        shutil.copy(Path(__file__).parent.parent / '.gitconfig', cls.working / '.git' / 'config')
+        cls.repo = Repo.init(cls.working, initial_branch='main')
+        Path(cls.working, '.git', 'HEAD').write_text('ref: refs/heads/main')
+        shutil.copy(Path(__file__).parent.parent / '.gitconfig',
+                    cls.working / '.git' / 'config')
         cls.repo.index.add(cls.repo.untracked_files)
         cls.repo.index.commit('Test Data')
         cls.repo.create_remote('origin', cls.upstream.as_posix())
-        cls.repo.remotes.origin.push('master:master')
+        cls.repo.remotes.origin.push('main:main')
+        # When we clone at repo access, we use a git clone which
+        # sets this automatically.
+        cls.repo.git.remote('set-head', 'origin', '-a')
 
     @classmethod
     def tearDownClass(cls):
@@ -37,7 +42,7 @@ class TestRepo(unittest.TestCase):
     def tearDown(self):
         meta = self.repo
         meta.git.clean('-df')
-        meta.heads.master.checkout()
+        meta.heads.main.checkout()
         try:
             cleanup = meta.create_head('cleanup', 'HEAD~1')
             meta.head.reference = cleanup
@@ -52,45 +57,108 @@ class TestNetkanRepo(TestRepo):
     def setUp(self):
         self.nk_repo = NetkanRepo(self.repo)
 
+    def test_repr(self):
+        self.assertEqual(str(self.nk_repo),
+                         f'<NetkanRepo({self.nk_repo.git_repo})>')
+
     def test_nk_path(self):
         self.assertTrue(self.nk_repo.nk_path('DogeCoinFlag').exists())
 
+    def test_nk_frozen_path(self):
+        self.assertEqual(
+            self.nk_repo.frozen_path('DogeCoinFlag').as_posix(),
+            f'{self.nk_repo.git_repo.working_dir}/NetKAN/DogeCoinFlag.frozen'
+        )
+
     def test_active_branch(self):
-        self.assertEqual(self.nk_repo.active_branch, 'master')
+        self.assertEqual(self.nk_repo.active_branch, 'main')
+
+    def test_primary_active(self):
+        self.assertTrue(self.nk_repo.is_primary_active())
+
+    def test_primary_inactive(self):
+        with self.nk_repo.change_branch('not/primary'):
+            self.assertFalse(self.nk_repo.is_primary_active())
+
+    def test_primary_branch(self):
+        self.assertEqual(self.nk_repo.primary_branch, 'main')
+
+    def test_primary_branch_path(self):
+        self.assertEqual(self.nk_repo.primary_branch_path, 'refs/heads/main')
 
     def test_is_active_branch(self):
-        self.assertTrue(self.nk_repo.is_active_branch('master'))
+        self.assertTrue(self.nk_repo.is_active_branch('main'))
         self.assertFalse(self.nk_repo.is_active_branch('some/other/branch'))
 
     def test_checkout_branch(self):
         with self.nk_repo.change_branch('a/branch'):
             pass
-        self.assertTrue(self.nk_repo.is_active_branch('master'))
+        self.assertTrue(self.nk_repo.is_active_branch('main'))
         self.nk_repo.checkout_branch('a/branch')
         self.assertTrue(self.nk_repo.is_active_branch('a/branch'))
 
-    def test_push_pull(self):
+    def test_checkout_primary(self):
+        with self.nk_repo.change_branch('not/primary'):
+            self.assertFalse(self.nk_repo.is_primary_active())
+            self.nk_repo.checkout_primary()
+            self.assertTrue(self.nk_repo.is_primary_active())
+
+    def test_primary_push_pull(self):
+        new_clone = Repo.init(Path(self.tmpdir.name, 'primary_push_pull'))
+        new_clone.create_remote('origin', self.upstream.as_posix())
+        Path(new_clone.working_dir, '.git', 'HEAD').write_text(
+            'ref: refs/heads/main')
+        new_clone.remotes.origin.pull('main')
+        new_clone.git.remote('set-head', 'origin', '-a')
+        new_repo = NetkanRepo(new_clone)
+        new_repo.pull_remote_primary()
+        Path(new_repo.nk_dir, 'test_pushpull_file').write_text(
+            'I can haz cheezburger')
+        new_repo.commit(new_repo.git_repo.untracked_files, 'Pls')
+        new_repo.push_remote_primary()
+        self.assertFalse(
+            Path(self.nk_repo.nk_dir, 'test_pushpull_file').exists())
+        self.nk_repo.pull_remote_primary()
+        self.assertTrue(
+            Path(self.nk_repo.nk_dir, 'test_pushpull_file').exists())
+
+    def test_branch_push_pull(self):
         new_clone = Repo.init(Path(self.tmpdir.name, 'push_pull'))
         new_clone.create_remote('origin', self.upstream.as_posix())
+        new_clone.remotes.origin.pull('main')
+        new_clone.git.remote('set-head', 'origin', '-a')
         new_repo = NetkanRepo(new_clone)
-        new_repo.pull_remote_branch('master')
-        Path(new_repo.nk_dir, 'test_pushpull_file').write_text('I can haz cheezburger')
+        with new_repo.change_branch('test/change'):
+            pass
+        new_repo.checkout_branch('test/change')
+        new_repo.pull_remote_branch('test/change')
+        Path(new_repo.nk_dir, 'test_pushpull_file').write_text(
+            'I can haz cheezburger')
         new_repo.commit(new_repo.git_repo.untracked_files, 'Pls')
-        new_repo.push_remote_branch('master')
-        self.assertFalse(Path(self.nk_repo.nk_dir, 'test_pushpull_file').exists())
-        self.nk_repo.pull_remote_branch('master')
-        self.assertTrue(Path(self.nk_repo.nk_dir, 'test_pushpull_file').exists())
+        new_repo.push_remote_branch('test/change')
+        self.assertFalse(
+            Path(self.nk_repo.nk_dir, 'test_pushpull_file').exists())
+        with self.nk_repo.change_branch('test/change'):
+            self.nk_repo.pull_remote_branch('test/change')
+            self.assertTrue(
+                Path(self.nk_repo.nk_dir, 'test_pushpull_file').exists())
 
     def test_change_branch(self):
-        self.assertTrue(self.nk_repo.is_active_branch('master'))
+        self.assertTrue(self.nk_repo.is_primary_active())
         staged = Path(self.nk_repo.nk_dir, 'StagedMod.netkan')
         self.assertFalse(staged.exists())
         with self.nk_repo.change_branch('some/other/branch'):
             self.assertTrue(self.nk_repo.is_active_branch('some/other/branch'))
             staged.write_text('{"name": "Stagey McStage"}')
             self.assertTrue(staged.exists())
-            self.nk_repo.commit(self.nk_repo.nk_paths(['StagedMod']), 'Test Stage')
+            self.nk_repo.commit(self.nk_repo.nk_paths(
+                ['StagedMod']), 'Test Stage')
         self.assertFalse(staged.exists())
+
+    def test_create_branch_local(self):
+        self.nk_repo.git_repo.create_head('local/test')
+        with self.nk_repo.change_branch('local/test'):
+            self.assertEqual(self.nk_repo.active_branch, 'local/test')
 
 
 class TestCkanMetaRepo(TestRepo):
@@ -101,6 +169,19 @@ class TestCkanMetaRepo(TestRepo):
 
     def test_mod_path(self):
         self.assertTrue(self.ckm_repo.mod_path('AwesomeMod').exists())
+
+    def test_identifiers(self):
+        self.assertListEqual(
+            sorted(self.ckm_repo.identifiers()),
+            ['AdequateMod', 'AmazingMod', 'AwesomeMod']
+        )
+
+    def test_all_latest_modules(self):
+        self.assertListEqual(
+            sorted([str(x) for x in self.ckm_repo.all_latest_modules()]),
+            ['<Ckan(AdequateMod, 1:0.2)>', '<Ckan(AmazingMod, v1.1)>',
+             '<Ckan(AwesomeMod, 0.11)>']
+        )
 
 
 class TestRepoConfig(TestRepo):

--- a/netkan/tests/testdata/NotAnotherFlag.netkan
+++ b/netkan/tests/testdata/NotAnotherFlag.netkan
@@ -1,0 +1,15 @@
+{
+    "spec_version"   : 1,
+    "identifier"     : "NotAnotherFlag",
+    "name"           : "Not Another Flag",
+    "abstract"       : "Such flag. Very currency. Wow.",
+    "description"    : "Adorn your craft with your favourite cryptocurrency. To the mün!",
+    "$kref"          : "#/ckan/github/pjf/DogeCoinFlag",
+    "ksp_version"    : "any",
+    "comment"        : "flagmod",
+    "license"        : "CC-BY",
+    "author"         : "daviddwk",
+    "resources"      : {
+        "homepage"   : "https://www.reddit.com/r/dogecoin/comments/1tdlgg/i_made_a_more_accurate_dogecoin_and_a_ksp_flag/"
+    }
+}

--- a/netkan/tests/webhooks.py
+++ b/netkan/tests/webhooks.py
@@ -71,7 +71,7 @@ class TestWebhookGitHubInflate(WebhooksHarness):
     @staticmethod
     def mock_netkan_hook() -> dict:
         return {
-            'ref': 'refs/heads/master',
+            'ref': 'refs/heads/main',
             'commits': [
                 {
                     'id': 'fec27dc0350adc7dc8659cde980d1eca9ce30167',
@@ -203,7 +203,7 @@ class TestWebhookGitHubMirror(WebhooksHarness):
     @staticmethod
     def mock_netkan_hook() -> dict:
         return {
-            'ref': 'refs/heads/master',
+            'ref': 'refs/heads/main',
             'commits': [
                 {
                     'id': 'fec27dc0350adc7dc8659cde980d1eca9ce30167',


### PR DESCRIPTION
Many assumptions around branches and repos were made early on, since then we moved a lot of the common repo actions into relevant classes. This furthers that work and replaces all direct branch access with methods that automatically figure out the primary branch of the repo. Tests updated to reference 'main'

It is intended that #283 is reviewed and merged first, then once happy we can move onto this in preparation for adding KSP2 config. We will be able to follow soon after by renaming master -> main for the existing KSP repos.