### PR TITLE
Get SpaceDock co-authors from POST form lists

### DIFF
--- a/netkan/netkan/spacedock_adder.py
+++ b/netkan/netkan/spacedock_adder.py
@@ -89,20 +89,12 @@ class SpaceDockAdder:
     @staticmethod
     def _pr_body(info: Dict[str, Any]) -> str:
         try:
-            shared_authors = info.get('shared_authors', [])
-            # It's supposed to be a list of dicts, SpaceDock has a bug right now where it's a string
-            bad_author = (not isinstance(shared_authors, list)
-                          or any(not isinstance(auth, dict) for auth in shared_authors))
-            if bad_author:
-                logging.error('shared_authors should be list of dicts, is: %s', shared_authors)
             return SpaceDockAdder.PR_BODY_TEMPLATE.safe_substitute(defaultdict(
                 lambda: '',
                 {**info,
                  'all_authors_md': ', '.join(SpaceDockAdder.USER_TEMPLATE.safe_substitute(
                                                                 defaultdict(lambda: '', a))
-                                             for a in ([info]
-                                                       if bad_author else
-                                                       [info, *info.get('shared_authors', [])]))}))
+                                             for a in info.get('all_authors', []))}))
         except Exception as exc:
             # Log the input on failure
             logging.error('Failed to generate pull request body from %s', info)


### PR DESCRIPTION
## Problem

See #293 and #294; #287 doesn't work. Instead of the `shared_authors` property containing the co-authors, we just receive `username`, so attempting to add the co-authors throws an exception.

## Cause

You can't send a list of dicts in a POST form. I thought it was JSON.

## Changes

Someday soon, SpaceDock will start sending multiple values for the user fields, one per author (see KSP-SpaceDock/SpaceDock#490). This is supported in POST forms. Once we have that, this pull request will read those lists to get the co-authors.

**Note that KSP-SpaceDock/SpaceDock#490 must be deployed to production before this is merged!** Currently there is no specific plan for the next upgrade, but SpaceDock updates have been somewhat frequent lately, so it shouldn't take too long.
