### PR TITLE
AutoFreezer ModStatus

### DIFF
--- a/netkan/netkan/cli/utilities.py
+++ b/netkan/netkan/cli/utilities.py
@@ -34,6 +34,7 @@ def auto_freezer(common: SharedArgs, days_limit: int, days_till_ignore: int) -> 
         afr = AutoFreezer(
             common.game(game_id).netkan_repo,
             common.game(game_id).github_pr,
+            game_id,
         )
         afr.freeze_idle_mods(days_limit, days_till_ignore)
         afr.mark_frozen_mods()

--- a/netkan/netkan/webhooks/github_inflate.py
+++ b/netkan/netkan/webhooks/github_inflate.py
@@ -90,7 +90,7 @@ def freeze(ids: List[str], game_id: str) -> None:
         logging.info('Marking frozen mods...')
         for ident in ids:
             try:
-                status = ModStatus.get(ident)
+                status = ModStatus.get(ident, range_key=game_id)
                 if not status.frozen:
                     logging.info('Marking frozen: %s', ident)
                     # https://readthedocs.org/projects/pynamodb/downloads/pdf/stable/

--- a/netkan/tests/auto_freezer.py
+++ b/netkan/tests/auto_freezer.py
@@ -51,10 +51,11 @@ class TestAutoFreezer(unittest.TestCase):
                 Netkan(contents='{ "identifier": "SmartTank"  }'),
                 Netkan(contents='{ "identifier": "Ringworld"  }'),
             ]
-            status_mock.get.side_effect = lambda ident: unittest.mock.Mock(release_date=self.IDENT_TIMESTAMPS[ident])
+            status_mock.get.side_effect = lambda ident, range_key: unittest.mock.Mock(
+                release_date=self.IDENT_TIMESTAMPS[ident])
             nk_repo = nk_repo_mock(git.Repo('/blah'))
             github_pr = pr_mock('', '', '')
-            af = AutoFreezer(nk_repo, github_pr)
+            af = AutoFreezer(nk_repo, github_pr, 'ksp')
 
             # Act
             astrogator_dttm = af._last_timestamp('Astrogator')
@@ -79,14 +80,14 @@ class TestAutoFreezer(unittest.TestCase):
             patch('netkan.auto_freezer.ModStatus') as status_mock, \
             patch('netkan.github_pr.GitHubPR') as pr_mock:
 
-            status_mock.get.side_effect = lambda ident: unittest.mock.Mock(
+            status_mock.get.side_effect = lambda ident, range_key: unittest.mock.Mock(
                 release_date=self.IDENT_TIMESTAMPS[ident],
                 resources=MapAttribute(**self.IDENT_RESOURCES[ident]))
-            unittest.util._MAX_LENGTH=999999999 # :snake:
+            unittest.util._MAX_LENGTH = 999999999  # :snake:
 
             nk_repo = nk_repo_mock(git.Repo('/blah'))
             github_pr = pr_mock('', '', '')
-            af = AutoFreezer(nk_repo, github_pr)
+            af = AutoFreezer(nk_repo, github_pr, 'ksp')
 
             # Act
             af._submit_pr('test_branch_name', 69, [


### PR DESCRIPTION
As with the indexer, the range_key was overlooked. This ensures the game_id is passed to ModStatus.get, which is compliant with the new schema.