### PR TITLE
Fix timezone problem in ticket closer

### DIFF
--- a/netkan/netkan/ticket_closer.py
+++ b/netkan/netkan/ticket_closer.py
@@ -1,5 +1,5 @@
 import logging
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 from importlib.resources import read_text
 from collections import defaultdict
 from string import Template
@@ -18,7 +18,7 @@ class TicketCloser:
         self._user_name = user_name
 
     def close_tickets(self, days_limit: int = 7) -> None:
-        date_cutoff = datetime.now() - timedelta(days=days_limit)
+        date_cutoff = datetime.now(timezone.utc) - timedelta(days=days_limit)
 
         for repo_name in self.REPO_NAMES:
             repo = self._gh.get_repo(f'{self._user_name}/{repo_name}')


### PR DESCRIPTION
## Problem

The ticket closer has thrown this the last 2 days:

![image](https://github.com/KSP-CKAN/NetKAN-Infra/assets/1559108/21973c85-1c8d-4863-a08b-f3a52e48c807)

## Cause

Python throws a runtime exception if time zones aren't handled to its liking. 🐍 

`datetime.now()` doesn't have timezone info associated with it, so by process of elimination `issue.updated_at` must have it. Maybe we updated the GitHub API library recently. 🤷 

## Changes

Now we pass `timezone.utc` to `datetime.now()` so both parts of the comparison will have timezone data.

I'll self review this so we can see if it works in tomorrow's run.
