### PR TITLE
Handle bad author list input from SpaceDock

### DIFF
--- a/netkan/netkan/spacedock_adder.py
+++ b/netkan/netkan/spacedock_adder.py
@@ -84,11 +84,19 @@ class SpaceDockAdder:
     @staticmethod
     def _pr_body(info: Dict[str, Any]) -> str:
         try:
-            return SpaceDockAdder.PR_BODY_TEMPLATE.safe_substitute(
-                defaultdict(lambda: '',
-                            {**info,
-                             'all_authors_md': ', '.join(SpaceDockAdder.USER_TEMPLATE.safe_substitute(defaultdict(lambda: '', a))
-                                                         for a in [info, *info.get('shared_authors', [])])}))
+            shared_authors = info.get('shared_authors', [])
+            # It's supposed to be a list of dicts, SpaceDock has a bug right now where it's a string
+            bad_author = (not isinstance(shared_authors, list)
+                          or any(not isinstance(auth, dict) for auth in shared_authors))
+            if bad_author:
+                logging.error('shared_authors should be list of dicts, is: %s', shared_authors)
+            return SpaceDockAdder.PR_BODY_TEMPLATE.safe_substitute(defaultdict(
+                lambda: '',
+                {**info,
+                 'all_authors_md': ', '.join(SpaceDockAdder.USER_TEMPLATE.safe_substitute(defaultdict(lambda: '', a))
+                                             for a in ([info]
+                                                       if bad_author else
+                                                       [info, *info.get('shared_authors', [])]))}))
         except Exception as exc:
             # Log the input on failure
             logging.error('Failed to generate pull request body from %s', info)


### PR DESCRIPTION
## Problem

See #293, the SpaceDockAdder is repeatedly failing for a mod with co-authors.

## Cause

After #293, we can see that SpaceDock is passing a string where it's supposed to pass a list of dicts:

```json
"shared_authors": "username"
```

(`username` is the first key in the contained dicts)

## Changes

Now the SpaceDockAdder performs run-time type checks on the shared authors property and only uses it to generate the PR body if it's correct. Otherwise an error is logged.

This will allow the bot to finally finish processing the request that's been stuck in the queue. The underlying SpaceDock bug will be fixed later.
