### PR TITLE
Update spacedock_adder.py to also generate the Github download in it's NetKANs

### DIFF
--- a/netkan/netkan/spacedock_adder.py
+++ b/netkan/netkan/spacedock_adder.py
@@ -169,7 +169,7 @@ class SpaceDockAdder:
         props: Dict[str, Any] = {}
         try:
             latest_release = gh_repo.get_latest_release()
-        except: # pylint: disable=broad-except
+        except: # pylint: disable=broad-except,bare-except
             logging.warning('No releases found on GitHub for %s, omitting GitHub section', ident)
             return None
         tag_name = latest_release.tag_name

--- a/netkan/netkan/spacedock_adder.py
+++ b/netkan/netkan/spacedock_adder.py
@@ -8,16 +8,15 @@ import logging
 from typing import Dict, Deque, Any, List, Optional, Type, TYPE_CHECKING
 import git
 from ruamel.yaml import YAML
+from github.Repository import Repository
+from github.GitRelease import GitRelease
+from github import Github
 
 from .cli.common import Game
 from .github_pr import GitHubPR
 from .mod_analyzer import ModAnalyzer
 from .queue_handler import BaseMessageHandler, QueueHandler
 from .repos import NetkanRepo
-from github.Repository import Repository
-from github.GitRelease import GitRelease
-from github.GitReleaseAsset import GitReleaseAsset
-from github import Github
 
 if TYPE_CHECKING:
     from mypy_boto3_sqs.service_resource import Message
@@ -164,7 +163,7 @@ class SpaceDockAdder:
         else:
             return None
 
-    def make_github_netkan(self, ident: str, gh_repo: Repository, info: Dict[str, Any]) -> Optional[Dict[str, Any]]:
+    def make_github_netkan(self, ident: str, gh_repo: Repository, info: Dict[str, Any]) -> Optional[Dict[str, Any]]: # pylint: disable=too-many-locals
         mod: Optional[ModAnalyzer] = None
         props: Dict[str, Any] = {}
         releases = gh_repo.get_releases()

--- a/netkan/netkan/spacedock_adder.py
+++ b/netkan/netkan/spacedock_adder.py
@@ -169,8 +169,8 @@ class SpaceDockAdder:
         props: Dict[str, Any] = {}
         try:
             latest_release = gh_repo.get_latest_release()
-        except:
-            logging.warn('No releases found on GitHub for %s, omitting GitHub section', ident)
+        except: # pylint: disable=broad-except
+            logging.warning('No releases found on GitHub for %s, omitting GitHub section', ident)
             return None
         tag_name = latest_release.tag_name
         digit = re.search(r"\d", tag_name)
@@ -179,7 +179,7 @@ class SpaceDockAdder:
             version_find = tag_name[:digit.start()]
         assets = latest_release.assets
         if len(assets) == 0:
-            logging.warn('Release for %s has no assets, omitting GitHub section', ident)
+            logging.warning('Release for %s has no assets, omitting GitHub section', ident)
             return None
         url = assets[0].browser_download_url
         try:

--- a/netkan/netkan/spacedock_adder.py
+++ b/netkan/netkan/spacedock_adder.py
@@ -32,7 +32,6 @@ class SpaceDockAdder:
     PR_BODY_TEMPLATE = Template(read_text('netkan', 'sd_adder_pr_body_template.md'))
     USER_TEMPLATE = Template('[$username]($user_url)')
     TITLE_TEMPLATE = Template('Add $name from $site_name')
-    NETKAN_SEPARATOR = '---\n'
     _info: Dict[str, Any]
 
 
@@ -66,7 +65,7 @@ class SpaceDockAdder:
         branch_name = f"add/{netkan[0].get('identifier')}"
         with self.nk_repo.change_branch(branch_name):
             # Create file
-            netkan_path.write_text(SpaceDockAdder.NETKAN_SEPARATOR.join([self.yaml_dump(single_netkan) for single_netkan in netkan]))
+            netkan_path.write_text(self.yaml_dump(netkan))
 
             # Add netkan to branch
             self.nk_repo.git_repo.index.add([netkan_path.as_posix()])
@@ -107,9 +106,9 @@ class SpaceDockAdder:
             logging.error('Failed to generate pull request body from %s', info)
             raise exc
 
-    def yaml_dump(self, obj: Dict[str, Any]) -> str:
+    def yaml_dump(self, objs: List[Dict[str, Any]]) -> str:
         sio = io.StringIO()
-        self.yaml.dump(obj, sio)
+        self.yaml.dump_all(objs, sio)
         return sio.getvalue()
 
     @staticmethod
@@ -121,10 +120,10 @@ class SpaceDockAdder:
         ident = re.sub(r'[\W_]+', '', info.get('name', ''))
         gh_repo = self.get_github_repo(info.get('source_link',''))
         if gh_repo is not None:
-            gh_netkan = self.make_github_netkan(ident,gh_repo,info)
+            gh_netkan = self.make_github_netkan(ident, gh_repo, info)
             if gh_netkan is not None:
                 netkans.append(gh_netkan)
-        netkans.append(self.make_spacedock_netkan(ident,info))
+        netkans.append(self.make_spacedock_netkan(ident, info))
         return netkans
 
     def make_spacedock_netkan(self, ident: str, info: Dict[str, Any]) -> Dict[str, Any]:

--- a/netkan/netkan/spacedock_adder.py
+++ b/netkan/netkan/spacedock_adder.py
@@ -6,10 +6,10 @@ from string import Template
 from collections import defaultdict, deque
 import logging
 from typing import Dict, Deque, Any, List, Optional, Type, TYPE_CHECKING
+import urllib.parse
 import git
 from ruamel.yaml import YAML
 from github.Repository import Repository
-from github.GitRelease import GitRelease
 from github import Github
 
 from .cli.common import Game
@@ -32,8 +32,8 @@ class SpaceDockAdder:
     PR_BODY_TEMPLATE = Template(read_text('netkan', 'sd_adder_pr_body_template.md'))
     USER_TEMPLATE = Template('[$username]($user_url)')
     TITLE_TEMPLATE = Template('Add $name from $site_name')
+    GITHUB_PATH_PATTERN = re.compile(r'^/([^/]+)/([^/]+)')
     _info: Dict[str, Any]
-
 
     def __init__(self, message: Message, nk_repo: NetkanRepo, game: Game, github_pr: Optional[GitHubPR] = None) -> None:
         self.message = message
@@ -118,7 +118,7 @@ class SpaceDockAdder:
     def make_netkan(self, info: Dict[str, Any]) -> List[Dict[str, Any]]:
         netkans = []
         ident = re.sub(r'[\W_]+', '', info.get('name', ''))
-        gh_repo = self.get_github_repo(info.get('source_link',''))
+        gh_repo = self.get_github_repo(info.get('source_link', ''))
         if gh_repo is not None:
             gh_netkan = self.make_github_netkan(ident, gh_repo, info)
             if gh_netkan is not None:
@@ -148,28 +148,30 @@ class SpaceDockAdder:
             'x_via': f"Automated {info.get('site_name')} CKAN submission"
         }
 
-
     def get_github_repo(self, source_link: str) -> Optional[Repository]:
-        if 'github.com/' in source_link:
-            sections = source_link.strip('/').split('/')
-            repo_name = sections[-2] + '/' + sections[-1]
-            g = Github()
-            try:
-                return g.get_repo(repo_name)
-            except Exception as exc: # pylint: disable=broad-except
-                # Tell Discord about the problem and move on
-                logging.error('%s failed to get the github repository from spacedock source url %s', self.__class__.__name__, source_link, exc_info=exc)
-                return None
-        else:
-            return None
+        url_parse = urllib.parse.urlparse(source_link)
+        if url_parse.netloc == 'github.com':
+            match = self.GITHUB_PATH_PATTERN.match(url_parse.path)
+            if match:
+                repo_name = '/'.join(match.groups())
+                g = Github(self.github_pr.token)
+                try:
+                    return g.get_repo(repo_name)
+                except Exception as exc: # pylint: disable=broad-except
+                    # Tell Discord about the problem and move on
+                    logging.error('%s failed to get the GitHub repository from SpaceDock source url %s',
+                                  self.__class__.__name__, source_link, exc_info=exc)
+                    return None
+        return None
 
     def make_github_netkan(self, ident: str, gh_repo: Repository, info: Dict[str, Any]) -> Optional[Dict[str, Any]]: # pylint: disable=too-many-locals
         mod: Optional[ModAnalyzer] = None
         props: Dict[str, Any] = {}
-        releases = gh_repo.get_releases()
-        if releases.totalCount == 0:
+        try:
+            latest_release = gh_repo.get_latest_release()
+        except:
+            logging.warn('No releases found on GitHub for %s, omitting GitHub section', ident)
             return None
-        latest_release: GitRelease = releases[0]
         tag_name = latest_release.tag_name
         digit = re.search(r"\d", tag_name)
         version_find = ''
@@ -177,6 +179,7 @@ class SpaceDockAdder:
             version_find = tag_name[:digit.start()]
         assets = latest_release.assets
         if len(assets) == 0:
+            logging.warn('Release for %s has no assets, omitting GitHub section', ident)
             return None
         url = assets[0].browser_download_url
         try:
@@ -203,7 +206,6 @@ class SpaceDockAdder:
                 'strict': 'false'
             }
         return netkan
-
 
     @property
     def delete_attrs(self) -> DeleteMessageBatchRequestEntryTypeDef:

--- a/netkan/netkan/spacedock_adder.py
+++ b/netkan/netkan/spacedock_adder.py
@@ -35,7 +35,7 @@ class SpaceDockAdder:
     GITHUB_PATH_PATTERN = re.compile(r'^/([^/]+)/([^/]+)')
     _info: Dict[str, Any]
 
-    def __init__(self, message: Message, nk_repo: NetkanRepo, game: Game, github_pr: Optional[GitHubPR] = None) -> None:
+    def __init__(self, message: Message, nk_repo: NetkanRepo, game: Game, github_pr: GitHubPR) -> None:
         self.message = message
         self.nk_repo = nk_repo
         self.game = game

--- a/netkan/netkan/spacedock_adder.py
+++ b/netkan/netkan/spacedock_adder.py
@@ -155,7 +155,8 @@ class SpaceDockAdder:
             sections = source_link.strip('/').split('/')
             repo_name = sections[-2] + '/' + sections[-1]
             g = Github()
-            try:
+            try: # pylint: disable=broad-except
+            # Tell Discord about the problem and move on
                 return g.get_repo(repo_name)
             except Exception as exc:
                 logging.error('%s failed to get the github repository from spacedock source url %s', self.__class__.__name__, source_link, exc_info=exc)
@@ -182,7 +183,7 @@ class SpaceDockAdder:
         try:
             mod = ModAnalyzer(ident, url, self.game)
             props = mod.get_netkan_properties() if mod else {}
-        except Exception as exc:  # pylint: disable=broad-except
+        except Exception as exc: # pylint: disable=broad-except
             # Tell Discord about the problem and move on
             logging.error('%s failed to analyze %s from %s',
                           self.__class__.__name__, ident, url, exc_info=exc)

--- a/netkan/netkan/spacedock_adder.py
+++ b/netkan/netkan/spacedock_adder.py
@@ -36,6 +36,7 @@ class SpaceDockAdder:
     NETKAN_SEPARATOR = '---\n'
     _info: Dict[str, Any]
 
+
     def __init__(self, message: Message, nk_repo: NetkanRepo, game: Game, github_pr: Optional[GitHubPR] = None) -> None:
         self.message = message
         self.nk_repo = nk_repo
@@ -120,9 +121,9 @@ class SpaceDockAdder:
         netkans = []
         ident = re.sub(r'[\W_]+', '', info.get('name', ''))
         gh_repo = self.get_github_repo(info.get('source_link',''))
-        if gh_repo != None:
+        if gh_repo is not None:
             gh_netkan = self.make_github_netkan(ident,gh_repo,info)
-            if gh_netkan != None:
+            if gh_netkan is not None:
                 netkans.append(gh_netkan)
         netkans.append(self.make_spacedock_netkan(ident,info))
         return netkans

--- a/netkan/netkan/spacedock_adder.py
+++ b/netkan/netkan/spacedock_adder.py
@@ -134,7 +134,7 @@ class SpaceDockAdder:
         try:
             mod = ModAnalyzer(ident, url, self.game)
             props = mod.get_netkan_properties() if mod else {}
-        except Exception as exc:  # pylint: disable=broad-except
+        except Exception as exc: # pylint: disable=broad-except
             # Tell Discord about the problem and move on
             logging.error('%s failed to analyze %s from %s',
                           self.__class__.__name__, ident, url, exc_info=exc)
@@ -155,10 +155,10 @@ class SpaceDockAdder:
             sections = source_link.strip('/').split('/')
             repo_name = sections[-2] + '/' + sections[-1]
             g = Github()
-            try: # pylint: disable=broad-except
-            # Tell Discord about the problem and move on
+            try:
                 return g.get_repo(repo_name)
-            except Exception as exc:
+            except Exception as exc: # pylint: disable=broad-except
+                # Tell Discord about the problem and move on
                 logging.error('%s failed to get the github repository from spacedock source url %s', self.__class__.__name__, source_link, exc_info=exc)
                 return None
         else:

--- a/netkan/netkan/status.py
+++ b/netkan/netkan/status.py
@@ -47,7 +47,7 @@ class ModStatus(Model):
     release_date = UTCDateTimeAttribute(null=True)
     success = BooleanAttribute()
     frozen = BooleanAttribute(default=False)
-    resources: 'MapAttribute[str, Any]' = MapAttribute(default={})
+    resources: 'MapAttribute[str, Any]' = MapAttribute()
 
     def mod_attrs(self) -> Dict[str, Any]:
         attributes = {}


### PR DESCRIPTION
# Motivation
Since version 1.34 of CKAN, CKAN has supported multiple download links in its NetKANs. And since then most mods for KSP2 have been using this feature. But it is slightly tedious when wrangling a NetKAN generated from the spacedock adder to have to go and find the repo, and copy the correct structure to add the github download link.

# Solution.

When the spacedock_adder recieves a request to add a mod to spacedock it now checks if the `source_link` is a valid github repository that has a release with assets, and generates the github portion of a netkan using this repo, and also tries to deduce what the correct `x_netkan_version_edit` is for said github portion. When it does this it will place this portion of the netkan in front of the spacedock portion of the netkan, in line with how most of the KSP2 netkans in this style have already been structured.