### PR TITLE
Put $vref before license in SD PRs

### DIFF
--- a/netkan/netkan/spacedock_adder.py
+++ b/netkan/netkan/spacedock_adder.py
@@ -123,10 +123,12 @@ class SpaceDockAdder:
             # Tell Discord about the problem and move on
             logging.error('%s failed to analyze %s from %s',
                           self.__class__.__name__, ident, url, exc_info=exc)
+        vref_props = {'$vref': props.pop('$vref')} if '$vref' in props else {}
         return {
             'spec_version': 'v1.18',
             'identifier': ident,
             '$kref': f"#/ckan/spacedock/{info.get('id', '')}",
+            **(vref_props),
             'license': info.get('license', '').strip().replace(' ', '-'),
             **(props),
             'x_via': f"Automated {info.get('site_name')} CKAN submission"


### PR DESCRIPTION
## Motivation

Currently the SpaceDockAdder's autogenerated netkans have the `license` property before the `$vref` if one exists, which is contrary to how the existing metadata looks. I've been swapping them by hand while adding tags, but if [we're hopefully going to have new Wranglers joining](https://github.com/KSP-CKAN/CKAN/wiki/How-to-Wrangle-Metadata-for-KSP2), I'd like to get this into more of a turnkey state.

## Changes

Now if the mod analyzer returns a vref, we extract it from the rest of the props and include it specifically in the right spot.
