### PR TITLE
Exclude internetarchive's internal logging from Discord

### DIFF
--- a/netkan/netkan/notifications.py
+++ b/netkan/netkan/notifications.py
@@ -1,9 +1,13 @@
 import os
 import sys
+import re
 import logging
 from typing import Iterable, Type, Optional
 from types import TracebackType
 import discord
+
+# A regex to prevent internetarchive's errors from going to Discord
+NOT_IA_PATTERN = re.compile('^(?!.*internetarchive)')
 
 
 def catch_all(type_: Type[BaseException], value: BaseException, traceback: Optional[TracebackType]) -> None:
@@ -16,16 +20,19 @@ def catch_all(type_: Type[BaseException], value: BaseException, traceback: Optio
 
 class DiscordLogHandler(logging.Handler):
 
-    def __init__(self, webhook_id: str, webhook_token: str) -> None:
+    def __init__(self, webhook_id: str, webhook_token: str,
+                 logger_filter: re.Pattern[str]) -> None:
         super().__init__()
         self.webhook = discord.Webhook.partial(webhook_id, webhook_token,
                                                adapter=discord.RequestsWebhookAdapter())
+        self.logger_filter = logger_filter
 
     def emit(self, record: logging.LogRecord) -> None:
-        fmt = self.format(record)
-        as_code = "\n" in fmt
-        for part in self._message_parts(fmt, as_code):
-            self.webhook.send(part)
+        if self.logger_filter.match(record.name):
+            fmt = self.format(record)
+            as_code = "\n" in fmt
+            for part in self._message_parts(fmt, as_code):
+                self.webhook.send(part)
 
     @staticmethod
     def _message_parts(msg: str, as_code: bool, max_len: int = 2000) -> Iterable[str]:
@@ -47,7 +54,7 @@ def setup_log_handler(debug: bool = False) -> bool:
     discord_webhook_id = os.environ.get('DISCORD_WEBHOOK_ID')
     discord_webhook_token = os.environ.get('DISCORD_WEBHOOK_TOKEN')
     if discord_webhook_id and discord_webhook_token:
-        handler = DiscordLogHandler(discord_webhook_id, discord_webhook_token)
+        handler = DiscordLogHandler(discord_webhook_id, discord_webhook_token, NOT_IA_PATTERN)
         handler.setLevel(logging.ERROR)
         logging.getLogger('').addHandler(handler)
         return True


### PR DESCRIPTION
## Problem

After #345, the archive.org-related Discord log spam is reduced to one of these every 5 minutes:

> `(MaxRetryError("HTTPSConnectionPool(host='s3.us.archive.org', port=443): Max retries exceeded with url: /?check_limit=1&accesskey=<KEY PRUNED> (Caused by ConnectTimeoutError(<urllib3.connection.HTTPSConnection object at 0x7fcb3cf37560>, 'Connection to s3.us.archive.org timed out. (connect timeout=12)'))"), 'https://s3.us.archive.org/?check_limit=1&accesskey=<KEY PRUNED>')`

## Cause

The Mirrorer is (appropriately) checking whether archive.org is overloaded here, which returns `True`:

https://github.com/KSP-CKAN/NetKAN-Infra/blob/9831903c2b4602e460dee2f9aca33be3a8bb934a/netkan/netkan/mirrorer.py#L292

We don't log that message; `internetarchive` itself does, specifically here:

https://github.com/jjjake/internetarchive/blob/c578552d0c532f513b6e972b9f5529584b04c254/internetarchive/session.py#L539

This shouldn't be forwarded to Discord.

## Changes

Now `DiscordLogHandler`'s constructor accepts a regex to evaluate against each log record's logger name, which we pass as a zero-width negative lookahead assertion to exclude loggers containing `internetarchive`.
