### PR TITLE
Ensure processed queue is emptied

### DIFF
--- a/netkan/netkan/indexer.py
+++ b/netkan/netkan/indexer.py
@@ -214,7 +214,9 @@ class MessageHandler(BaseMessageHandler):
             self.processed.append(ckan)
 
     def sqs_delete_entries(self) -> List[DeleteMessageBatchRequestEntryTypeDef]:
-        return [c.delete_attrs for c in self.processed]
+        entries = [c.delete_attrs for c in self.processed]
+        self.processed = []
+        return entries
 
     # Currently we intermingle Staged/Master commits
     # separating them out will be a little more efficient

--- a/netkan/netkan/spacedock_adder.py
+++ b/netkan/netkan/spacedock_adder.py
@@ -188,7 +188,9 @@ class SpaceDockMessageHandler(BaseMessageHandler):
                 self.processed.append(netkan)
 
     def sqs_delete_entries(self) -> List[DeleteMessageBatchRequestEntryTypeDef]:
-        return [c.delete_attrs for c in self.processed]
+        entries = [c.delete_attrs for c in self.processed]
+        self.processed = []
+        return entries
 
     def process_messages(self) -> None:
         self._process_queue(self.queued)

--- a/netkan/tests/indexer.py
+++ b/netkan/tests/indexer.py
@@ -308,6 +308,7 @@ class TestMessageHandler(SharedArgsHarness):
         attrs = [{'Id': 'MessageMcMessageFace', 'ReceiptHandle': 'HandleMcHandleFace'}, {
             'Id': 'MessageMcMessageFace', 'ReceiptHandle': 'HandleMcHandleFace'}]
         self.assertEqual(self.handler.sqs_delete_entries(), attrs)
+        self.assertEqual(len(self.handler.processed), 0)
 
 
 class TestIndexerQueueHandler(SharedArgsHarness):

--- a/netkan/tests/spacedock_adder.py
+++ b/netkan/tests/spacedock_adder.py
@@ -65,6 +65,7 @@ class TestSpaceDockMessageHandler(SharedArgsHarness):
         attrs = [{'Id': 'MessageMcMessageFace',
                   'ReceiptHandle': 'HandleMcHandleFace'}]
         self.assertEqual(self.handler.sqs_delete_entries(), attrs)
+        self.assertEqual(len(self.handler.processed), 0)
 
 
 class TestSpaceDockAdderQueueHandler(SharedArgsHarness):


### PR DESCRIPTION
As the handlers are kept in memory, they keep this list state between processing. This leads to the occaisional failure when we inevitably end up with more than 10 in the list. We should consider tests and a cleaner solution, but this will keep the bots uptime and logs quieter for now.