### PR TITLE
Pin pytest below 9 until pytest-pylint supports it

### DIFF
--- a/netkan/pyproject.toml
+++ b/netkan/pyproject.toml
@@ -40,7 +40,9 @@ development = [
     "boto3-stubs[essential,cloudwatch]",
     "coverage",
     "troposphere",
-    "pytest",
+    # 2026-07-04 capping below 9 - pytest-pylint crashes on pytest 9,
+    # https://github.com/carsongee/pytest-pylint/issues/197
+    "pytest<9",
     "mypy",
     "pytest-mypy",
     "pylint",
@@ -54,7 +56,9 @@ development = [
 test = [
     "boto3-stubs[essential,cloudwatch]",
     "coverage",
-    "pytest",
+    # 2026-07-04 capping below 9 - pytest-pylint crashes on pytest 9,
+    # https://github.com/carsongee/pytest-pylint/issues/197
+    "pytest<9",
     "mypy",
     "pytest-mypy",
     "pylint",


### PR DESCRIPTION
## Problem

`pip install .[test]` now resolves pytest 9.x, and pytest-pylint 0.21.0 registers a hookimpl with the legacy `path` parameter that pytest 9 removed, so pytest dies with an INTERNALERROR at plugin registration (carsongee/pytest-pylint#197).

## Change

Pin pytest below 9 in the `test` and `development` extras, with a dated comment linking the pytest-pylint issue (same style as the existing botocore cap).

pytest-pylint has no compatible release (0.21.0 is from Oct 2023, the crash is unfixed in its master, and the repo has been quiet since April 2024).

## Testing

With this pin, all four checks pass in the fork (pytest x2, Build, coverage-build): https://github.com/KSAModding/NetKAN-Infra/pull/4/checks
