### PR TITLE
Add Aspect to ModAnalyzer to detect patch manager patches

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -2,14 +2,6 @@
   "python.pythonPath": "/usr/bin/python3",
   "python.formatting.provider": "autopep8",
   "editor.formatOnSave": true,
-  "python.linting.pylintEnabled": true,
-  "python.linting.enabled": true,
-  "python.linting.pylintArgs": [
-    "--rcfile",
-    "/home/netkan/workspace/.pylintrc"
-  ],
-  "python.linting.mypyEnabled": true,
-  "python.linting.pylintUseMinimalCheckers": false,
   "files.exclude": {
     "**/__pycache__": true
   },
@@ -18,5 +10,6 @@
   "python.testing.unittestEnabled": false,
   "files.trimTrailingWhitespace": true,
   "files.insertFinalNewline": true,
-  "files.trimFinalNewlines": true
+  "files.trimFinalNewlines": true,
+  "mypy.configFile": "netkan/mypy.ini"
 }

--- a/netkan/netkan/github_pr.py
+++ b/netkan/netkan/github_pr.py
@@ -28,10 +28,11 @@ class GitHubPR:
     def default_branch(self) -> str:
         return self.repo.default_branch
 
-    def create_pull_request(self, title: str, branch: str, body: str, labels: Optional[List[str]] = None) -> None:
+    def create_pull_request(self, title: str, branch: str, body: str,
+                            labels: Optional[List[str]] = None) -> None:
         try:
-            pull = self.repo.create_pull(
-                title, body, self.default_branch, branch)
+            pull = self.repo.create_pull(self.default_branch, branch,
+                                         title=title, body=body)
             logging.info('Pull request for %s opened at %s',
                          branch, pull.html_url)
 

--- a/netkan/netkan/mod_analyzer.py
+++ b/netkan/netkan/mod_analyzer.py
@@ -69,6 +69,7 @@ class ModAnalyzer:
         FilenameAspect(r'swinfo\.json$',    [],               ['SpaceWarp']),
         FilenameAspect(r'\.dll$',           ['plugin'],       []),
         FilenameAspect(r'\.cfg$',           ['config'],       []),
+        FilenameAspect(r'\.patch$',         ['config'],       ['PatchManager']),
     ]
     FILTERS = [
         '__MACOSX', '.DS_Store',

--- a/netkan/setup.py
+++ b/netkan/setup.py
@@ -24,7 +24,7 @@ setup(
         'jinja2',
         'internetarchive!=3.0.1',
         'gunicorn>=19.9,!=20.0.0',
-        'discord.py>=1.6.0',
+        'discord.py>=1.6.0,<=1.7.3',
         'PyGithub',
         'ruamel.yaml',
     ],

--- a/netkan/tests/webhooks.py
+++ b/netkan/tests/webhooks.py
@@ -1,5 +1,6 @@
 import os
 import sys
+from typing import Mapping, Any, cast
 
 from unittest import mock, TestCase
 from unittest.mock import MagicMock
@@ -121,7 +122,7 @@ class TestWebhookGitHubInflate(WebhooksHarness):
         response = self.client.post(
             '/gh/inflate/ksp', json=data, follow_redirects=True)
         self.assertEqual(response.status_code, 200)
-        self.assertDictEqual(response.json, {'message': 'Wrong branch'})
+        self.assertDictEqual(cast(Mapping[Any, object], response.json), {'message': 'Wrong branch'})
 
     @mock.patch('netkan.webhooks.github_utils.sig_match')
     def test_inflate_ksp2_wrong_branch(self, sig: MagicMock):
@@ -131,7 +132,7 @@ class TestWebhookGitHubInflate(WebhooksHarness):
         response = self.client.post(
             '/gh/inflate/ksp2', json=data, follow_redirects=True)
         self.assertEqual(response.status_code, 200)
-        self.assertDictEqual(response.json, {'message': 'Wrong branch'})
+        self.assertDictEqual(cast(Mapping[Any, object], response.json), {'message': 'Wrong branch'})
 
     @mock.patch('netkan.webhooks.github_utils.sig_match')
     def test_inflate_ksp_no_commits(self, sig: MagicMock):
@@ -141,7 +142,8 @@ class TestWebhookGitHubInflate(WebhooksHarness):
         response = self.client.post(
             '/gh/inflate/ksp', json=data, follow_redirects=True)
         self.assertEqual(response.status_code, 200)
-        self.assertDictEqual(response.json, {'message': 'No commits received'})
+        self.assertDictEqual(cast(Mapping[Any, object], response.json),
+                             {'message': 'No commits received'})
 
     @mock.patch('netkan.webhooks.github_utils.sig_match')
     def test_inflate_ksp2_no_commits(self, sig: MagicMock):
@@ -151,7 +153,8 @@ class TestWebhookGitHubInflate(WebhooksHarness):
         response = self.client.post(
             '/gh/inflate/ksp2', json=data, follow_redirects=True)
         self.assertEqual(response.status_code, 200)
-        self.assertDictEqual(response.json, {'message': 'No commits received'})
+        self.assertDictEqual(cast(Mapping[Any, object], response.json),
+                             {'message': 'No commits received'})
 
     @mock.patch('netkan.status.ModStatus.get')
     @mock.patch('netkan.webhooks.github_utils.sig_match')
@@ -251,7 +254,7 @@ class TestWebhookGitHubMirror(WebhooksHarness):
         response = self.client.post(
             '/gh/mirror/ksp', json=data, follow_redirects=True)
         self.assertEqual(response.status_code, 200)
-        self.assertDictEqual(response.json, {'message': 'Wrong branch'})
+        self.assertDictEqual(cast(Mapping[Any, object], response.json), {'message': 'Wrong branch'})
 
     @mock.patch('netkan.webhooks.github_utils.sig_match')
     def test_inflate_ksp2_wrong_branch(self, sig: MagicMock):
@@ -261,7 +264,7 @@ class TestWebhookGitHubMirror(WebhooksHarness):
         response = self.client.post(
             '/gh/mirror/ksp2', json=data, follow_redirects=True)
         self.assertEqual(response.status_code, 200)
-        self.assertDictEqual(response.json, {'message': 'Wrong branch'})
+        self.assertDictEqual(cast(Mapping[Any, object], response.json), {'message': 'Wrong branch'})
 
     @mock.patch('netkan.webhooks.github_utils.sig_match')
     def test_inflate_ksp_no_commits(self, sig: MagicMock):
@@ -271,7 +274,8 @@ class TestWebhookGitHubMirror(WebhooksHarness):
         response = self.client.post(
             '/gh/mirror/ksp', json=data, follow_redirects=True)
         self.assertEqual(response.status_code, 200)
-        self.assertDictEqual(response.json, {'message': 'No commits received'})
+        self.assertDictEqual(cast(Mapping[Any, object], response.json),
+                             {'message': 'No commits received'})
 
     @mock.patch('netkan.webhooks.github_utils.sig_match')
     def test_inflate_ksp2_no_commits(self, sig: MagicMock):
@@ -281,7 +285,8 @@ class TestWebhookGitHubMirror(WebhooksHarness):
         response = self.client.post(
             '/gh/mirror/ksp2', json=data, follow_redirects=True)
         self.assertEqual(response.status_code, 200)
-        self.assertDictEqual(response.json, {'message': 'No commits received'})
+        self.assertDictEqual(cast(Mapping[Any, object], response.json),
+                             {'message': 'No commits received'})
 
 
 class TestWebhookInflate(WebhooksHarness):
@@ -433,7 +438,7 @@ class TestWebhookSpaceDockAdd(WebhooksHarness):
     @staticmethod
     def mock_netkan_hook() -> dict:
         return {
-            'name:              Mod Name Entered by the User on spacedock'
+            'name': 'Mod Name Entered by the User on spacedock',
             'id': '12345',
             'license': 'GPL-3.0',
             'username': 'modauthor1',


### PR DESCRIPTION
## Motivation
A mod has been released for KSP2, `PatchManager`, that uses special files (.patch files) to either patch data in the addressables for the game, and/or add new data to the addressables assets. any KSP2 mod that use files with this extension necessarily depend on this mod, examples being `CommunityResources`, or `KerbalLifeSupportSystem`. So it would make sense for them to be autodetected to add `PatchManager` as a dependency to the mods via the `ModAnalyzer` class.

## Changes
Adds an aspect to the `ModAnalyzer` class that detects *.patch files, and adds the `config` tag (closest tag to match for what patch files are), and adds a dependency on `PatchManager`