### PR TITLE
Run redeploy commands in parallel

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -78,10 +78,11 @@ jobs:
           AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           AWS_DEFAULT_REGION: ${{ secrets.AWS_DEFAULT_REGION }}
         run: |
-          netkan redeploy-service --cluster NetKANCluster --service-name Indexer
-          netkan redeploy-service --cluster NetKANCluster --service-name Webhooks
-          netkan redeploy-service --cluster NetKANCluster --service-name Adder
-          netkan redeploy-service --cluster NetKANCluster --service-name Mirrorer
+          for SERVICE in Indexer Webhooks Adder Mirrorer
+          do
+            netkan redeploy-service --cluster NetKANCluster --service-name $SERVICE &
+          done
+          wait
       - name: CKAN repo dispatch
         env:
           REPO_ACCESS_TOKEN: ${{ secrets.REPO_ACCESS_TOKEN }}


### PR DESCRIPTION
The redeploy action takes a long time, and we run it 4 times.

Now they run in parallel.
