### PR TITLE
Quick fix for multi-doc YAML

### DIFF
--- a/netkan/netkan/metadata.py
+++ b/netkan/netkan/metadata.py
@@ -35,7 +35,7 @@ class Netkan:
         self.game_id = game_id
         yaml = YAML(typ='safe')
         # YAML parser doesn't allow tabs, so replace with spaces
-        self._raw = yaml.load(self.contents.replace('\t', '    '))
+        self._raw = next(yaml.load_all(self.contents.replace('\t', '    ')))
         # Extract kref_src + kref_id from the kref
         self.kref_src: Optional[str]
         self.kref_id: Optional[str]


### PR DESCRIPTION
## Problem

After the merge of KSP-CKAN/NetKAN#9882, the scheduler is throwing this:

```
Uncaught exception:
Traceback (most recent call last):
  File ".local/bin/netkan", line 8, in <module>
    sys.exit(netkan())
  File "/home/netkan/.local/lib/python3.7/site-packages/click/core.py", line 1157, in __call__
    return self.main(*args, **kwargs)
  File "/home/netkan/.local/lib/python3.7/site-packages/click/core.py", line 1078, in main
    rv = self.invoke(ctx)
  File "/home/netkan/.local/lib/python3.7/site-packages/click/core.py", line 1688, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/home/netkan/.local/lib/python3.7/site-packages/click/core.py", line 1434, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "/home/netkan/.local/lib/python3.7/site-packages/click/core.py", line 783, in invoke
    return __callback(*args, **kwargs)
  File "/home/netkan/.local/lib/python3.7/site-packages/click/decorators.py", line 92, in new_func
    return ctx.invoke(f, obj, *args, **kwargs)
  File "/home/netkan/.local/lib/python3.7/site-packages/click/core.py", line 783, in invoke
    return __callback(*args, **kwargs)
  File "/home/netkan/.local/lib/python3.7/site-packages/netkan/cli/services.py", line 63, in scheduler
    sched.schedule_all_netkans()
  File "/home/netkan/.local/lib/python3.7/site-packages/netkan/scheduler.py", line 59, in schedule_all_netkans
    for batch in sqs_batch_entries(messages):
  File "/home/netkan/.local/lib/python3.7/site-packages/netkan/common.py", line 34, in sqs_batch_entries
    for msg in messages:
  File "/home/netkan/.local/lib/python3.7/site-packages/netkan/scheduler.py", line 57, in <genexpr>
    messages = (nk.sqs_message(self.ckm_repo.highest_version(nk.identifier))
  File "/home/netkan/.local/lib/python3.7/site-packages/netkan/repos.py", line 170, in <genexpr>
    return (Netkan(f, game_id=self.game_id) for f in self.all_nk_paths())
  File "/home/netkan/.local/lib/python3.7/site-packages/netkan/metadata.py", line 38, in __init__
    self._raw = yaml.load(self.contents.replace('\t', '    '))
  File "/home/netkan/.local/lib/python3.7/site-packages/ruamel/yaml/main.py", line 451, in load
    return constructor.get_single_data()
  File "/home/netkan/.local/lib/python3.7/site-packages/ruamel/yaml/constructor.py", line 112, in get_single_data
    node = self.composer.get_single_node()
  File "_ruamel_yaml.pyx", line 718, in ruamel.yaml.clib._ruamel_yaml.CParser.get_single_node
ruamel.yaml.composer.ComposerError: expected a single document in the stream
  in "<unicode string>", line 1, column 1
but found another document
  in "<unicode string>", line 11, column 1
```

## Cause

`rueaml.yaml.load` apparently only supports single documents. `load_all` is needed for mulitple.

## Changes

Now we use `load_all`.

The full file contents will still be assigned to `Netkan.contents`, but `_raw` will contain only the first document (the part before the first `---` in YAML). This is a quick patch just to get the scheduler online again. In the future we can consider some kind of merge logic to handle both documents, but this isn't important at this point because only a few properties are needed.
