### PR TITLE
Absolute entrypoint path to run as Action

### DIFF
--- a/netkan/Dockerfile
+++ b/netkan/Dockerfile
@@ -30,7 +30,7 @@ USER netkan
 COPY .gitconfig .
 ENV PATH="$PATH:/home/netkan/.local/bin"
 RUN /home/netkan/.local/bin/netkan --help
-ENTRYPOINT [".local/bin/netkan"]
+ENTRYPOINT ["/home/netkan/.local/bin/netkan"]
 CMD ["--help"]
 
 FROM production AS test


### PR DESCRIPTION
## Motivation

I'm trying to use the `kspckan/netkan` container in a GitHub Action, see KSP-CKAN/CKAN#4265 for details.

GitHub's docker command uses `--workdir /github/workspace` to override the container's `WORKDIR`. This breaks our `ENTRYPOINT` because it uses a relative path.

- <https://github.com/KSP-CKAN/CKAN/actions/runs/12002494825/job/33454558662>

## Changes

Now the `ENTRYPOINT` contains the full absolute path.
