### PR TITLE
Don't allow spaces in filenames for archive.org

### DIFF
--- a/netkan/netkan/metadata.py
+++ b/netkan/netkan/metadata.py
@@ -446,6 +446,6 @@ class Ckan:
     def _format_version(self, with_epoch: bool) -> Optional[str]:
         if self.version:
             if with_epoch:
-                return self.version.string.replace(':', '-')
-            return self.EPOCH_VERSION_REGEXP.sub('', self.version.string)
+                return self.version.string.replace(' ', '_').replace(':', '-')
+            return self.EPOCH_VERSION_REGEXP.sub('', self.version.string.replace(' ', '_'))
         return None


### PR DESCRIPTION
## Problem

![image](https://github.com/KSP-CKAN/NetKAN-Infra/assets/1559108/9d5cec50-6f5f-4f1c-a392-bfae70a0c8ee)

## Cause

Spaces in versions wreaking havoc again.

## Changes

Now spaces in versions are replaced with underscores when uploading to archive.org. Will need a corresponding change in the client to actually use such fallbacks.

Will self-review.
