### PR TITLE
Fix missing author URLs in SpaceDock pull requests

### DIFF
--- a/netkan/netkan/webhooks/spacedock_add.py
+++ b/netkan/netkan/webhooks/spacedock_add.py
@@ -52,13 +52,15 @@ def batch_message(raw: 'ImmutableMultiDict[str, str]', game_id: str) -> SendMess
                                         'user_github':         user_tuple[1],
                                         'user_forum_id':       user_tuple[2],
                                         'user_forum_username': user_tuple[3],
-                                        'email':               user_tuple[4]}
+                                        'email':               user_tuple[4],
+                                        'user_url':            user_tuple[5]}
                                        for user_tuple
                                        in zip(raw.getlist('username'),
                                               raw.getlist('user_github'),
                                               raw.getlist('user_forum_id'),
                                               raw.getlist('user_forum_username'),
-                                              raw.getlist('email'))]})
+                                              raw.getlist('email'),
+                                              raw.getlist('user_url'))]})
     return {
         'Id':                     '1',
         'MessageBody':            body,


### PR DESCRIPTION
## Problem

Since #297, the author name hyperlinks in SpaceDock pull requests have been missing their URLs. See KSP-CKAN/NetKAN#10410 for a recent example.

## Cause

The `user_url` list wasn't passed to the `zip` call that generates the per-user objects that ultimately get rendered into the pull request.

## Changes

Now `user_url` is passed through to the pull request.
