### PR TITLE
Suppress SpaceDock pull requests for frozen mods

### DIFF
--- a/netkan/netkan/spacedock_adder.py
+++ b/netkan/netkan/spacedock_adder.py
@@ -55,11 +55,16 @@ class SpaceDockAdder:
 
     def try_add(self) -> bool:
         netkan = self.make_netkan(self.info)
+        ident = netkan[0].get('identifier', '')
 
         # Create .netkan file or quit if already there
-        netkan_path = self.nk_repo.nk_path(netkan[0].get('identifier', ''))
+        netkan_path = self.nk_repo.nk_path(ident)
         if netkan_path.exists():
             # Already exists, we are done
+            return True
+
+        if self.nk_repo.frozen_path(ident).exists():
+            # Already frozen, quit
             return True
 
         # Create and checkout branch

--- a/netkan/tests/spacedock_adder.py
+++ b/netkan/tests/spacedock_adder.py
@@ -104,6 +104,12 @@ class TestSpaceDockAdder(SharedArgsHarness):
         self.adder.nk_repo.nk_path('NotAnotherFlag').unlink()
         self.assertEqual(len(self.adder.github_pr.method_calls), 0)
 
+    def test_frozen_already_exists(self):
+        self.adder.nk_repo.frozen_path('NotAnotherFlag').touch()
+        self.adder.try_add()
+        self.adder.nk_repo.frozen_path('NotAnotherFlag').unlink()
+        self.assertEqual(len(self.adder.github_pr.method_calls), 0)
+
     def test_netkan_creates_add_branch(self):
         self.adder.try_add()
         refs = [x.name for x in self.adder.nk_repo.git_repo.refs]


### PR DESCRIPTION
## Problem

KSP-CKAN/NetKAN#10430, KSP-CKAN/NetKAN#10435, and KSP-CKAN/NetKAN#10435 are duplicates of KSP-CKAN/NetKAN/pull/10333. They all deal with a mod that hasn't been added because it probably violates the code of conduct.

At least some of these PRs came in when there was no new release of the mod, which means the author may be intentionally re-editing it on SpaceDock and clicking the add to CKAN button to generate more pull requests. Since they won't be merged, this is a nuisance.

https://github.com/KSP-CKAN/NetKAN/commit/7733e922771a72df7b53245c7434b6d5515dac3a added a `.frozen` file for this identifier, which will cause the validation script to error out, but it won't suppress the PRs yet.

## Changes

Now if `<identifier>.frozen` exists, we don't make a PR, just like if `<identifier>.netkan` exists.