### PR TITLE
fix: Avoid empty call to SQL delete

### DIFF
--- a/netkan/netkan/queue_handler.py
+++ b/netkan/netkan/queue_handler.py
@@ -96,6 +96,7 @@ class QueueHandler:
             for _, handler in self.game_handlers.items():
                 with handler:
                     processed = handler.process_messages()
-                    queue.delete_messages(
-                        Entries=processed
-                    )
+                    if processed:
+                        queue.delete_messages(
+                            Entries=processed
+                        )


### PR DESCRIPTION
We always had messages to delete previously, now it's possible/likely to have a game that doesn't have any messages to delete.