### PR TITLE
Refactor Scheduler parameters

### DIFF
--- a/netkan/netkan/scheduler.py
+++ b/netkan/netkan/scheduler.py
@@ -110,8 +110,8 @@ class NetkanScheduler:
             logging.error("Couldn't acquire Volume Credit Stats")
         return creds
 
-    def can_schedule(self, max_queued: int, dev: bool = False,
-                     min_cpu: int = 50, min_io: int = 70, min_gh: int = 1500) -> bool:
+    def can_schedule(self, max_queued: int, min_cpu: int, min_io: int, min_gh: int,
+                     dev: bool = False) -> bool:
         if not dev:
             github_remaining = github_limit_remaining(self.github_token)
             if github_remaining < min_gh:


### PR DESCRIPTION
## Motivation

This is a quick follow-up to #348, after which I was confused by this "200" because the default for the `min_cpu` parameter is `50`:

![image](https://github.com/user-attachments/assets/32d48668-df2f-427c-a89d-a76edc7ad285)

## Cause

Defaults for these parameters were being specified in multiple places, with different values, and only one of them was being used.

## Changes

- Now the limit parameters to `can_schedule` no longer have defaults, so it is much more clear that the actual defaults come from the `@click.option` attributes on `scheduler`
  - To do that, the `dev` parameter is now last so it can retain its default
- Now `--min-gh` can be passed on the command line to specify the GitHub API rate limit threshold, with the param's previous default of 1500
- Now `--max-queued`'s `help` string describes that parameter instead of some other parameter
