### PR TITLE
Multi Game Status

### DIFF
--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -17,12 +17,13 @@ services:
       AWS_ACCESS_KEY_ID: ${CKAN_AWS_ACCESS_KEY_ID}
       GH_Token: ${CKAN_GH_Token}
       SQS_TIMEOUT: 30
-      STATUS_DB: DevNetKANStatus
+      STATUS_DB: DevMultiKANStatus
       XKAN_GHSECRET: test
       INFLATION_QUEUES: ksp=InboundDevKsp.fifo ksp2=InboundDevKsp2.fifo
       MIRROR_SQS_QUEUE: MirroringDev.fifo
       STATUS_BUCKET: ckan-test-status
       STATUS_INTERVAL: 0
+      STATUS_KEYS: 'ksp=status/netkan.json ksp2=status/netkan-ksp2.json'
       DISCORD_WEBHOOK_ID: ${DISCORD_WEBHOOK_ID}
       DISCORD_WEBHOOK_TOKEN: ${DISCORD_WEBHOOK_TOKEN}
     volumes:

--- a/dev-stack.py
+++ b/dev-stack.py
@@ -91,10 +91,14 @@ for queue in [inbound_ksp, inbound_ksp2, outbound, addqueue, mirrorqueue]:
     ])
 
 dev_db = t.add_resource(Table(
-    "DevNetKANStatus",
+    "DevMultiKANStatus",
     AttributeDefinitions=[
         AttributeDefinition(
             AttributeName="ModIdentifier",
+            AttributeType="S"
+        ),
+        AttributeDefinition(
+            AttributeName="game_id",
             AttributeType="S"
         ),
     ],
@@ -102,9 +106,13 @@ dev_db = t.add_resource(Table(
         KeySchema(
             AttributeName="ModIdentifier",
             KeyType="HASH"
-        )
+        ),
+        KeySchema(
+            AttributeName="game_id",
+            KeyType="RANGE"
+        ),
     ],
-    TableName="DevNetKANStatus",
+    TableName="DevMultiKANStatus",
     ProvisionedThroughput=ProvisionedThroughput(
         ReadCapacityUnits=5,
         WriteCapacityUnits=5

--- a/netkan/tests/__init__.py
+++ b/netkan/tests/__init__.py
@@ -10,4 +10,5 @@ from .utils import *
 from .csharp_compat import *
 from .auto_freezer import *
 from .spacedock_adder import *
+from .status import *
 from .webhooks import *

--- a/netkan/tests/status.py
+++ b/netkan/tests/status.py
@@ -1,0 +1,51 @@
+# pylint: disable-all
+# flake8: noqa
+
+from datetime import datetime
+from unittest import TestCase
+
+from netkan.status import ModStatus
+
+
+class TestModStatusRestore(TestCase):
+    def item_data(self):
+        return {
+            "frozen": False,
+            "game_id": "ksp2",
+            "last_checked": "2023-04-11T13:40:16.261429+00:00",
+            "last_downloaded": "2023-04-11T13:40:16.261429+00:00",
+            "last_error": None,
+            "last_indexed": "2023-04-11T14:40:18.673421+00:00",
+            "last_inflated": "2023-04-13T08:10:15+00:00",
+            "last_warnings": "No plugin matching the identifier, manual installations won't be detected: BepInEx/plugins/utilityuplift/utilityuplift.dll",
+            "release_date": "2023-04-11T13:34:15.550546+00:00",
+            "failed": False
+        }
+
+    def test_datetime_types(self):
+        values = self.item_data()
+        ModStatus.normalise_item('TestMod', values)
+        for val in ['last_checked', 'last_downloaded', 'last_indexed', 'last_inflated', 'release_date']:
+            self.assertIsInstance(values.get(val), datetime)
+
+    def test_success_true(self):
+        values = self.item_data()
+        ModStatus.normalise_item('SuccessMod', values)
+        self.assertTrue(values.get('success'))
+
+    def test_success_false(self):
+        values = self.item_data()
+        values.update(failed=True)
+        ModStatus.normalise_item('FailedMod', values)
+        self.assertFalse(values.get('success'))
+
+    def test_default_game(self):
+        values = self.item_data()
+        values.update(game_id=None)
+        ModStatus.normalise_item('DefaultMod', values)
+        self.assertEqual(values.get('game_id'), 'ksp')
+
+    def test_modidentifier(self):
+        values = self.item_data()
+        ModStatus.normalise_item('TheMod', values)
+        self.assertEqual(values.get('ModIdentifier'), 'TheMod')


### PR DESCRIPTION
This changes the dynamodb table to us a Range key of 'game_id', so that we can query a record specifically by ModIdentifier + game_id.

It includes the ability to export/import all mods, defaulting the game_id to ksp on import. This is required as setting a range key requires recreation of the table.

Export to S3 splits the games on export. Persisting how the current status works, giving us some time to address it separately.

I've created/done an initial load of the data to the new table, so if all looks good, we can merge and handle the clean up of the previous table after.