### PR TITLE
Ensure ModStatus.resources isn't None

### DIFF
--- a/netkan/netkan/status.py
+++ b/netkan/netkan/status.py
@@ -47,7 +47,7 @@ class ModStatus(Model):
     release_date = UTCDateTimeAttribute(null=True)
     success = BooleanAttribute()
     frozen = BooleanAttribute(default=False)
-    resources: 'MapAttribute[str, Any]' = MapAttribute()
+    resources: 'MapAttribute[str, Any]' = MapAttribute(default=dict)
 
     def mod_attrs(self) -> Dict[str, Any]:
         attributes = {}


### PR DESCRIPTION
## Problem

Instead of working, the Indexer has been spamming errors:

```
netkan.status.ModStatus.DoesNotExist: Item does not exist

During handling of the above exception, another exception occurred:

  File "/home/netkan/.local/lib/python3.10/site-packages/netkan/indexer.py", line 152, in _process_ckan
    ModStatus(**self.status_attrs(True)).save()

pynamodb.exceptions.AttributeNullError: Attribute 'resources' cannot be None
```

## Cause

The `ModStatus.resources` pynamodb column both defaults to `None` and forbids it as a value. Somehow this was tripped after KSP-CKAN/NetKAN#9958 and KSP-CKAN/NetKAN#9960.

## Changes

Now the default for this column is `dict`, which is how pynamodb requires you to say `{}`.

<https://pynamodb.readthedocs.io/en/latest/api.html#pynamodb.attributes.Attribute>
