### PR TITLE
Send max prerelease version separately

### DIFF
--- a/netkan/netkan/scheduler.py
+++ b/netkan/netkan/scheduler.py
@@ -54,7 +54,9 @@ class NetkanScheduler:
         return self.webhooks_group if netkan.hook_only() else self.nonhooks_group
 
     def schedule_all_netkans(self) -> None:
-        messages = (nk.sqs_message(self.ckm_repo.highest_version(nk.identifier))
+        repo = self.ckm_repo
+        messages = (nk.sqs_message(repo.highest_version(nk.identifier),
+                                   repo.highest_version_prerelease(nk.identifier))
                     for nk in self.nk_repo.netkans() if self._in_group(nk))
         for batch in sqs_batch_entries(messages):
             self.client.send_message_batch(**self.sqs_batch_attrs(batch))

--- a/netkan/netkan/webhooks/github_inflate.py
+++ b/netkan/netkan/webhooks/github_inflate.py
@@ -64,7 +64,9 @@ def inflate(ids: Iterable[str], game_id: str) -> None:
     if game.netkan_repo.git_repo.working_dir:
         # Make sure our NetKAN and CKAN-meta repos are up to date
         pull_all(game.repos)
-        messages = (nk.sqs_message(game.ckanmeta_repo.highest_version(nk.identifier))
+        repo = game.ckanmeta_repo
+        messages = (nk.sqs_message(repo.highest_version(nk.identifier),
+                                   repo.highest_version_prerelease(nk.identifier))
                     for nk in netkans(str(game.netkan_repo.git_repo.working_dir), ids, game_id))
         for batch in sqs_batch_entries(messages):
             current_config.client.send_message_batch(

--- a/netkan/netkan/webhooks/inflate.py
+++ b/netkan/netkan/webhooks/inflate.py
@@ -22,7 +22,9 @@ def inflate_hook(game_id: str) -> Tuple[str, int]:
         return 'An array of identifiers is required', 400
     # Make sure our NetKAN and CKAN-meta repos are up to date
     pull_all(game.repos)
-    messages = (nk.sqs_message(game.ckanmeta_repo.highest_version(nk.identifier))
+    repo = game.ckanmeta_repo
+    messages = (nk.sqs_message(repo.highest_version(nk.identifier),
+                               repo.highest_version_prerelease(nk.identifier))
                 for nk in netkans(str(game.netkan_repo.git_repo.working_dir), ids, game_id=game_id))
     for batch in sqs_batch_entries(messages):
         current_app.logger.info(

--- a/netkan/netkan/webhooks/spacedock_inflate.py
+++ b/netkan/netkan/webhooks/spacedock_inflate.py
@@ -44,9 +44,10 @@ def inflate_hook(game_id: str) -> Tuple[str, int]:
             return '', 204
 
         # Submit them to the queue
-        messages = (nk.sqs_message(
-            current_config.common.game(game_id).ckanmeta_repo.highest_version(nk.identifier))
-            for nk in nks)
+        repo = current_config.common.game(game_id).ckanmeta_repo
+        messages = (nk.sqs_message(repo.highest_version(nk.identifier),
+                                   repo.highest_version_prerelease(nk.identifier))
+                    for nk in nks)
         for batch in sqs_batch_entries(messages):
             current_config.client.send_message_batch(
                 QueueUrl=current_config.inflation_queue(game_id).url,


### PR DESCRIPTION
## Motivation

Currently multi-hosted mods with single-hosted prereleases end up with `Out-of-order version found on unreliable server` inflation errors because the version on the host without the prerelease is less than the prerelease.

## Changes

Now the `HighestVersion` message attribute reflects non-prereleases only, which will resolve these inflation errors while temporarily opening a new potential functional issue where out-of-order prerelease versions might not be caught.

A new `HighestVersionPrerelease` message attribute now contains the highest version number of a prerelease for the given mod. A subsequent update in the Inflator will use this attribute to address the above gap. This PR will not be merged until that one is ready.
