### PR TITLE
Remove spaces from staging branch names

### DIFF
--- a/netkan/netkan/indexer.py
+++ b/netkan/netkan/indexer.py
@@ -74,7 +74,7 @@ class CkanMessage:
 
     @property
     def staging_branch_name(self) -> str:
-        return f'add/{self.mod_version}'
+        return f'add/{self.mod_version}'.replace(' ', '')
 
     def mod_file_md5(self) -> str:
         with open(self.mod_file, mode='rb') as file:


### PR DESCRIPTION
## Problem

The scheduler hasn't run in about 20 hours.

## Cause

The indexer has been failing to create a staging branch with a space in it because a mod author fat-fingered a period as a comma (otherwise it wouldn't have been staged):

<https://spacedock.info/mod/3664/Kerbal%20Infinity>

```
Uncaught exception:
Traceback (most recent call last):
  File "/home/netkan/.local/lib/python3.10/site-packages/netkan/repos.py", line 101, in change_branch
    self.git_repo.remotes.origin.fetch(branch_name)
  File "/home/netkan/.local/lib/python3.10/site-packages/git/remote.py", line 1069, in fetch
    res = self._get_fetch_info_from_stderr(proc, progress, kill_after_timeout=kill_after_timeout)
  File "/home/netkan/.local/lib/python3.10/site-packages/git/remote.py", line 895, in _get_fetch_info_from_stderr
    proc.wait(stderr=stderr_text)
  File "/home/netkan/.local/lib/python3.10/site-packages/git/cmd.py", line 834, in wait
    raise GitCommandError(remove_password_if_present(self.args), status, errstr)
git.exc.GitCommandError: Cmd('git') failed due to: exit code(128)
  cmdline: git fetch -v -- origin add/KerbalInfinity-1-0,2 - Pyrox
  stderr: 'fatal: invalid refspec 'add/KerbalInfinity-1-0,2 - Pyrox''
```

Doing this every 5 minutes has presumably overloaded all of the server credits and whatnot.

## Changes

Now spaces are excluded from staging branch names. I have confirmed that this will allow the above branch to be created.
