### PR TITLE
Leave spec version out of generated netkans

### DIFF
--- a/.github/workflows/coverage-report.yml
+++ b/.github/workflows/coverage-report.yml
@@ -15,7 +15,7 @@ permissions:
 jobs:
   coverage-report:
     runs-on: ubuntu-latest
-    if: false && ${{ github.event.workflow_run.conclusion == 'success' }}
+    if: ${{ false && github.event.workflow_run.conclusion == 'success' }}
     steps:
       - uses: actions/download-artifact@v4
         with:

--- a/.github/workflows/coverage-report.yml
+++ b/.github/workflows/coverage-report.yml
@@ -15,7 +15,7 @@ permissions:
 jobs:
   coverage-report:
     runs-on: ubuntu-latest
-    if: ${{ github.event.workflow_run.conclusion == 'success' }}
+    if: false && ${{ github.event.workflow_run.conclusion == 'success' }}
     steps:
       - uses: actions/download-artifact@v4
         with:

--- a/.github/workflows/coverage-report.yml
+++ b/.github/workflows/coverage-report.yml
@@ -15,7 +15,7 @@ permissions:
 jobs:
   coverage-report:
     runs-on: ubuntu-latest
-    if: ${{ false && github.event.workflow_run.conclusion == 'success' }}
+    if: ${{ github.event.workflow_run.conclusion == 'success' }}
     steps:
       - uses: actions/download-artifact@v4
         with:
@@ -23,6 +23,7 @@ jobs:
           run-id: ${{ github.event.workflow_run.id }}
           github-token: ${{ secrets.GITHUB_TOKEN }}
       - name: Get Cover
+        if: false
         uses: techman83/coverage@feat/workflow_run
         with:
           coverageFile: coverage.xml

--- a/.github/workflows/coverage-report.yml
+++ b/.github/workflows/coverage-report.yml
@@ -15,7 +15,7 @@ permissions:
 jobs:
   coverage-report:
     runs-on: ubuntu-latest
-    if: ${{ github.event.workflow_run.conclusion == 'success' }}
+    if: ${{ false && github.event.workflow_run.conclusion == 'success' }}
     steps:
       - uses: actions/download-artifact@v4
         with:
@@ -23,7 +23,6 @@ jobs:
           run-id: ${{ github.event.workflow_run.id }}
           github-token: ${{ secrets.GITHUB_TOKEN }}
       - name: Get Cover
-        if: false
         uses: techman83/coverage@feat/workflow_run
         with:
           coverageFile: coverage.xml

--- a/netkan/netkan/cli/utilities.py
+++ b/netkan/netkan/cli/utilities.py
@@ -79,7 +79,6 @@ def analyze_mod(common: SharedArgs, ident: str, download_url: str) -> None:
     yaml.dump(ModAnalyzer(ident, download_url, common.game(common.game_id or 'KSP'))
                   .get_netkan_properties(),
               sio)
-    click.echo('spec_version: v1.18')
     click.echo(f'identifier: {ident}')
     click.echo(sio.getvalue())
 

--- a/netkan/netkan/spacedock_adder.py
+++ b/netkan/netkan/spacedock_adder.py
@@ -139,7 +139,6 @@ class SpaceDockAdder:
                           self.__class__.__name__, ident, url, exc_info=exc)
         vref_props = {'$vref': props.pop('$vref')} if '$vref' in props else {}
         return {
-            'spec_version': 'v1.34',
             'identifier': ident,
             '$kref': f"#/ckan/spacedock/{info.get('id', '')}",
             **(vref_props),
@@ -191,7 +190,6 @@ class SpaceDockAdder:
                           self.__class__.__name__, ident, url, exc_info=exc)
         vref_props = {'$vref': props.pop('$vref')} if '$vref' in props else {}
         netkan = {
-            'spec_version': 'v1.34',
             'identifier': ident,
             '$kref': f"#/ckan/github/{gh_repo.full_name}",
             **(vref_props),


### PR DESCRIPTION
## Motivation

Maintaining `spec_version` by hand is tedious, and KSP-CKAN/CKAN#4155 just made it optional.

## Changes

Now the netkans that we autogenerate will no longer specify the `spec_version`, so the inflator can fill in the correct values automatically downstream.

Also the coverage workflow broke again, so now it's disabled again.
