### PR TITLE
Log SpaceDockAdder._pr_body input on failure

### DIFF
--- a/netkan/netkan/spacedock_adder.py
+++ b/netkan/netkan/spacedock_adder.py
@@ -83,11 +83,16 @@ class SpaceDockAdder:
 
     @staticmethod
     def _pr_body(info: Dict[str, Any]) -> str:
-        return SpaceDockAdder.PR_BODY_TEMPLATE.safe_substitute(
-            defaultdict(lambda: '',
-                        {**info,
-                         'all_authors_md': ', '.join(SpaceDockAdder.USER_TEMPLATE.safe_substitute(defaultdict(lambda: '', a))
-                                                     for a in [info, *info.get('shared_authors', [])])}))
+        try:
+            return SpaceDockAdder.PR_BODY_TEMPLATE.safe_substitute(
+                defaultdict(lambda: '',
+                            {**info,
+                             'all_authors_md': ', '.join(SpaceDockAdder.USER_TEMPLATE.safe_substitute(defaultdict(lambda: '', a))
+                                                         for a in [info, *info.get('shared_authors', [])])}))
+        except Exception as exc:
+            # Log the input on failure
+            logging.error('Failed to generate pull request body from %s', info)
+            raise exc
 
     def yaml_dump(self, obj: Dict[str, Any]) -> str:
         sio = io.StringIO()


### PR DESCRIPTION
## Problem

This happened:

```
Uncaught exception:
Traceback (most recent call last):
  File ".local/bin/netkan", line 8, in <module>
    sys.exit(netkan())
  File "/home/netkan/.local/lib/python3.7/site-packages/click/core.py", line 1130, in __call__
    return self.main(*args, **kwargs)
  File "/home/netkan/.local/lib/python3.7/site-packages/click/core.py", line 1055, in main
    rv = self.invoke(ctx)
  File "/home/netkan/.local/lib/python3.7/site-packages/click/core.py", line 1657, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/home/netkan/.local/lib/python3.7/site-packages/click/core.py", line 1404, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "/home/netkan/.local/lib/python3.7/site-packages/click/core.py", line 760, in invoke
    return __callback(*args, **kwargs)
  File "/home/netkan/.local/lib/python3.7/site-packages/click/decorators.py", line 84, in new_func
    return ctx.invoke(f, obj, *args, **kwargs)
  File "/home/netkan/.local/lib/python3.7/site-packages/click/core.py", line 760, in invoke
    return __callback(*args, **kwargs)
  File "/home/netkan/.local/lib/python3.7/site-packages/netkan/cli/services.py", line 75, in spacedock_adder
    SpaceDockAdderQueueHandler(common).run()
  File "/home/netkan/.local/lib/python3.7/site-packages/netkan/queue_handler.py", line 98, in run
    processed = handler.process_messages()
  File "/home/netkan/.local/lib/python3.7/site-packages/netkan/spacedock_adder.py", line 164, in process_messages
    return [c.delete_attrs for c in self._process_queue(self.queued)]
  File "/home/netkan/.local/lib/python3.7/site-packages/netkan/spacedock_adder.py", line 159, in _process_queue
    if netkan.try_add():
  File "/home/netkan/.local/lib/python3.7/site-packages/netkan/spacedock_adder.py", line 80, in try_add
    body=SpaceDockAdder._pr_body(self.info),
  File "/home/netkan/.local/lib/python3.7/site-packages/netkan/spacedock_adder.py", line 90, in _pr_body
    for a in [info, *info.get('shared_authors', [])])}))
  File "/home/netkan/.local/lib/python3.7/site-packages/netkan/spacedock_adder.py", line 90, in <genexpr>
    for a in [info, *info.get('shared_authors', [])])}))
ValueError: dictionary update sequence element #0 has length 1; 2 is required
```

## Cause

Seems to be related to co-author handling from #287, since the mod that I think it's for has co-authors and the others so far haven't:

- <https://spacedock.info/mod/3331/Galaxy%20Tweaker%20(Now%20allows%20editing%20physical%20properties%20of%20planets!)>

That's a really weird error; if there's a dictionary update sequence there, I don't see it. There's a _list_ of dictionaries, but that should be fine. When I try running this code with some hand-made sample data, it works and doesn't throw.

## Changes

Now we log the `info` object if there's an exception so if this happens again, we can figure out why.
