### PR TITLE
Send download count summaries to Discord

### DIFF
--- a/netkan/netkan/cli/utilities.py
+++ b/netkan/netkan/cli/utilities.py
@@ -57,10 +57,9 @@ def download_counter(common: SharedArgs) -> None:
     """
     for game_id in common.game_ids:
         logging.info('Starting Download Count Calculation (%s)...', game_id)
-        DownloadCounter(
-            common.game(game_id).ckanmeta_repo,
-            common.token
-        ).update_counts()
+        DownloadCounter(game_id,
+                        common.game(game_id).ckanmeta_repo,
+                        common.token).update_counts()
         logging.info('Download Counter completed! (%s)', game_id)
 
 

--- a/netkan/netkan/download_counter.py
+++ b/netkan/netkan/download_counter.py
@@ -288,7 +288,7 @@ class DownloadCounter:
 
     def log_top(self, how_many: int) -> None:
         if self.output_file and self.output_file.exists():
-            with open(self.output_file) as old_file:
+            with open(self.output_file, encoding='UTF-8') as old_file:
                 old_counts = json.load(old_file)
                 deltas = {ident: count - old_counts[ident]
                           for ident, count in self.counts.items()

--- a/netkan/netkan/download_counter.py
+++ b/netkan/netkan/download_counter.py
@@ -283,7 +283,7 @@ class DownloadCounter:
     @staticmethod
     def _download_summary_table(counts: Dict[str, int], how_many: int) -> str:
         return '\n'.join(f'    {counts[ident]:8}  {ident}'
-                         for ident in heapq.nlargest(how_many, counts, counts.get)
+                         for ident in heapq.nlargest(how_many, counts, lambda i: counts.get(i))
                          if counts[ident] > 0)
 
     def log_top(self, how_many: int) -> None:

--- a/netkan/netkan/download_counter.py
+++ b/netkan/netkan/download_counter.py
@@ -283,7 +283,7 @@ class DownloadCounter:
     @staticmethod
     def _download_summary_table(counts: Dict[str, int], how_many: int) -> str:
         return '\n'.join(f'    {counts[ident]:8}  {ident}'
-                         for ident in heapq.nlargest(how_many, counts, lambda i: counts.get(i))
+                         for ident in heapq.nlargest(how_many, counts, lambda i: counts.get(i, 0))
                          if counts[ident] > 0)
 
     def log_top(self, how_many: int) -> None:


### PR DESCRIPTION
## Motivation

Now that KSP2 has been quietly soft-discontinued, its modding community has gone mostly inactive; the last new KSP2 mod release was on May 14.

Since then, all we've gotten is download count updates, and I'm curious to see what's going on in there. Are people still installing KSP2 mods? If so, which ones, and how often?

## Changes

Now after each nightly download count, a summary will be sent to Discord for each game so we can easily get a sense of how much activity there is:

```
Top 5 downloads for KSP all-time:
     2714360  EnvironmentalVisualEnhancements-HR
     1752723  CommunityResourcePack
     1700835  Scatterer
     1700339  Scatterer-config
     1698858  Scatterer-sunflare

Top 5 downloads for KSP today:
         100  Astrogator
```
