### PR TITLE
Multigame ModStatus

### DIFF
--- a/netkan/netkan/indexer.py
+++ b/netkan/netkan/indexer.py
@@ -34,6 +34,7 @@ class CkanMessage:
         self.ckan = Ckan(contents=self.body)
         # pylint: disable=invalid-name
         self.ModIdentifier: str
+        self.GameId: str
         self.CheckTime: str
         self.FileName: str
         self.Success: bool
@@ -103,6 +104,7 @@ class CkanMessage:
 
     def status_attrs(self, new: bool = False) -> Dict[str, Any]:
         attrs: Dict[str, Any] = {
+            'game_id': self.GameId.lower(),
             'success': self.Success,
             'last_error': self.ErrorMessage,
             'last_warnings': self.WarningMessages,

--- a/netkan/netkan/status.py
+++ b/netkan/netkan/status.py
@@ -35,6 +35,7 @@ class ModStatus(Model):
         region = region()
 
     ModIdentifier = UnicodeAttribute(hash_key=True)
+    game_id = UnicodeAttribute(null=True)
     last_error = UnicodeAttribute(null=True)
     last_warnings = UnicodeAttribute(null=True)
     last_checked = UTCDateTimeAttribute(null=True)

--- a/netkan/netkan/status.py
+++ b/netkan/netkan/status.py
@@ -109,6 +109,9 @@ class ModStatus(Model):
 
                 item['ModIdentifier'] = key
                 item['success'] = not item['failed']
+                # Assist in migration of tables to multi-game
+                if item['game_id'] is None:
+                    item['game_id'] = 'ksp'
                 item.pop('failed')
 
                 # Every batch write consumes a credit, we want to leave spare

--- a/netkan/netkan/status.py
+++ b/netkan/netkan/status.py
@@ -95,6 +95,8 @@ class ModStatus(Model):
         existing = json.loads(Path(filename).read_text(encoding='UTF-8'))
         with cls.batch_write() as batch:
             for key, item in existing.items():
+                # Ensure all date/time items are passed to ModStatus
+                # as proper datetime.datetime obects
                 for item_key in ['checked', 'indexed', 'inflated']:
                     update_key = f'last_{item_key}'
                     if not item[update_key]:
@@ -102,6 +104,9 @@ class ModStatus(Model):
                     item[update_key] = parse(
                         item.pop(update_key)
                     )
+                if item['release_date'] is not None:
+                    item['release_date'] = parse(item.pop('release_date'))
+
                 item['ModIdentifier'] = key
                 item['success'] = not item['failed']
                 item.pop('failed')

--- a/netkan/tests/indexer.py
+++ b/netkan/tests/indexer.py
@@ -32,6 +32,8 @@ class TestCkan(unittest.TestCase):
                 'StringValue': '2019-06-24T19:06:14', 'DataType': 'String'},
             'ModIdentifier': {
                 'StringValue': 'DogeCoinFlag', 'DataType': 'String'},
+            'GameId': {
+                'StringValue': 'ksp', 'DataType': 'String'},
             'Staged': {'StringValue': 'False', 'DataType': 'String'},
             'Success': {'StringValue': 'True', 'DataType': 'String'},
             'FileName': {


### PR DESCRIPTION
This is an initial piece of work that will at least set the 'game_id' in our status table in advance of moving the query to a Hash + Range key.

No changes to the Table will happen in this PR. Upon merge, status updates will begin populating the field.