### PR TITLE
Add x_netkan_check_parent_downloads

### DIFF
--- a/netkan/netkan/cli/utilities.py
+++ b/netkan/netkan/cli/utilities.py
@@ -60,6 +60,7 @@ def download_counter(common: SharedArgs) -> None:
         logging.info('Starting Download Count Calculation (%s)...', game_id)
         DownloadCounter(game_id,
                         common.game(game_id).ckanmeta_repo,
+                        common.game(game_id).netkan_repo,
                         common.token).update_counts()
         logging.info('Download Counter completed! (%s)', game_id)
 

--- a/netkan/netkan/download_counter.py
+++ b/netkan/netkan/download_counter.py
@@ -315,7 +315,8 @@ class DownloadCounter:
                         match = GitHubBatchedQuery.PATH_PATTERN.match(url_parse.path)
                         if match:
                             # Process GitHub modules together in big batches
-                            graph_query.add(ckan.identifier, *match.groups(), include_parents)
+                            user, repo = match.groups()
+                            graph_query.add(ckan.identifier, user, repo, include_parents)
                             if graph_query.full():
                                 # Run the query
                                 graph_query.get_result(self.counts)

--- a/netkan/netkan/download_counter.py
+++ b/netkan/netkan/download_counter.py
@@ -16,9 +16,7 @@ from requests.exceptions import ConnectTimeout
 
 from .utils import repo_file_add_or_changed, legacy_read_text
 from .repos import CkanMetaRepo, NetkanRepo
-from .metadata import Ckan
-from .metadata import Netkan
-
+from .metadata import Ckan, Netkan
 
 class GitHubBatchedQuery:
 

--- a/netkan/netkan/download_counter.py
+++ b/netkan/netkan/download_counter.py
@@ -307,11 +307,17 @@ class DownloadCounter:
         for ckan in self.ckm_repo.all_latest_modules():  # pylint: disable=too-many-nested-blocks
             if ckan.kind == 'dlc':
                 continue
-            nk = Netkan(self.nk_repo.nk_path(ckan.identifier), game_id=self.game_id)
+            if self.nk_repo.nk_path(ckan.identifier).exists():
+                nk = Netkan(self.nk_repo.nk_path(ckan.identifier), game_id=self.game_id)
+            else:
+                nk = None
             for download in ckan.downloads:
                 try:
                     url_parse = urllib.parse.urlparse(download)
-                    include_parents = nk.check_parent_downloads()
+                    if nk is not None:
+                        include_parents = nk.check_parent_downloads()
+                    else:
+                        include_parents = True
                     if url_parse.netloc == 'github.com':
                         match = GitHubBatchedQuery.PATH_PATTERN.match(url_parse.path)
                         if match:

--- a/netkan/netkan/metadata.py
+++ b/netkan/netkan/metadata.py
@@ -483,3 +483,6 @@ class Ckan:
                 return self.version.string.replace(' ', '_').replace(':', '-')
             return self.EPOCH_VERSION_REGEXP.sub('', self.version.string.replace(' ', '_'))
         return None
+
+    def check_parent_downloads(self) -> bool:
+        return getattr(self, 'x_netkan_check_parent_downloads', True)

--- a/netkan/netkan/metadata.py
+++ b/netkan/netkan/metadata.py
@@ -117,6 +117,9 @@ class Netkan:
             'MessageAttributes': self.sqs_message_attribs(high_ver, high_ver_pre),
         }
 
+    def check_parent_downloads(self) -> bool:
+        return getattr(self, 'x_netkan_check_parent_downloads', True)
+
 
 class Ckan:
 
@@ -483,6 +486,3 @@ class Ckan:
                 return self.version.string.replace(' ', '_').replace(':', '-')
             return self.EPOCH_VERSION_REGEXP.sub('', self.version.string.replace(' ', '_'))
         return None
-
-    def check_parent_downloads(self) -> bool:
-        return getattr(self, 'x_netkan_check_parent_downloads', True)


### PR DESCRIPTION
When x_netkan_check_parent_downloads is false, do not check the github parent repos for the download count. Defaults to true. (the current behavior)
Unsure of how to test this to make sure it works.