### PR TITLE
Prune Docker image

### DIFF
--- a/netkan/Dockerfile
+++ b/netkan/Dockerfile
@@ -1,4 +1,18 @@
-FROM python:3.11 as base
+FROM ubuntu:latest as ubuntu_with_python
+
+# Don't prompt for time zone
+ENV DEBIAN_FRONTEND=noninteractive
+
+# Install Git and Python
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends \
+        git libffi-dev openssh-client \
+        python3 python-is-python3 \
+    && apt-get clean
+
+FROM ubuntu_with_python as base
+RUN apt-get install -y --no-install-recommends \
+    python3-pip python3-setuptools python3-dev
 RUN useradd -ms /bin/bash netkan
 ADD . /netkan
 WORKDIR /netkan
@@ -7,8 +21,8 @@ RUN chown -R netkan:netkan /netkan
 USER netkan
 RUN pip install --user . --no-warn-script-location
 
-FROM python:3.11 as production
-COPY --from=base /home/netkan /home/netkan
+FROM ubuntu_with_python as production
+COPY --from=base /home/netkan/.local /home/netkan/.local
 RUN useradd -Ms /bin/bash netkan
 RUN chown -R netkan:netkan /home/netkan
 WORKDIR /home/netkan
@@ -21,6 +35,8 @@ CMD ["--help"]
 
 FROM production as test
 USER root
+RUN apt-get install -y --no-install-recommends \
+    python3-pip python3-setuptools python3-dev
 RUN pip install pip --upgrade
 ADD . /netkan
 RUN chown -R netkan:netkan /netkan
@@ -31,6 +47,8 @@ RUN /home/netkan/.local/bin/pytest -v
 
 FROM production as dev
 USER root
+RUN apt-get install -y --no-install-recommends \
+    python3-pip python3-setuptools python3-dev
 RUN pip install pip --upgrade
 ADD . /netkan
 RUN chown -R netkan:netkan /netkan


### PR DESCRIPTION
The `kspckan/netkan` image inherits a lot of cruft from `python:3.11`: autoconf, automake, make, dpkg-dev, gcc, g++, hicolor-icon-theme, imagemagick, subversion, tcl/tk, lots of libs, x11-common, etc., as well as the package download cache in `/home/netkan/.cache/pip`. This bloats it quite a bit:

```
REPOSITORY                         TAG       IMAGE ID       CREATED              SIZE
kspckan/netkan                     latest    4883cd42823b   3 days ago           1.11GB
```

Now it starts from `ubuntu:latest`, installs only the Python components it needs for each step, and excludes the pip cache from the copy-forward of `/home/netkan`, resulting in a much slimmed down image (~31% of previous):

```
REPOSITORY                         TAG       IMAGE ID       CREATED              SIZE
infra_testing                      latest    13fa9e747ffa   About a minute ago   355MB
```

This may slightly speed up redeploying the bot.

Note that this will downgrade Python from 3.11 to 3.10, which will not matter in the short term, but over the long term it will automatically get future Python versions as they are added to `ubuntu:latest` and the image is rebuilt.
