### PR TITLE
Automatically Iterate Games + Add KSP2 Config

### DIFF
--- a/netkan/netkan/cli/common.py
+++ b/netkan/netkan/cli/common.py
@@ -182,6 +182,7 @@ class SharedArgs:
     user: str
     _debug: bool
     _ssh_key: str
+    _game_ids: List[str]
 
     def __init__(self) -> None:
         self._environment_data = None
@@ -226,6 +227,18 @@ class SharedArgs:
         if getattr(self, f'_game_{game_id}', None) is None:
             setattr(self, f'_game_{game_id}', Game(game_id, self))
         return getattr(self, f'_game_{game_id}')
+
+    @property
+    def game_ids(self) -> List[str]:
+        if getattr(self, '_game_ids', None) is None:
+            game_ids = set()
+            for arg in ['ckanmeta_remotes', 'netkan_remotes', 'ia_collections', 'repos']:
+                if arg not in vars(self):
+                    continue
+                game_ids.update([x.split('=', maxsplit=1)[0]
+                                 for x in getattr(self, arg)])
+            self._game_ids = sorted(game_ids)  # sorts + casts to list type
+        return self._game_ids
 
 
 pass_state = click.make_pass_decorator(

--- a/netkan/netkan/cli/services.py
+++ b/netkan/netkan/cli/services.py
@@ -44,15 +44,16 @@ def scheduler(
     min_cpu: int,
     min_io: int
 ) -> None:
-    game = common.game(common.game_id)
-    sched = NetkanScheduler(
-        common, game.inflation_queue, common.token, game.name,
-        nonhooks_group=(group in ('all', 'nonhooks')),
-        webhooks_group=(group in ('all', 'webhooks')),
-    )
-    if sched.can_schedule(max_queued, common.dev, min_cpu, min_io):
-        sched.schedule_all_netkans()
-        logging.info("NetKANs submitted to %s", game.inflation_queue)
+    for game_id in common.game_ids:
+        game = common.game(game_id)
+        sched = NetkanScheduler(
+            common, game.inflation_queue, common.token, game.name,
+            nonhooks_group=(group in ('all', 'nonhooks')),
+            webhooks_group=(group in ('all', 'webhooks')),
+        )
+        if sched.can_schedule(max_queued, common.dev, min_cpu, min_io):
+            sched.schedule_all_netkans()
+            logging.info("NetKANs submitted to %s", game.inflation_queue)
 
 
 @click.command()

--- a/netkan/netkan/cli/utilities.py
+++ b/netkan/netkan/cli/utilities.py
@@ -29,24 +29,26 @@ from ..mirrorer import Mirrorer
 @common_options
 @pass_state
 def auto_freezer(common: SharedArgs, days_limit: int, days_till_ignore: int) -> None:
-    afr = AutoFreezer(
-        common.game(common.game_id).netkan_repo,
-        common.game(common.game_id).github_pr,
-    )
-    afr.freeze_idle_mods(days_limit, days_till_ignore)
-    afr.mark_frozen_mods()
+    for game_id in common.game_ids:
+        afr = AutoFreezer(
+            common.game(game_id).netkan_repo,
+            common.game(game_id).github_pr,
+        )
+        afr.freeze_idle_mods(days_limit, days_till_ignore)
+        afr.mark_frozen_mods()
 
 
 @click.command()
 @common_options
 @pass_state
 def download_counter(common: SharedArgs) -> None:
-    logging.info('Starting Download Count Calculation...')
-    DownloadCounter(
-        common.game(common.game_id).ckanmeta_repo,
-        common.token
-    ).update_counts()
-    logging.info('Download Counter completed!')
+    for game_id in common.game_ids:
+        logging.info('Starting Download Count Calculation (%s)...', game_id)
+        DownloadCounter(
+            common.game(game_id).ckanmeta_repo,
+            common.token
+        ).update_counts()
+        logging.info('Download Counter completed! (%s)', game_id)
 
 
 @click.command()

--- a/netkan/netkan/queue_handler.py
+++ b/netkan/netkan/queue_handler.py
@@ -46,10 +46,7 @@ class BaseMessageHandler:
     def append(self, message: Message) -> None:
         raise NotImplementedError
 
-    def process_messages(self) -> None:
-        raise NotImplementedError
-
-    def sqs_delete_entries(self) -> List[DeleteMessageBatchRequestEntryTypeDef]:
+    def process_messages(self) -> List[DeleteMessageBatchRequestEntryTypeDef]:
         raise NotImplementedError
 
 
@@ -98,7 +95,7 @@ class QueueHandler:
 
             for _, handler in self.game_handlers.items():
                 with handler:
-                    handler.process_messages()
-                queue.delete_messages(
-                    Entries=handler.sqs_delete_entries()
-                )
+                    processed = handler.process_messages()
+                    queue.delete_messages(
+                        Entries=processed
+                    )

--- a/netkan/tests/cli.py
+++ b/netkan/tests/cli.py
@@ -71,6 +71,28 @@ class TestSharedArgs(TestCase):
             shared.ckanmeta_remote  # pylint: disable=pointless-statement
         self.assertEqual(error.exception.code, 1)
 
+    def test_shared_games_none(self):
+        shared = SharedArgs()
+        self.assertEqual(shared.game_ids, [])
+
+    def test_shared_games_ksp(self):
+        shared = SharedArgs()
+        shared.ckanmeta_remotes = ('ksp=ckan_url',)
+        shared.repos = ('ksp=ckan',)
+        self.assertEqual(shared.game_ids, ['ksp'])
+
+    def test_shared_games_ksp2(self):
+        shared = SharedArgs()
+        shared.ckanmeta_remotes = ('ksp2=ckan_url',)
+        shared.repos = ('ksp2=ckan',)
+        self.assertEqual(shared.game_ids, ['ksp2'])
+
+    def test_shared_games_multi(self):
+        shared = SharedArgs()
+        shared.ckanmeta_remotes = ('ksp2=ckan_url', 'ksp=ckan_url')
+        shared.repos = ('ksp2=ckan', 'ksp2=ckan')
+        self.assertEqual(shared.game_ids, ['ksp', 'ksp2'])
+
 
 class TestGame(SharedArgsHarness):
 

--- a/netkan/tests/indexer.py
+++ b/netkan/tests/indexer.py
@@ -298,22 +298,21 @@ class TestMessageHandler(SharedArgsHarness):
         with MessageHandler(game=self.shared_args.game('ksp')) as handler:
             self.assertTrue(repo.is_primary_active())
 
-    @ mock.patch('netkan.indexer.CkanMessage.process_ckan')
+    @mock.patch('netkan.indexer.CkanMessage.process_ckan')
     def test_process_ckans(self, mocked_process):
         self.handler.append(self.mocked_message())
         self.handler.append(self.mocked_message(staged=True))
-        self.handler.process_messages()
-        self.assertEqual(len(self.handler.processed), 2)
+        processed = self.handler.process_messages()
+        self.assertEqual(len(processed), 2)
 
-    @ mock.patch('netkan.indexer.CkanMessage.process_ckan')
+    @mock.patch('netkan.indexer.CkanMessage.process_ckan')
     def test_delete_attrs(self, mocked_process):
         self.handler.append(self.mocked_message())
         self.handler.append(self.mocked_message(staged=True))
-        self.handler.process_messages()
+        processed = self.handler.process_messages()
         attrs = [{'Id': 'MessageMcMessageFace', 'ReceiptHandle': 'HandleMcHandleFace'}, {
             'Id': 'MessageMcMessageFace', 'ReceiptHandle': 'HandleMcHandleFace'}]
-        self.assertEqual(self.handler.sqs_delete_entries(), attrs)
-        self.assertEqual(len(self.handler.processed), 0)
+        self.assertEqual(processed, attrs)
 
 
 class TestIndexerQueueHandler(SharedArgsHarness):

--- a/netkan/tests/spacedock_adder.py
+++ b/netkan/tests/spacedock_adder.py
@@ -48,26 +48,25 @@ class TestSpaceDockMessageHandler(SharedArgsHarness):
     def test_process_netkans(self, mocked_process):
         mocked_process.return_value = True
         self.handler.append(self.mocked_message())
-        self.handler.process_messages()
-        self.assertEqual(len(self.handler.processed), 1)
+        processed = self.handler.process_messages()
+        self.assertEqual(len(processed), 1)
 
     @mock.patch('netkan.spacedock_adder.SpaceDockAdder.try_add')
     def test_process_netkans_fail(self, mocked_process):
         mocked_process.return_value = False
         self.handler.append(self.mocked_message())
         self.assertEqual(len(self.handler.queued), 1)
-        self.handler.process_messages()
-        self.assertEqual(len(self.handler.processed), 0)
+        processed = self.handler.process_messages()
+        self.assertEqual(len(processed), 0)
 
     @mock.patch('netkan.spacedock_adder.SpaceDockAdder.try_add')
     def test_delete_attrs(self, mocked_process):
         mocked_process.return_value = True
         self.handler.append(self.mocked_message())
-        self.handler.process_messages()
+        processed = self.handler.process_messages()
         attrs = [{'Id': 'MessageMcMessageFace',
                   'ReceiptHandle': 'HandleMcHandleFace'}]
-        self.assertEqual(self.handler.sqs_delete_entries(), attrs)
-        self.assertEqual(len(self.handler.processed), 0)
+        self.assertEqual(processed, attrs)
 
 
 class TestSpaceDockAdderQueueHandler(SharedArgsHarness):

--- a/prod-stack.py
+++ b/prod-stack.py
@@ -22,12 +22,12 @@ ZONE_ID = os.environ.get('CKAN_ZONEID', False)
 BOT_FQDN = 'netkan.ksp-ckan.space'
 EMAIL = 'domains@ksp-ckan.space'
 PARAM_NAMESPACE = '/NetKAN/Indexer/'
-NETKAN_REMOTES = 'ksp=git@github.com:KSP-CKAN/NetKAN.git'
+NETKAN_REMOTES = 'ksp=git@github.com:KSP-CKAN/NetKAN.git ksp2=git@github.com:KSP-CKAN/KSP2-NetKAN.git'
 NETKAN_USER = 'KSP-CKAN'
-NETKAN_REPOS = 'ksp=NetKAN'
-CKANMETA_REMOTES = 'ksp=git@github.com:KSP-CKAN/CKAN-meta.git'
+NETKAN_REPOS = 'ksp=NetKAN ksp2=KSP2-NetKAN'
+CKANMETA_REMOTES = 'ksp=git@github.com:KSP-CKAN/CKAN-meta.git ksp2=git@github.com:KSP-CKAN/KSP2-CKAN-meta.git'
 CKANMETA_USER = 'KSP-CKAN'
-CKANMETA_REPOS = 'ksp=CKAN-meta'
+CKANMETA_REPOS = 'ksp=CKAN-meta ksp2=KSP2-CKAN-meta'
 NETKAN_USER = 'KSP-CKAN'
 STATUS_BUCKET = 'status.ksp-ckan.space'
 status_key = 'status/netkan.json'
@@ -704,7 +704,7 @@ services = [
         'linux_parameters': LinuxParameters(InitProcessEnabled=True),
     },
     {
-        'name': 'SchedulerKsp',
+        'name': 'Scheduler',
         'command': 'scheduler',
         'memory': '156',
         'secrets': ['SSH_KEY', 'GH_Token'],
@@ -717,7 +717,7 @@ services = [
         'schedule': 'rate(30 minutes)',
     },
     {
-        'name': 'SchedulerKspWebhooksPass',
+        'name': 'SchedulerWebhooksPass',
         'command': [
             'scheduler', '--group', 'webhooks',
                 '--max-queued', '2000',
@@ -797,7 +797,7 @@ services = [
         'schedule': 'rate(5 minutes)',
     },
     {
-        'name': 'DownloadCounterKsp',
+        'name': 'DownloadCounter',
         'command': 'download-counter',
         'memory': '156',
         'secrets': [

--- a/prod-stack.py
+++ b/prod-stack.py
@@ -709,7 +709,6 @@ services = [
         'memory': '156',
         'secrets': ['SSH_KEY', 'GH_Token'],
         'env': [
-            ('GAME_ID', 'ksp'),
             ('INFLATION_QUEUES', INFLATION_QUEUES),
             ('NETKAN_REMOTES', NETKAN_REMOTES),
             ('CKANMETA_REMOTES', CKANMETA_REMOTES),
@@ -728,7 +727,6 @@ services = [
         'memory': '156',
         'secrets': ['SSH_KEY', 'GH_Token'],
         'env': [
-            ('GAME_ID', 'ksp'),
             ('INFLATION_QUEUES', INFLATION_QUEUES),
             ('NETKAN_REMOTES', NETKAN_REMOTES),
             ('CKANMETA_REMOTES', CKANMETA_REMOTES),
@@ -806,7 +804,6 @@ services = [
             'SSH_KEY', 'GH_Token',
         ],
         'env': [
-            ('GAME_ID', 'ksp'),
             ('NETKAN_REMOTES', NETKAN_REMOTES),
             ('CKANMETA_REMOTES', CKANMETA_REMOTES),
         ],
@@ -850,7 +847,6 @@ services = [
         'name': 'AutoFreezer',
         'command': 'auto-freezer',
         'env': [
-            ('GAME_ID', 'ksp'),
             ('NETKAN_REMOTES', NETKAN_REMOTES),
             ('CKAN_USER', NETKAN_USER),
             ('CKAN_REPOS', NETKAN_REPOS),


### PR DESCRIPTION
This PR is intended to come after #283 + #288 - will rebase when ready

## Adds
- `games` method that automatically returns a list of the configured games
- KSP2 Configuration

## Changes
- Utilities configured within the stack will iterate through all available games (Scheduler/Freezer/Counter)

## Fixes
- Remove `processed` from the QueueHandler, avoiding the risk of the list growing perpetually until SQS throws an exception

## Extra
- Left the mirrorer out to focus on it as a separate piece in preparation for when we have > 50 mod versions