### PR TITLE
Fully sanitize archive.org bucket names

### DIFF
--- a/netkan/netkan/download_counter.py
+++ b/netkan/netkan/download_counter.py
@@ -2,14 +2,13 @@ import json
 import logging
 import re
 from pathlib import Path
-from importlib.resources import read_text
 from string import Template
 import urllib.parse
 from typing import Dict, Tuple, Any, Optional
 
 import requests
 
-from .utils import repo_file_add_or_changed
+from .utils import repo_file_add_or_changed, legacy_read_text
 from .repos import CkanMetaRepo
 from .metadata import Ckan
 
@@ -23,7 +22,7 @@ class GraphQLQuery:
     MODULES_PER_GRAPHQL = 20
 
     # The request we send to GitHub, with a parameter for the module specific section
-    GRAPHQL_TEMPLATE = Template(read_text('netkan', 'downloads_query.graphql'))
+    GRAPHQL_TEMPLATE = Template(legacy_read_text('netkan', 'downloads_query.graphql'))
 
     # The request string per module, depends on getDownloads fragment existing in
     # the main template

--- a/netkan/netkan/mirrorer.py
+++ b/netkan/netkan/mirrorer.py
@@ -6,7 +6,6 @@ import hashlib
 import logging
 import shutil
 from pathlib import Path
-from importlib.resources import read_text
 from typing import Optional, List, Union, Iterable, BinaryIO, Dict, Any, TYPE_CHECKING
 import boto3
 import github
@@ -16,6 +15,7 @@ from jinja2 import Template
 from .metadata import Ckan
 from .repos import CkanMetaRepo
 from .common import deletion_msg, download_stream_to_file, USER_AGENT
+from .utils import legacy_read_text
 
 if TYPE_CHECKING:
     from mypy_boto3_sqs.type_defs import DeleteMessageBatchRequestEntryTypeDef
@@ -26,7 +26,7 @@ else:
 class CkanMirror(Ckan):
 
     DESCRIPTION_TEMPLATE = Template(
-        read_text('netkan', 'mirror_description_template.jinja2'))
+        legacy_read_text('netkan', 'mirror_description_template.jinja2'))
 
     BUCKET_EXCLUDE_PATTERN = re.compile(r'^[^a-zA-Z0-9]+|[^a-zA-Z0-9._-]')
 

--- a/netkan/netkan/spacedock_adder.py
+++ b/netkan/netkan/spacedock_adder.py
@@ -1,7 +1,6 @@
 import json
 import re
 import io
-from importlib.resources import read_text
 from string import Template
 from collections import defaultdict, deque
 import logging
@@ -17,6 +16,7 @@ from .github_pr import GitHubPR
 from .mod_analyzer import ModAnalyzer
 from .queue_handler import BaseMessageHandler, QueueHandler
 from .repos import NetkanRepo
+from .utils import legacy_read_text
 
 if TYPE_CHECKING:
     from mypy_boto3_sqs.service_resource import Message
@@ -28,8 +28,8 @@ else:
 
 # https://github.com/KSP-SpaceDock/SpaceDock/blob/master/KerbalStuff/ckan.py
 class SpaceDockAdder:
-    COMMIT_TEMPLATE = Template(read_text('netkan', 'sd_adder_commit_template.md'))
-    PR_BODY_TEMPLATE = Template(read_text('netkan', 'sd_adder_pr_body_template.md'))
+    COMMIT_TEMPLATE = Template(legacy_read_text('netkan', 'sd_adder_commit_template.md'))
+    PR_BODY_TEMPLATE = Template(legacy_read_text('netkan', 'sd_adder_pr_body_template.md'))
     USER_TEMPLATE = Template('[$username]($user_url)')
     TITLE_TEMPLATE = Template('Add $name from $site_name')
     GITHUB_PATH_PATTERN = re.compile(r'^/([^/]+)/([^/]+)')

--- a/netkan/netkan/ticket_closer.py
+++ b/netkan/netkan/ticket_closer.py
@@ -1,17 +1,17 @@
 import logging
 from datetime import datetime, timedelta, timezone
-from importlib.resources import read_text
 from collections import defaultdict
 from string import Template
 import github
 
 from .common import USER_AGENT
+from .utils import legacy_read_text
 
 
 class TicketCloser:
 
     REPO_NAMES = ['CKAN', 'NetKAN']
-    BODY_TEMPLATE = Template(read_text('netkan', 'ticket_close_template.md'))
+    BODY_TEMPLATE = Template(legacy_read_text('netkan', 'ticket_close_template.md'))
 
     def __init__(self, token: str, user_name: str) -> None:
         self._gh = github.Github(token, user_agent=USER_AGENT)

--- a/netkan/netkan/utils.py
+++ b/netkan/netkan/utils.py
@@ -2,6 +2,8 @@ import logging
 import subprocess
 from pathlib import Path
 from typing import Union
+from importlib.resources import files
+
 from git import Repo
 
 
@@ -42,3 +44,7 @@ def repo_file_add_or_changed(repo: Repo, filename: Union[str, Path]) -> bool:
                 x.a_path for x in repo.index.diff(None)]:
             return True
     return False
+
+
+def legacy_read_text(pkg: str, resource: str) -> str:
+    return files(pkg).joinpath(resource).read_text()


### PR DESCRIPTION
## Problem

The bot has been spamming this every 5 minutes for 2 hours:

![image](https://github.com/KSP-CKAN/NetKAN-Infra/assets/1559108/9d57e3b8-2016-446f-a661-e2f718f8578a)

## Cause

The error message explains it well; only certain characters are allowed in archive.org bucket names, and we currently construct those names from user inputs and don't guarantee that the rules will be followed.

We fixed spaces specifically in #307, since they seemed particularly likely to come up, and it was easier than trying to go all the way and guarantee all bucket names fit the allowed pattern. Surely that's sufficient, right? Nobody needs to put even more obscure characters than that into a **version number**, which is typically of the form `1.2.3.4`. Right?

<https://spacedock.info/mod/2604/Tantares%20Intercolor%20(Recolors)>

![image](https://github.com/KSP-CKAN/NetKAN-Infra/assets/1559108/495ee34c-65a6-4556-a163-289126207fe0)

<https://github.com/KSP-CKAN/CKAN-meta/tree/master/IntercolorTantaresRecolors>

![image](https://github.com/KSP-CKAN/NetKAN-Infra/assets/1559108/cb0b4952-f914-46d4-b9fd-36f662d60d75)

## Changes

- Now we use a regex to remove invalid characters from archive.org bucket names
- A few trivial changes are made to quell pylint warnings
  - One license URL was triggering a "line to long" warning, and fortunately it already has a server redirect to a shorter URL

Note that the client will need to be updated in order to actually use these uploads.

I'll self-review this and merge to stop the bot spam.
