### PR TITLE
Stop attempting archive.org download counts after timeout

### DIFF
--- a/netkan/netkan/metadata.py
+++ b/netkan/netkan/metadata.py
@@ -366,7 +366,7 @@ class Ckan:
     def download(self) -> str:
         download = self._raw.get('download')
         if isinstance(download, list):
-            return download[0] if len(download) > 0 else None
+            return download[0] if isinstance(download[0], str) and len(download) > 0 else None
         return download
 
     # Provide all downloads with alternate property in case we need them,

--- a/netkan/netkan/metadata.py
+++ b/netkan/netkan/metadata.py
@@ -366,7 +366,7 @@ class Ckan:
     def download(self) -> str:
         download = self._raw.get('download')
         if isinstance(download, list):
-            return download[0] if isinstance(download[0], str) and len(download) > 0 else None
+            return download[0] if isinstance(download[0], str) and len(download) > 0 else ''
         return download
 
     # Provide all downloads with alternate property in case we need them,


### PR DESCRIPTION
## Problem

Download counts last updated on October 10.

## Cause

archive.org is down, and the download counter is stuck in a loop trying to connect to it and timing out, spamming Discord all the way.

## Changes

Now the download counter catches `ConnectTimeout` from `requests.get` and stops trying to reach archive.org. This should allow it to recover during the downtime, and then when archive.org comes back up, it'll start working again.
