### PR TITLE
Use deep clone for SpaceDockAdder

### DIFF
--- a/prod-stack.py
+++ b/prod-stack.py
@@ -842,7 +842,7 @@ services = [
     },
     {
         'name': 'Adder',
-        'command': 'spacedock-adder',
+        'command': ['spacedock-adder', '--deep-clone'],
         'secrets': ['GH_Token', 'SSH_KEY'],
         'env': [
             ('SQS_QUEUE', GetAtt(addqueue, 'QueueName')),


### PR DESCRIPTION
## Problem

We've been getting spammed by these every 5 minutes:

![image](https://github.com/KSP-CKAN/NetKAN-Infra/assets/1559108/6262165a-94b3-4a00-bcee-65f1df493983)

## Cause

The CKAN checkbox came unchecked for this mod on SpaceDock, so I re-checked it, which caused the webhooks to put an entry into the `SpaceDockAdder`'s input queue for it.

The `SpaceDockAdder` then fails to process it, leaves it in the queue, and tries again in 5 minutes. This happens because KSP-CKAN/NetKAN#9778 is still open and its branch still exists, so the adder fails to push the branch, because it's using a shallow clone.

This is the same problem that the `AutoFreezer` was having in #302.

## Changes

Just like #303 did for the `AutoFreezer`, the `SpaceDockAdder` now uses a deep clone, which will allow it to re-use existing branches.
