### PR TITLE
Detect VertexMitchellNetravaliHeightMap

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v1
       - name: Build Image

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -13,7 +13,7 @@ jobs:
       run:
         working-directory: netkan
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Setup Python
         uses: actions/setup-python@v1
         with:

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v1
       - name: Login to DockerHub
@@ -39,7 +39,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v1
       - name: Login to DockerHub
@@ -61,7 +61,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: [ 'build', 'webhooks' ]
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Set up Python 3.7
         uses: actions/setup-python@v1
         with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,7 +8,7 @@ jobs:
   pytest:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Setup Python
         uses: actions/setup-python@v1
         with:

--- a/netkan/netkan/mod_analyzer.py
+++ b/netkan/netkan/mod_analyzer.py
@@ -61,6 +61,8 @@ class ModAnalyzer:
                                             [],               ['B9PartSwitch']),
         CfgAspect(r'^\s*name\s*=\s*ModuleWaterfallFX\b',
                                             ['graphics'],     ['Waterfall']),
+        CfgAspect(r'^\s*VertexMitchellNetravaliHeightMap\b',
+                                            [],               ['VertexMitchellNetravaliHeightMap']),
 
         FilenameAspect(r'\.ks$',            ['config',
                                              'control'],      ['kOS']),


### PR DESCRIPTION
## Motivation

The mod for KSP-CKAN/NetKAN#9788 says:

![image](https://github.com/KSP-CKAN/NetKAN-Infra/assets/1559108/5f3937c8-9241-408f-abb9-59716a2c53ca)

That third entry is this, which we have as [`VertexMitchellNetravaliHeightMap`](https://github.com/KSP-CKAN/NetKAN/tree/master/NetKAN/VertexMitchellNetravaliHeightMap.netkan):

![image](https://github.com/KSP-CKAN/NetKAN-Infra/assets/1559108/761119e2-35f5-4e6c-bef8-fc5bd7fd05b6)

In browsing the depending mod, I found what looks like some config to use that plugin:

```
				//Heightmaps
				VertexMitchellNetravaliHeightMap //ancient terrain
				{
					map = TPR/PluginData/Munheightancient.png
					offset = -2300
					deformity = 3800
					scaleDeformityByRadius = False
					order = 10
					enabled = True
					name = _Height
				}
```

## Changes

Now if the `ModAnalyzer` spots that string in a `.cfg`, it'll add this dependency automatically.
