### PR TITLE
Use deep clone so Indexer can handle existing branches

### DIFF
--- a/prod-stack.py
+++ b/prod-stack.py
@@ -634,7 +634,7 @@ t.add_resource(RecordSetType(
 services = [
     {
         'name': 'Indexer',
-        'command': 'indexer',
+        'command': ['indexer', '--deep-clone'],
         'memory': '256',
         'secrets': [
             'SSH_KEY', 'GH_Token',


### PR DESCRIPTION
## Problem

We haven't had a full successful inflation pass in 2 days.

![image](https://github.com/user-attachments/assets/7407bf72-5c71-4f19-a34b-b0841898c923)

## Cause

There are several pending pull requests at https://github.com/KSP-CKAN/CKAN-meta/pulls, and the Indexer keeps failing to push to them because it doesn't have the current state of their branches after restarting after KSP-CKAN/CKAN#4119 was merged. These attempts somehow overwhelm the container's volume credits, which eventually end up at 0.

See #303 and #315 for previous instances of the same issue for other services (except in those cases they were just failing, not overloading the volume credits and blocking the Scheduler from running).

## Changes

Now the Indexer uses a deep clone of CKAN-meta, so the existing branches will be retrieved.
