### PR TITLE
Ensure Status range_key is consistent

### DIFF
--- a/netkan/netkan/auto_freezer.py
+++ b/netkan/netkan/auto_freezer.py
@@ -59,7 +59,7 @@ class AutoFreezer:
 
     def _last_timestamp(self, ident: str) -> Optional[datetime]:
         try:
-            status = ModStatus.get(ident, range_key=self.game_id)
+            status = ModStatus.get(ident, range_key=self.game_id.lower())
             return getattr(status, 'release_date',
                            getattr(status, 'last_indexed',
                                    None))
@@ -84,7 +84,7 @@ class AutoFreezer:
 
     @staticmethod
     def _mod_cell(ident: str, game_id: str) -> str:
-        status = ModStatus.get(ident, range_key=game_id)
+        status = ModStatus.get(ident, range_key=game_id.lower())
         resources = getattr(status, 'resources', None)
         if resources:
             links = r' \| '.join(f'[{key}]({url})'

--- a/netkan/netkan/indexer.py
+++ b/netkan/netkan/indexer.py
@@ -136,7 +136,8 @@ class CkanMessage:
             self.write_metadata()
             self.commit_metadata(new_file)
         try:
-            status = ModStatus.get(self.ModIdentifier, range_key=self.GameId)
+            status = ModStatus.get(
+                self.ModIdentifier, range_key=self.GameId.lower())
             attrs = self.status_attrs()
             if not self.Success and getattr(status, 'last_error', None) != self.ErrorMessage:
                 logging.error('New inflation error for %s: %s',

--- a/netkan/netkan/webhooks/github_inflate.py
+++ b/netkan/netkan/webhooks/github_inflate.py
@@ -90,7 +90,7 @@ def freeze(ids: List[str], game_id: str) -> None:
         logging.info('Marking frozen mods...')
         for ident in ids:
             try:
-                status = ModStatus.get(ident, range_key=game_id)
+                status = ModStatus.get(ident, range_key=game_id.lower())
                 if not status.frozen:
                     logging.info('Marking frozen: %s', ident)
                     # https://readthedocs.org/projects/pynamodb/downloads/pdf/stable/

--- a/netkan/tests/indexer.py
+++ b/netkan/tests/indexer.py
@@ -88,6 +88,9 @@ class TestCkan(unittest.TestCase):
     def test_ckan_message_mod_version(self):
         self.assertEqual('DogeCoinFlag-v1.02', self.message.mod_version)
 
+    def test_ckan_message_game_id(self):
+        self.assertEqual(self.message.GameId, 'ksp')
+
     def test_ckan_message_success(self):
         self.assertTrue(self.message.Success)
 
@@ -128,6 +131,7 @@ class TestCkan(unittest.TestCase):
     def test_ckan_message_status_attrs(self):
         attrs = self.message.status_attrs(new=True)
         self.assertEqual(attrs['ModIdentifier'], 'DogeCoinFlag')
+        self.assertEqual(attrs['game_id'], 'ksp')
         self.assertTrue(attrs['success'])
         self.assertIsInstance(attrs['last_inflated'], datetime)
         self.assertEqual(attrs['last_error'], None)


### PR DESCRIPTION
All range keys are lower, however we could be asking for it in upper, which won't exist and upon save PynamoDB will dutifly wipe out the fields that aren't set. Instead of doing the update during status as expected.