### PR TITLE
Update to Python 3.11

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -18,7 +18,7 @@ jobs:
       - name: Setup Python
         uses: actions/setup-python@v1
         with:
-          python-version: 3.7
+          python-version: 3.11
       - name: Install test dependencies
         run: pip install .[test]
       - name: force our git config

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -62,10 +62,10 @@ jobs:
     needs: [ 'build', 'webhooks' ]
     steps:
       - uses: actions/checkout@v4
-      - name: Set up Python 3.7
+      - name: Set up Python
         uses: actions/setup-python@v1
         with:
-          python-version: 3.7
+          python-version: 3.11
       - name: Install Dependencies
         run: |
           pip install netkan/.

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,7 +12,7 @@ jobs:
       - name: Setup Python
         uses: actions/setup-python@v1
         with:
-          python-version: 3.7
+          python-version: 3.11
       - name: Install test dependencies
         working-directory: netkan
         run: pip install .[test]

--- a/netkan/Dockerfile
+++ b/netkan/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.7 as base
+FROM python:3.11 as base
 RUN useradd -ms /bin/bash netkan
 ADD . /netkan
 WORKDIR /netkan
@@ -7,7 +7,7 @@ RUN chown -R netkan:netkan /netkan
 USER netkan
 RUN pip install --user . --no-warn-script-location
 
-FROM python:3.7 as production
+FROM python:3.11 as production
 COPY --from=base /home/netkan /home/netkan
 RUN useradd -Ms /bin/bash netkan
 RUN chown -R netkan:netkan /home/netkan


### PR DESCRIPTION
Python 3.7 is getting a little long in the tooth, and we've started to receive warnings about it no longer being supported during the builds. Let's see how the workflows handle 3.11.